### PR TITLE
Ensure payment_status updates

### DIFF
--- a/shared/checkout/handleCheckout.ts
+++ b/shared/checkout/handleCheckout.ts
@@ -349,13 +349,16 @@ export async function handleCheckout({ req, res }:{ req: NextApiRequest; res: Ne
 
   let orderPayload;
   try {
-    const authorizeNetSuccess =
-      provider === 'authorizeNet' && providerResult?.success !== false;
+    const providerIntent = providerResult?.intent ?? providerResult;
+    const paymentConfirmed =
+      (provider === 'authorizeNet' && providerResult?.success !== false) ||
+      (provider === 'stripe' && providerIntent?.status === 'succeeded') ||
+      (provider === 'nmi' && providerResult?.success === true);
 
     orderPayload = {
       order_number: orderNumber,
-      status: authorizeNetSuccess ? 'paid' : 'unpaid',
-      payment_status: authorizeNetSuccess ? 'paid' : 'unpaid',
+      status: paymentConfirmed ? 'paid' : 'unpaid',
+      payment_status: paymentConfirmed ? 'paid' : 'unpaid',
       payment_provider: provider,
       raw_data:
         provider === 'authorizeNet'

--- a/smoothr/pages/api/webhooks/stripe.ts
+++ b/smoothr/pages/api/webhooks/stripe.ts
@@ -76,6 +76,7 @@ export default async function handler(
         .from("orders")
         .update({
           status: "paid",
+          payment_status: "paid",
           paid_at: new Date().toISOString(),
         })
         .eq("payment_intent_id", id)


### PR DESCRIPTION
## Summary
- flag Stripe webhook payments as paid in `payment_status`
- decide if payment is confirmed in checkout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e9b5f5db08325aa678293ce2db5d7