### PR TITLE
Add PayPal API endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "smoothr-monorepo",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "workspaces": [
         "smoothr",
         "storefronts",
@@ -575,6 +576,28 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@paypal/checkout-server-sdk": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@paypal/checkout-server-sdk/-/checkout-server-sdk-1.0.3.tgz",
+      "integrity": "sha512-UEdq8akEdMz0Vs4qoQFU2gMp8PpyE/HKyMwiZuK4vIWUKl8jfd1fWKjQN5cDFm9NkFUIp5U7h++rdMOVj9WMNA==",
+      "deprecated": "Package no longer supported. The author suggests using the @paypal/paypal-server-sdk package instead: https://www.npmjs.com/package/@paypal/paypal-server-sdk. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "SEE LICENSE IN https://github.com/paypal/Checkout-NodeJS-SDK/blob/master/LICENSE",
+      "dependencies": {
+        "@paypal/paypalhttp": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@paypal/paypalhttp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@paypal/paypalhttp/-/paypalhttp-1.0.1.tgz",
+      "integrity": "sha512-DC7AHxTT7drF6dUi3YaFdPVuT15sIkpD5H2eHmdtFgxM4UanS1o1ZDfMhR9mpxd8o+X6pz2r+EZVRRq+n1cssQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2643,6 +2666,7 @@
       "name": "smoothr-admin",
       "version": "1.0.0",
       "dependencies": {
+        "@paypal/checkout-server-sdk": "^1.0.3",
         "@supabase/supabase-js": "^2.50.0",
         "next": "^14.1.0",
         "react": "^18.2.0",

--- a/smoothr/package.json
+++ b/smoothr/package.json
@@ -8,15 +8,16 @@
     "start": "next start"
   },
   "dependencies": {
+    "@paypal/checkout-server-sdk": "^1.0.3",
     "@supabase/supabase-js": "^2.50.0",
-    "stripe": "^12.16.0",
     "next": "^14.1.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "stripe": "^12.16.0"
   },
   "devDependencies": {
-    "typescript": "^5.4.5",
+    "@types/node": "^20.11.25",
     "@types/react": "^18.2.27",
-    "@types/node": "^20.11.25"
+    "typescript": "^5.4.5"
   }
 }

--- a/smoothr/pages/api/checkout/paypal/capture-order.ts
+++ b/smoothr/pages/api/checkout/paypal/capture-order.ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import PayPal from '@paypal/checkout-server-sdk';
+import { handleCheckout } from '../../../shared/checkout';
+
+const env = process.env.PAYPAL_ENV === 'production'
+  ? new PayPal.core.LiveEnvironment(process.env.PAYPAL_CLIENT_ID, process.env.PAYPAL_SECRET)
+  : new PayPal.core.SandboxEnvironment(process.env.PAYPAL_CLIENT_ID, process.env.PAYPAL_SECRET);
+const client = new PayPal.core.PayPalHttpClient(env);
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const { orderID } = req.body;
+  const request = new PayPal.orders.OrdersAuthorizeRequest(orderID);
+
+  try {
+    const { result } = await client.execute(request);
+    const data = await handleCheckout({ provider: 'paypal', paymentData: result });
+    res.status(200).json({ success: data.success, order_id: data.order_id });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ success: false, error: 'PayPal capture failed' });
+  }
+}

--- a/smoothr/pages/api/checkout/paypal/create-order.ts
+++ b/smoothr/pages/api/checkout/paypal/create-order.ts
@@ -1,0 +1,26 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import PayPal from '@paypal/checkout-server-sdk';
+
+const env = process.env.PAYPAL_ENV === 'production'
+  ? new PayPal.core.LiveEnvironment(process.env.PAYPAL_CLIENT_ID, process.env.PAYPAL_SECRET)
+  : new PayPal.core.SandboxEnvironment(process.env.PAYPAL_CLIENT_ID, process.env.PAYPAL_SECRET);
+const client = new PayPal.core.PayPalHttpClient(env);
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end();
+  const { amount, currency } = req.body;
+  const request = new PayPal.orders.OrdersCreateRequest();
+  request.prefer('return=representation');
+  request.requestBody({
+    intent: 'AUTHORIZE',
+    purchase_units: [{ amount: { currency_code: currency, value: amount.toString() } }]
+  });
+
+  try {
+    const { result } = await client.execute(request);
+    res.status(200).json({ id: result.id });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'PayPal order creation failed' });
+  }
+}


### PR DESCRIPTION
## Summary
- add PayPal checkout server SDK as dependency
- implement `create-order` and `capture-order` API routes for PayPal

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876aae676448325ad40b04cdcb9c70e