### PR TITLE
fix: restore postinstall workspace installs

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -14,3 +14,14 @@ if (cwd !== root) {
   console.log(`[Smoothr] Skipping postinstall — running from ${cwd}, not monorepo root`);
   process.exit(0);
 }
+
+// ✅ Verify workspace installs so vitest and other dev tools are available
+const workspaces = ['storefronts', 'smoothr'];
+
+for (const ws of workspaces) {
+  const modulesDir = path.join(root, ws, 'node_modules');
+  if (!fs.existsSync(modulesDir)) {
+    console.log(`[Smoothr] Installing dependencies for ${ws}...`);
+    execSync(`npm --workspace ${ws} install`, { stdio: 'inherit' });
+  }
+}


### PR DESCRIPTION
## Summary
- ensure `scripts/postinstall.js` installs workspace deps when missing

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68774799e2a88325a759815ce01f4844