### PR TITLE
Update NMI tests for CollectJS callback

### DIFF
--- a/storefronts/tests/providers/provider-nmi-global.test.ts
+++ b/storefronts/tests/providers/provider-nmi-global.test.ts
@@ -3,10 +3,14 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 beforeEach(() => {
   vi.resetModules();
   delete (window as any).Smoothr;
+  Object.defineProperty(document, 'readyState', { configurable: true, value: 'loading' });
+  vi.spyOn(document, 'addEventListener').mockImplementation(() => {});
 });
 
 afterEach(() => {
   delete (window as any).Smoothr;
+  Object.defineProperty(document, 'readyState', { configurable: true, value: 'complete' });
+  (document.addEventListener as any).mockRestore?.();
 });
 
 describe('nmi gateway global', () => {


### PR DESCRIPTION
## Summary
- expect CollectJS callback stub in create-payment-method-nmi tests
- update NMI mount tests for new script handling
- prevent auto mount side effects in NMI global tests

## Testing
- `npm test` *(fails: connect ENETUNREACH secure.nmi.com)*

------
https://chatgpt.com/codex/tasks/task_e_687898edee988325bc5cfc4db90049bc