### PR TITLE
Fix webflow checkout export

### DIFF
--- a/storefronts/platforms/webflow/checkout.js
+++ b/storefronts/platforms/webflow/checkout.js
@@ -1,8 +1,4 @@
-
-
-import { initCheckout } from '../../checkout/checkout.js';
-
-
-document.addEventListener('DOMContentLoaded', () => {
-  initCheckout();
-});
+export async function initCheckout(...args) {
+  const mod = await import('../../checkout/checkout.js');
+  return mod.initCheckout(...args);
+}


### PR DESCRIPTION
## Summary
- avoid side-effecting import in webflow checkout adapter
- lazily import checkout.js when initCheckout is called

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687878978670832594236dde568802cc