### PR TITLE
Fix NMI gateway script loading

### DIFF
--- a/storefronts/checkout/gateways/nmi.js
+++ b/storefronts/checkout/gateways/nmi.js
@@ -65,7 +65,7 @@ export function initNMI(tokenizationKey) {
     '[NMI] Set data-tokenization-key on script tag:',
     tokenizationKey.substring(0, 8) + '…'
   )
-  script.async = true
+  script.async = false
   document.head.appendChild(script)
 
   script.onload = () => {


### PR DESCRIPTION
## Summary
- load Collect.js synchronously in the NMI gateway

## Testing
- `npm test` *(fails: connect ENETUNREACH and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6878981f06588325a6883f16d2f650e3