### PR TITLE
Fix checkout initialization flag behavior

### DIFF
--- a/storefronts/checkout/checkout.js
+++ b/storefronts/checkout/checkout.js
@@ -1,7 +1,3 @@
-(() => {
-  if (window.__SMOOTHR_CHECKOUT_INITIALIZED__) return;
-  window.__SMOOTHR_CHECKOUT_INITIALIZED__ = true;
-})();
 
 if (
   typeof document !== 'undefined' &&
@@ -45,6 +41,8 @@ export async function computeCartHash(cart, total, email) {
 }
 
 export async function initCheckout(config) {
+  if (window.__SMOOTHR_CHECKOUT_INITIALIZED__) return;
+  window.__SMOOTHR_CHECKOUT_INITIALIZED__ = true;
   console.log('[Smoothr] initCheckout', config);
   const payButtons = document.querySelectorAll('[data-smoothr-pay]');
   console.log('[Smoothr] Found pay buttons:', payButtons.length);


### PR DESCRIPTION
## Summary
- remove top level IIFE from `checkout.js`
- set `__SMOOTHR_CHECKOUT_INITIALIZED__` flag when `initCheckout()` runs
- keep DOMContentLoaded hook for automatic initialization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687879fda9e88325bdebf54fb59930a6