### PR TITLE
Fix README note on client folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,11 @@ This repository contains all code for Smoothr, structured as a modular SaaS plat
 ## Directory Overview
 
 - **/storefronts/** – Client-facing storefront code and widgets.
-  - _Note: the older `/client` folder was removed in favor of `/storefronts`. Any
-    Cloudflare `_headers` configuration previously under `client/dist` is no
-    longer required._
   - **/core/** – Core storefront modules such as orders, returns, reviews, analytics, discounts, currency, affiliates, cart, customer dashboard, abandoned cart, and subscriptions.
   - **/platforms/** – Adapters for various web builder platforms.
   - **/clonables/** – Embeddable widgets and plug‑and‑play code.
- - **/shared/** – Server-side logic for orders, returns, reviews, analytics, discounts, currency, affiliates, cart, abandoned cart, subscriptions, and Supabase helpers.
+- **/client/** – Legacy platform scripts like the Webflow checkout adapter kept for compatibility.
+- **/shared/** – Server-side logic for orders, returns, reviews, analytics, discounts, currency, affiliates, cart, abandoned cart, subscriptions, and Supabase helpers.
 - **/smoothr/** – Next.js admin dashboard application.
   - **/admin-modules/** – Admin views for orders, returns, reviews, analytics, discounts, currency, affiliates, cart, dashboard, abandoned cart, and subscriptions.
 - **.gitignore** – Ignore Node modules, logs, env files, and build output.


### PR DESCRIPTION
## Summary
- clarify that `/client` folder still exists for a legacy Webflow adapter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879675b484c8325a0c14ffc0b73b515