### PR TITLE
Update billing postal attribute references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Updated checkout forms to use `[data-smoothr-bill-postal]` for the billing postal code field.
 - Removed the readiness poll for Authorize.Net card fields.
 - Added input sanitization and improved logging for Authorize.Net card fields.
 - Added debug logging feature controlled by `SMOOTHR_DEBUG` and documented the setting in the README.

--- a/storefronts/checkout/gateways/nmi.js
+++ b/storefronts/checkout/gateways/nmi.js
@@ -53,7 +53,7 @@ export async function mountNMI() {
   const numEl = await waitForElement('[data-smoothr-card-number]');
   const expEl = await waitForElement('[data-smoothr-card-expiry]');
   const cvvEl = await waitForElement('[data-smoothr-card-cvc]');
-  const postalEl = document.querySelector('[data-smoothr-postal]');
+  const postalEl = document.querySelector('[data-smoothr-bill-postal]');
   if (!numEl || !expEl || !cvvEl) return;
 
   [numEl, expEl, cvvEl].forEach(el =>

--- a/storefronts/dist/gateways/nmi.js
+++ b/storefronts/dist/gateways/nmi.js
@@ -53,7 +53,7 @@ export async function mountNMI() {
   const numEl = await waitForElement('[data-smoothr-card-number]');
   const expEl = await waitForElement('[data-smoothr-card-expiry]');
   const cvvEl = await waitForElement('[data-smoothr-card-cvc]');
-  const postalEl = document.querySelector('[data-smoothr-postal]');
+  const postalEl = document.querySelector('[data-smoothr-bill-postal]');
   if (!numEl || !expEl || !cvvEl) return;
 
   [numEl, expEl, cvvEl].forEach(el =>

--- a/storefronts/dist/platforms/webflow/checkout.js
+++ b/storefronts/dist/platforms/webflow/checkout.js
@@ -7532,7 +7532,7 @@ async function mountNMI() {
   const numEl = await waitForElement("[data-smoothr-card-number]");
   const expEl = await waitForElement("[data-smoothr-card-expiry]");
   const cvvEl = await waitForElement("[data-smoothr-card-cvc]");
-  const postalEl = document.querySelector("[data-smoothr-postal]");
+  const postalEl = document.querySelector("[data-smoothr-bill-postal]");
   if (!numEl || !expEl || !cvvEl)
     return;
   [numEl, expEl, cvvEl].forEach(

--- a/storefronts/platforms/README.md
+++ b/storefronts/platforms/README.md
@@ -87,7 +87,7 @@ styles.
 
 ## Billing address fields
 
-Optional billing information can be captured with `data-smoothr-bill-*` inputs. All fields are optional, but the checkout script will warn if some billing fields are filled in and the required ones (first name, last name, line1, city, postal and country) are missing.
+Optional billing information can be captured with `data-smoothr-bill-*` inputs. All fields are optional, but the checkout script will warn if some billing fields are filled in and the required ones (first name, last name, line1, city, postal and country) are missing. The postal code field should use `[data-smoothr-bill-postal]`.
 
 ```html
 <input data-smoothr-bill-first-name placeholder="Billing first name" />

--- a/storefronts/tests/providers/provider-nmi-mount.test.ts
+++ b/storefronts/tests/providers/provider-nmi-mount.test.ts
@@ -9,7 +9,7 @@ beforeEach(async () => {
   vi.resetModules();
   document.body.innerHTML = '';
   const wrapper = document.createElement('div');
-  ['card-number', 'card-expiry', 'card-cvc', 'postal'].forEach(attr => {
+  ['card-number', 'card-expiry', 'card-cvc', 'bill-postal'].forEach(attr => {
     const div = document.createElement('div');
     div.setAttribute(`data-smoothr-${attr}`, '');
     if (attr === 'card-expiry') {
@@ -62,7 +62,7 @@ describe('mountNMI', () => {
     await mountNMI();
     const num = document.querySelector('[data-smoothr-card-number]');
     const cvc = document.querySelector('[data-smoothr-card-cvc]');
-    const postal = document.querySelector('[data-smoothr-postal]');
+    const postal = document.querySelector('[data-smoothr-bill-postal]');
     const expiry = document.querySelector('[data-smoothr-card-expiry]');
     expect(num?.querySelector('input')?.getAttribute('data-collect')).toBe('cardNumber');
     expect(cvc?.querySelector('input')?.getAttribute('data-collect')).toBe('cvv');

--- a/storefronts/tests/sdk/checkout-payload.test.js
+++ b/storefronts/tests/sdk/checkout-payload.test.js
@@ -58,7 +58,7 @@ beforeEach(() => {
         '[data-smoothr-card-number]': cardNumberEl,
         '[data-smoothr-card-expiry]': cardExpiryEl,
         '[data-smoothr-card-cvc]': cardCvcEl,
-        '[data-smoothr-postal]': { value: '12345' },
+        '[data-smoothr-bill-postal]': { value: '12345' },
         '[data-smoothr-ship-line1]': { value: '' },
         '[data-smoothr-ship-line2]': { value: '' },
         '[data-smoothr-ship-city]': { value: '' },
@@ -89,6 +89,10 @@ beforeEach(() => {
         '#smoothr-checkout-theme': null
       };
       return map[sel] || null;
+    }),
+    querySelectorAll: vi.fn(sel => {
+      if (sel === '[data-smoothr-pay]') return [submitBtn];
+      return [];
     }),
     addEventListener: vi.fn((ev, cb) => {
       if (ev === 'DOMContentLoaded') domReadyCb = cb;


### PR DESCRIPTION
## Summary
- rename `[data-smoothr-postal]` to `[data-smoothr-bill-postal]`
- document the new attribute
- rebuild checkout assets
- update related tests

## Testing
- `npm test` *(fails: TypeError: clickHandler is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68785415b9948325990c4bc270b41382