### PR TITLE
Update gateway docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,24 @@ from the store's `store_settings` table in Supabase using the configured
 `storeId`. The `[provider]` segment in the route should match this value and
 defaults to `stripe` when no configuration is found.
 
+Payment gateway resolution is handled by `core/utils/resolveGateway()`. This
+function **throws an error** when no gateway is configured or when an
+unsupported value is supplied. Ensure `active_payment_gateway` is set on either
+`SMOOTHR_CONFIG` or in the store settings.
+
+```js
+import resolveGateway from './core/utils/resolveGateway.js';
+
+resolveGateway({ active_payment_gateway: 'stripe' });
+// => 'stripe'
+
+resolveGateway();
+// throws 'active_payment_gateway not configured'
+
+resolveGateway({ active_payment_gateway: 'bogus' });
+// throws 'Unknown payment gateway: bogus'
+```
+
 To enable Authorize.net create a row in the `store_integrations` table with
 `provider` set to `authorizeNet` and store your API credentials under the
 `settings` column:

--- a/storefronts/README.md
+++ b/storefronts/README.md
@@ -129,6 +129,21 @@ active payment gateway. This single endpoint handles all providers. `initCheckou
 `store_settings.settings.active_payment_gateway` in Supabase using the provided
 `storeId`. The default provider is `stripe`.
 
+Gateway detection relies on `core/utils/resolveGateway()`. It will **throw an
+error** when `active_payment_gateway` is missing or set to an unsupported
+provider. Always configure a valid gateway on `SMOOTHR_CONFIG` or in the store
+settings before initializing checkout.
+
+```js
+import resolveGateway from '../core/utils/resolveGateway.js';
+
+resolveGateway({ active_payment_gateway: 'nmi' });
+// => 'nmi'
+
+resolveGateway({});
+// throws 'active_payment_gateway not configured'
+```
+
 To integrate Authorize.net create a record in the `store_integrations` table
 with `provider` set to `authorizeNet` and save your credentials in the
 `settings` JSON column:


### PR DESCRIPTION
## Summary
- explain that `active_payment_gateway` must be configured
- note that `resolveGateway()` throws for missing or unsupported providers
- show simple examples of using `resolveGateway()`

## Testing
- `npm test` *(fails: initCheckout is not a function and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_68773718517c8325a0902fc6af56303f