### PR TITLE
Add bundling confirmation log

### DIFF
--- a/storefronts/scripts/bundle-webflow-checkout.js
+++ b/storefronts/scripts/bundle-webflow-checkout.js
@@ -44,6 +44,9 @@ try {
       __NEXT_PUBLIC_SUPABASE_ANON_KEY__: JSON.stringify(supabaseAnonKey)
     }
   });
+  // Always output a short confirmation that bundling completed.
+  console.log('[bundle-webflow-checkout] Bundled Webflow checkout');
+  // Detailed output still respects the SMOOTHR_DEBUG flag.
   log(`Bundled ${entry} to ${outFile}`);
 } catch (e) {
   err(`Failed to bundle Webflow checkout: ${e.message}`);


### PR DESCRIPTION
## Summary
- always log when Webflow checkout bundling finishes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687971380330832595624f404ca78055