### PR TITLE
Copy waitForElement util into build outputs

### DIFF
--- a/storefronts/scripts/check-sdk.js
+++ b/storefronts/scripts/check-sdk.js
@@ -20,15 +20,23 @@ const webflowCheckoutPath = join(
   'webflow',
   'checkout.js'
 );
+const waitForElementPath = join(
+  __dirname,
+  '..',
+  'dist',
+  'utils',
+  'waitForElement.js'
+);
 
 try {
   await access(sdkPath, constants.F_OK);
   await access(checkoutPath, constants.F_OK);
   await access(stripePath, constants.F_OK);
   await access(webflowCheckoutPath, constants.F_OK);
+  await access(waitForElementPath, constants.F_OK);
 } catch {
   err(
-    `File not found: ${sdkPath} or ${checkoutPath} or ${stripePath} or ${webflowCheckoutPath}`
+    `File not found: ${sdkPath} or ${checkoutPath} or ${stripePath} or ${webflowCheckoutPath} or ${waitForElementPath}`
   );
   process.exit(1);
 }

--- a/storefronts/scripts/copy-checkout.js
+++ b/storefronts/scripts/copy-checkout.js
@@ -22,6 +22,20 @@ const webflowDest = join(
   'webflow',
   'checkout.js'
 );
+const waitForElementSrc = join(
+  __dirname,
+  '..',
+  'checkout',
+  'utils',
+  'waitForElement.js'
+);
+const waitForElementDest = join(
+  __dirname,
+  '..',
+  'dist',
+  'utils',
+  'waitForElement.js'
+);
 
 try {
   await copyFile(src, dest);
@@ -37,6 +51,15 @@ try {
   log(`Copied ${webflowSrc} to ${webflowDest}`);
 } catch (err) {
   err(`Failed to copy Webflow checkout.js: ${err.message}`);
+  process.exit(1);
+}
+
+try {
+  await mkdir(dirname(waitForElementDest), { recursive: true });
+  await copyFile(waitForElementSrc, waitForElementDest);
+  log(`Copied ${waitForElementSrc} to ${waitForElementDest}`);
+} catch (error) {
+  err(`Failed to copy waitForElement.js: ${error.message}`);
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- copy `waitForElement.js` during `postbuild`
- verify the util exists in `check-sdk.js`

## Testing
- `npm --workspace storefronts run build`
- `npm test` *(fails: checkout and gateway tests)*

------
https://chatgpt.com/codex/tasks/task_e_68775d174c8c83258fa636a15aab2bbe