### PR TITLE
Fix PayPal capture order import path

### DIFF
--- a/smoothr/pages/api/checkout/paypal/capture-order.ts
+++ b/smoothr/pages/api/checkout/paypal/capture-order.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import PayPal from '@paypal/checkout-server-sdk';
-import { handleCheckout } from '../../../shared/checkout';
+import { handleCheckout } from '../../../../../shared/checkout';
 
 const env = process.env.PAYPAL_ENV === 'production'
   ? new PayPal.core.LiveEnvironment(process.env.PAYPAL_CLIENT_ID, process.env.PAYPAL_SECRET)


### PR DESCRIPTION
## Summary
- correct the checkout import path in PayPal capture handler

## Testing
- `npm test` *(fails: vitest reported failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6876af2a01e08325b280daf7084e842a