### PR TITLE
Fix recursive postinstall

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -31,6 +31,10 @@ for (const ws of workspaces) {
 
   if (!fs.existsSync(modulesDir)) {
     console.log(`[Smoothr] Installing dependencies for ${ws}...`);
-    execSync(`npm --workspace ${ws} install`, { stdio: 'inherit' });
+    // Prevent nested execution of this postinstall script by ignoring lifecycle
+    // scripts when installing workspace dependencies
+    execSync(`npm --workspace ${ws} install --ignore-scripts`, {
+      stdio: 'inherit',
+    });
   }
 }


### PR DESCRIPTION
## Summary
- prevent recursive execution of the monorepo postinstall script by ignoring scripts when installing workspace packages

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68775ae4a9e48325aafa2deb3b55cf8a