### PR TITLE
Fix Authorize.net provider tests

### DIFF
--- a/storefronts/core/__tests__/checkout-payload.test.js
+++ b/storefronts/core/__tests__/checkout-payload.test.js
@@ -9,7 +9,11 @@ beforeEach(() => {
   clickHandler = null;
 
   global.fetch = vi.fn(() =>
-    Promise.resolve({ ok: true, json: () => Promise.resolve({ success: true }) })
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ success: true }),
+      clone: () => ({ json: () => Promise.resolve({ success: true }) })
+    })
   );
 
   const cardElement = { mount: vi.fn() };
@@ -87,7 +91,8 @@ beforeEach(() => {
     SMOOTHR_CONFIG: {
       stripeKey: 'pk_test',
       baseCurrency: 'USD',
-      active_payment_gateway: 'stripe'
+      active_payment_gateway: 'stripe',
+      apiBase: 'https://example.com'
     },
     location: { origin: '', href: '', hostname: '' },
     addEventListener: vi.fn(),

--- a/storefronts/providers/__tests__/authorizeNet-provider.test.ts
+++ b/storefronts/providers/__tests__/authorizeNet-provider.test.ts
@@ -7,8 +7,13 @@ const originalFetch = global.fetch;
 
 vi.mock('../../../shared/checkout/getStoreIntegration.ts', () => {
   integrationMock = vi.fn(async () => ({
-    api_key: 'login',
-    settings: { transaction_key: 'key', client_key: 'client' }
+    api_login_id: 'fakeLogin',
+    transaction_key: 'fakeKey',
+    settings: {
+      api_login_id: 'fakeLogin',
+      transaction_key: 'fakeKey',
+      client_key: 'client'
+    }
   }));
   return { getStoreIntegration: integrationMock };
 });


### PR DESCRIPTION
## Summary
- mock Authorize.Net credentials with api_login_id and transaction_key
- make checkout payload tests work with apiBase and fetch clone()

## Testing
- `npm --workspace storefronts test`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f034f6fbc8325886102ad9cafad0f