### PR TITLE
Add apiBase validation to checkout scripts

### DIFF
--- a/storefronts/checkout/checkout.js
+++ b/storefronts/checkout/checkout.js
@@ -288,6 +288,16 @@ export async function initCheckout() {
       }
       const apiBase = window.SMOOTHR_CONFIG?.apiBase || '';
       log('POST', `${apiBase}/api/checkout/${provider}`);
+
+      if (!apiBase.startsWith('https://')) {
+        console.error(
+          '[Smoothr Checkout] ❌ apiBase is invalid or missing:',
+          apiBase
+        );
+        alert('Checkout is misconfigured. Please refresh the page or contact support.');
+        return;
+      }
+
       const res = await fetch(`${apiBase}/api/checkout/${provider}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/storefronts/dist/platforms/webflow/checkout.js
+++ b/storefronts/dist/platforms/webflow/checkout.js
@@ -8380,6 +8380,11 @@ async function initCheckout() {
         log3("billing_details:", billing_details);
         log3("shipping:", shipping);
         const base = ((_O = window == null ? void 0 : window.SMOOTHR_CONFIG) == null ? void 0 : _O.apiBase) || "";
+        if (!base.startsWith("https://")) {
+          console.error("[Smoothr Checkout] ❌ apiBase is invalid or missing:", base);
+          alert("Checkout is misconfigured. Please refresh the page or contact support.");
+          return;
+        }
         const res = await fetch(`${base}/api/checkout/${activeGateway}`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },

--- a/storefronts/platforms/webflow/checkout.js
+++ b/storefronts/platforms/webflow/checkout.js
@@ -329,6 +329,13 @@ export async function initCheckout() {
         log('billing_details:', billing_details);
         log('shipping:', shipping);
       const base = window?.SMOOTHR_CONFIG?.apiBase || '';
+
+      if (!base.startsWith('https://')) {
+        console.error('[Smoothr Checkout] ❌ apiBase is invalid or missing:', base);
+        alert('Checkout is misconfigured. Please refresh the page or contact support.');
+        return;
+      }
+
       const res = await fetch(`${base}/api/checkout/${activeGateway}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- ensure apiBase is a valid https URL before calling the checkout endpoint
- include the same check in the Webflow checkout bundle

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee59e5a808325aaecf300b1c24491