### PR TITLE
Fix cart template visibility

### DIFF
--- a/storefronts/platforms/webflow/checkout.js
+++ b/storefronts/platforms/webflow/checkout.js
@@ -2,6 +2,7 @@ let stripe;
 let elements;
 let cardElement;
 
+
 function initStripeElements() {
   const stripeKey = window.SMOOTHR_CONFIG?.stripeKey;
   if (!stripeKey) return;
@@ -19,11 +20,14 @@ export function initCheckout() {
   const Smoothr = window.Smoothr || window.smoothr;
   if (!Smoothr?.cart) return;
 
+
   const cart = Smoothr.cart.getCart();
   const list = document.querySelector('[data-smoothr-list]');
   const template = list?.querySelector('[data-smoothr-template]');
 
   if (list && template) {
+    // Hide template row to avoid showing it alongside cloned items
+    template.style.display = 'none';
     // clear previous items
     list.querySelectorAll('.smoothr-checkout-item').forEach(el => el.remove());
 
@@ -47,10 +51,14 @@ export function initCheckout() {
 
       clone.querySelectorAll('[data-smoothr-image]').forEach(el => {
         if (el.tagName === 'IMG') {
-          el.src = item.image || '';
+          if (item.image) {
+            el.src = item.image;
+          } else {
+            el.removeAttribute('src');
+          }
           el.alt = item.name || '';
         } else {
-          el.style.backgroundImage = `url(${item.image || ''})`;
+          el.style.backgroundImage = item.image ? `url(${item.image})` : '';
         }
       });
 

--- a/storefronts/platforms/webflow/renderCart.js
+++ b/storefronts/platforms/webflow/renderCart.js
@@ -9,6 +9,7 @@ function getSelectedCurrency(Smoothr) {
   );
 }
 
+
 export function renderCart() {
   const debug = window.SMOOTHR_CONFIG?.debug;
   if (debug) console.log('🎨 renderCart() triggered');
@@ -57,6 +58,9 @@ export function renderCart() {
       return;
     }
 
+    // Hide the template row so only cloned items are visible
+    template.style.display = 'none';
+
     cart.items.forEach(item => {
       const clone = template.cloneNode(true);
       clone.classList.add('cart-rendered', 'smoothr-cart-rendered');
@@ -102,10 +106,16 @@ export function renderCart() {
       const imageEl = clone.querySelector('[data-smoothr-image]');
       if (imageEl) {
         if (imageEl.tagName === 'IMG') {
-          imageEl.src = item.image || '';
+          if (item.image) {
+            imageEl.src = item.image;
+          } else {
+            imageEl.removeAttribute('src');
+          }
           imageEl.alt = item.name || '';
         } else {
-          imageEl.style.backgroundImage = `url(${item.image || ''})`;
+          imageEl.style.backgroundImage = item.image
+            ? `url(${item.image})`
+            : '';
         }
       }
 


### PR DESCRIPTION
## Summary
- ensure `[data-smoothr-template]` is hidden globally in cart and checkout renderers
- avoid broken images by removing the `src` attribute when no image is provided
- preserve image loading by removing global template hiding

## Testing
- `npm test` *(fails: vitest errors)*

------
https://chatgpt.com/codex/tasks/task_e_6866a9aeaf308325a2a33adf2188f291