### PR TITLE
Add NMI connection hints for Webflow checkout

### DIFF
--- a/storefronts/platforms/webflow/checkout.js
+++ b/storefronts/platforms/webflow/checkout.js
@@ -1,3 +1,36 @@
+;(function addNmiPerformanceHints() {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+  if (window.__NMI_PERF_HINTS__) return;
+  window.__NMI_PERF_HINTS__ = true;
+
+  const head = document.head || document.getElementsByTagName('head')[0];
+  const origin = 'https://secure.nmi.com';
+  const script = `${origin}/token/Collect.js`;
+
+  const dnsPrefetch = document.createElement('link');
+  dnsPrefetch.rel = 'dns-prefetch';
+  dnsPrefetch.href = origin;
+  head.appendChild(dnsPrefetch);
+
+  const preconnect = document.createElement('link');
+  preconnect.rel = 'preconnect';
+  preconnect.href = origin;
+  preconnect.crossOrigin = 'anonymous';
+  head.appendChild(preconnect);
+
+  const preload = document.createElement('link');
+  preload.rel = 'preload';
+  preload.href = script;
+  preload.as = 'script';
+  head.appendChild(preload);
+
+  try {
+    fetch(script, { method: 'HEAD', mode: 'no-cors' }).catch(() => {});
+  } catch {}
+
+  console.log('[NMI] performance hints injected');
+})();
+
 import { initCheckout } from '../../checkout/checkout.js';
 
 export { initCheckout };


### PR DESCRIPTION
## Summary
- inject dns-prefetch, preconnect and preload links for NMI
- warm the NMI connection once when running in the browser

## Testing
- `npm test` *(fails: Test Files  2 failed | 32 passed (34))*

------
https://chatgpt.com/codex/tasks/task_e_687896b849fc8325b51c92f7be4f498e