### PR TITLE
Format product prices

### DIFF
--- a/storefronts/README.md
+++ b/storefronts/README.md
@@ -87,7 +87,7 @@ a dropdown and mark prices using `data-smoothr-price`:
   <option value="GBP">GBP</option>
 </select>
 <script type="module">
-  import { setSelectedCurrency } from './platforms/webflow-dom.js';
+  import { setSelectedCurrency } from './core/currency/webflow-dom.js';
   document
     .getElementById('currency-picker')
     .addEventListener('change', e => setSelectedCurrency(e.target.value));

--- a/storefronts/core/currency/README.md
+++ b/storefronts/core/currency/README.md
@@ -41,7 +41,7 @@ and persists the choice in `localStorage`. Pair it with a select element and add
   <option value="EUR">EUR</option>
 </select>
 <script type="module">
-  import { setSelectedCurrency } from '../../platforms/webflow-dom.js';
+  import { setSelectedCurrency } from '../../core/currency/webflow-dom.js';
   document
     .getElementById('currency')
     .addEventListener('change', e => setSelectedCurrency(e.target.value));

--- a/storefronts/core/currency/webflow-dom.js
+++ b/storefronts/core/currency/webflow-dom.js
@@ -1,0 +1,1 @@
+export * from '../../platforms/webflow/webflow-dom.js';

--- a/storefronts/platforms/README.md
+++ b/storefronts/platforms/README.md
@@ -31,6 +31,10 @@ The attribute value (`data-smoothr-price` or `data-smoothr-total`) is also
 updated when the currency changes so you can access the converted amount via
 JavaScript.
 
+All elements with price attributes, including `[data-product-price]`, are
+formatted automatically when `initCurrencyDom()` runs on page load and whenever
+the currency changes.
+
 ### Automatic price detection
 
 `webflow-ecom-currency.js` searches for common Webflow price classes

--- a/storefronts/platforms/webflow/webflow-dom.js
+++ b/storefronts/platforms/webflow/webflow-dom.js
@@ -8,6 +8,10 @@ function parsePriceText(text) {
 }
 
 function getBaseAmount(el, attr) {
+  if (el.hasAttribute('data-product-price')) {
+    return parseFloat(el.getAttribute('data-product-price'));
+  }
+
   let base = parseFloat(el.dataset.smoothrBase);
   if (isNaN(base)) {
     base =

--- a/storefronts/platforms/webflow/webflow-ecom-currency.js
+++ b/storefronts/platforms/webflow/webflow-ecom-currency.js
@@ -1,4 +1,5 @@
 // Smoothr Checkout Script for Webflow with integrated NMI
+import { initCurrencyDom } from '../../core/currency/webflow-dom.js';
 
 // Integrated NMI logic
 let hasMounted = false;
@@ -109,6 +110,8 @@ async function initCheckout() {
   } else {
     console.warn('[Smoothr Checkout] Pay div not found');
   }
+
+  initCurrencyDom();
 }
 
 // Fetch key via Next.js API to bypass RLS

--- a/storefronts/tests/platforms/total-attr.test.js
+++ b/storefronts/tests/platforms/total-attr.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { initCurrencyDom, setSelectedCurrency } from '../../platforms/webflow-dom.js';
+import { initCurrencyDom, setSelectedCurrency } from '../../core/currency/webflow-dom.js';
 import { setBaseCurrency, updateRates } from '../../core/currency/index.js';
 
 class CustomEvt {

--- a/storefronts/tests/platforms/webflow-dom.test.js
+++ b/storefronts/tests/platforms/webflow-dom.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { setSelectedCurrency, initCurrencyDom } from "../../platforms/webflow-dom.js";
+import { setSelectedCurrency, initCurrencyDom } from "../../core/currency/webflow-dom.js";
 import { setBaseCurrency, updateRates } from "../../core/currency/index.js";
 
 class CustomEvt {
@@ -56,6 +56,20 @@ describe("webflow adapter price replacement", () => {
         textContent: "",
         dataset: {},
       },
+      {
+        attributes: { "data-product-price": "5" },
+        getAttribute: vi.fn(function (attr) {
+          return this.attributes[attr];
+        }),
+        setAttribute: vi.fn(function (attr, val) {
+          this.attributes[attr] = String(val);
+        }),
+        hasAttribute: vi.fn(function (attr) {
+          return attr in this.attributes;
+        }),
+        textContent: "",
+        dataset: {},
+      },
     ];
 
     global.document = {
@@ -80,12 +94,14 @@ describe("webflow adapter price replacement", () => {
   it("replaces prices immediately", () => {
     expect(els[0].textContent).toBe("$10.00");
     expect(els[1].textContent).toBe("$20.50");
+    expect(els[2].textContent).toBe("$5.00");
   });
 
   it("updates prices when currency changes", () => {
     setSelectedCurrency("EUR");
     expect(els[0].textContent).toBe("€5.00");
     expect(els[1].textContent).toBe("€10.25");
+    expect(els[2].textContent).toBe("€2.50");
   });
 
   it("does not compound on repeated currency changes", () => {
@@ -93,5 +109,6 @@ describe("webflow adapter price replacement", () => {
     setSelectedCurrency("USD");
     expect(els[0].textContent).toBe("$10.00");
     expect(els[1].textContent).toBe("$20.50");
+    expect(els[2].textContent).toBe("$5.00");
   });
 });


### PR DESCRIPTION
## Summary
- format product price elements on Webflow sites
- centralize DOM price formatting in `initCurrencyDom`

## Testing
- `npm test` *(fails: initCheckout not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6875eb6515048325ba807f18e45a0036