### PR TITLE
Fix checkout payload test initialization

### DIFF
--- a/storefronts/tests/sdk/checkout-payload.test.js
+++ b/storefronts/tests/sdk/checkout-payload.test.js
@@ -18,6 +18,12 @@ beforeEach(() => {
   delete global.window?.__SMOOTHR_CHECKOUT_INITIALIZED__;
   delete global.window?.__SMOOTHR_CHECKOUT_BOUND__;
 
+  global.localStorage = {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+    removeItem: vi.fn()
+  };
+
   originalFetch = global.fetch;
 
   global.fetch = vi.fn(() =>
@@ -83,6 +89,8 @@ beforeEach(() => {
     })
   };
 
+  submitBtn.closest = vi.fn(() => block);
+
   originalDocument = global.document;
   global.document = {
     querySelector: vi.fn(sel => {
@@ -123,7 +131,7 @@ beforeEach(() => {
     }
   };
   global.window.smoothr = global.window.Smoothr;
-  originalDocument = global.document;
+  global.alert = global.window.alert = vi.fn();
 });
 
 afterEach(() => {
@@ -143,6 +151,7 @@ describe('checkout payload', () => {
 
     expect(typeof clickHandler).toBe('function');
     await clickHandler({ preventDefault: vi.fn(), stopPropagation: vi.fn() });
+    await flushPromises();
 
 
     expect(global.fetch).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- setup localStorage mock in checkout payload test
- stub element closest and alert helpers
- await promises before fetch assertion
- keep original document instance intact

## Testing
- `npm --workspace storefronts test`


------
https://chatgpt.com/codex/tasks/task_e_6878670964288325a9a2887845462f37