### PR TITLE
Improve Webflow checkout bootstrap

### DIFF
--- a/storefronts/tests/platforms/webflow/checkout.dom.test.ts
+++ b/storefronts/tests/platforms/webflow/checkout.dom.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
+const originalFetch = global.fetch;
+
 beforeEach(() => {
   vi.resetModules();
   document.body.innerHTML = `
@@ -15,6 +17,8 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  global.fetch = originalFetch;
+  (global as any).window.fetch = originalFetch;
   delete (window as any).__SMOOTHR_CHECKOUT_INITIALIZED__;
 });
 
@@ -28,5 +32,67 @@ describe('webflow checkout adapter dom', () => {
     (window as any).__SMOOTHR_CHECKOUT_INITIALIZED__ = true;
     await import('../../../platforms/webflow/checkout.js');
     expect((window as any).__SMOOTHR_CHECKOUT_INITIALIZED__).toBe(true);
+  });
+
+  it('initializes phone and country fields from geo lookup', async () => {
+    document.body.innerHTML = `
+      <select name="shipping[country]">
+        <option value="GB">UK</option>
+        <option value="US">US</option>
+      </select>
+      <select name="billing[country]">
+        <option value="GB">UK</option>
+        <option value="US">US</option>
+      </select>
+      <select name="phone[country]">
+        <option value="GB|+44">UK</option>
+        <option value="US|+1">US</option>
+      </select>
+      <input name="shipping[phone]" />
+    `;
+
+    document.documentElement.lang = '';
+
+    const appendSpy = vi
+      .spyOn(document.head, 'appendChild')
+      .mockImplementation(el => {
+        const tag = (el as HTMLElement).tagName;
+        if (tag === 'SCRIPT') {
+          setTimeout(() => el.dispatchEvent(new Event('load')));
+          return el;
+        }
+        if (tag === 'LINK') {
+          return el;
+        }
+        return HTMLElement.prototype.appendChild.call(document.head, el);
+      });
+
+    const fetchMock = vi.fn(async () => ({ json: async () => ({ country_code: 'US' }) }));
+    global.fetch = fetchMock as any;
+    (global as any).window.fetch = fetchMock as any;
+    (window as any).Choices = vi.fn();
+    (window as any).intlTelInput = vi.fn();
+
+    await import('../../../../client/platforms/webflow/checkoutAdapter.js');
+
+    for (let i = 0; i < 4; i++) {
+      await new Promise(r => setTimeout(r, 0));
+    }
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect((window as any).Choices).toHaveBeenCalledTimes(3);
+    expect((window as any).intlTelInput).toHaveBeenCalledWith(
+      document.querySelector('input[name="shipping[phone]"]'),
+      expect.objectContaining({ initialCountry: 'us' })
+    );
+    expect(
+      document.querySelector('select[name="shipping[country]"]')?.value
+    ).toBe('US');
+    expect(
+      document.querySelector('select[name="billing[country]"]')?.value
+    ).toBe('US');
+    expect(document.querySelector('select[name="phone[country]"]')?.value).toBe('US|+1');
+
+    appendSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- bootstrap country pickers after country detection completes
- update Webflow adapter DOM test for phone/country pickers

## Testing
- `npm run bundle:webflow-checkout`
- `npm test` *(fails: checkout.test.js > posts cart and currency on click)*

------
https://chatgpt.com/codex/tasks/task_e_6879641699ec8325ac89dfaa433ca1e5