### PR TITLE
Update checkout attribute references

### DIFF
--- a/storefronts/README.md
+++ b/storefronts/README.md
@@ -116,7 +116,7 @@ Call `renderCart()` after page load to display items and totals. Use
 with the attributes `data-smoothr-card-number`, `data-smoothr-card-expiry` and
 `data-smoothr-card-cvc` where the fields should render. If any target is missing
 the script retries mounting every 200ms for up to five attempts. Attach
-`data-smoothr-checkout` to a checkout button or form. If placed on a `<form>`
+`data-smoothr-pay` to a checkout button or form. If placed on a `<form>`
 the SDK listens for the `submit` event so clicks on child elements won't start
 checkout. Avoid adding the attribute to generic containers to prevent unwanted
 triggers.

--- a/storefronts/tests/platforms/checkout.test.js
+++ b/storefronts/tests/platforms/checkout.test.js
@@ -30,7 +30,7 @@ beforeEach(() => {
   document.body.appendChild(totalEl);
 
   const btn = document.createElement('button');
-  btn.setAttribute('data-smoothr-checkout', '');
+  btn.setAttribute('data-smoothr-pay', '');
   document.body.appendChild(btn);
 
   const createInput = (attr, val = '') => {

--- a/storefronts/tests/platforms/webflow/checkout.dom.test.ts
+++ b/storefronts/tests/platforms/webflow/checkout.dom.test.ts
@@ -7,7 +7,7 @@ beforeEach(() => {
       <div data-smoothr-card-number></div>
       <div data-smoothr-card-expiry></div>
       <div data-smoothr-card-cvc></div>
-      <button data-smoothr-checkout></button>
+      <button data-smoothr-pay></button>
     </div>
   `;
   delete (window as any).__SMOOTHR_CHECKOUT_INITIALIZED__;

--- a/storefronts/tests/sdk/checkout-payload.test.js
+++ b/storefronts/tests/sdk/checkout-payload.test.js
@@ -43,7 +43,8 @@ beforeEach(() => {
     disabled: false,
     addEventListener: vi.fn((ev, cb) => {
       if (ev === 'click') clickHandler = cb;
-    })
+    }),
+    hasAttribute: vi.fn(attr => attr === 'data-smoothr-pay')
   };
   const block = {
     dataset: { smoothrProductId: 'prod1' },
@@ -54,7 +55,7 @@ beforeEach(() => {
         '[data-smoothr-last-name]': lastNameInput,
         '[data-smoothr-total]': totalEl,
         '[data-smoothr-gateway]': {},
-        '[data-smoothr-checkout]': submitBtn,
+        '[data-smoothr-pay]': submitBtn,
         '[data-smoothr-card-number]': cardNumberEl,
         '[data-smoothr-card-expiry]': cardExpiryEl,
         '[data-smoothr-card-cvc]': cardCvcEl,
@@ -82,7 +83,8 @@ beforeEach(() => {
   global.document = {
     querySelector: vi.fn(sel => {
       const map = {
-        '[data-smoothr-checkout]': submitBtn,
+        '[data-smoothr-pay], [data-smoothr-checkout]': submitBtn,
+        '[data-smoothr-pay]': submitBtn,
         '[data-smoothr-card-number]': cardNumberEl,
         '[data-smoothr-card-expiry]': cardExpiryEl,
         '[data-smoothr-card-cvc]': cardCvcEl,

--- a/storefronts/tests/sdk/stripe-mount.test.js
+++ b/storefronts/tests/sdk/stripe-mount.test.js
@@ -31,7 +31,7 @@ beforeEach(() => {
   global.document = {
     querySelector: vi.fn(sel => {
       const map = {
-        '[data-smoothr-checkout]': block,
+        '[data-smoothr-pay]': block,
         '[data-smoothr-card-number]': {},
         '[data-smoothr-card-expiry]': {},
         '[data-smoothr-card-cvc]': {},


### PR DESCRIPTION
## Summary
- switch README and tests to `[data-smoothr-pay]`
- adjust test helpers for the new attribute

## Testing
- `npm --workspace storefronts test` *(fails: create-payment-method-nmi.test.ts and checkout-payload.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6875c7ae16108325bff66df3f49c031e