### PR TITLE
Fix cart hash persistence logic

### DIFF
--- a/storefronts/checkout/checkout.js
+++ b/storefronts/checkout/checkout.js
@@ -217,7 +217,6 @@ export async function initCheckout(config) {
       alert("You’ve already submitted this cart. Please wait or modify your order.");
       return;
     }
-    localStorage.setItem('smoothr_last_cart_hash', cartHash);
 
     if (!gateway.ready()) {
       err('Payment gateway not ready');
@@ -238,12 +237,14 @@ export async function initCheckout(config) {
         (!token?.dataDescriptor || !token?.dataValue)
       ) {
         alert('Invalid payment details. Please try again.');
+        localStorage.removeItem('smoothr_last_cart_hash');
         enableButton(btn);
         isSubmitting = false;
         return;
       }
       if (!token || pmError) {
         err('Failed to create payment method', { error: pmError, payment_method: token });
+        localStorage.removeItem('smoothr_last_cart_hash');
         enableButton(btn);
         isSubmitting = false;
         return;
@@ -281,14 +282,18 @@ export async function initCheckout(config) {
 
       if (!res || !res.ok || !data.success) {
         err('Checkout failed');
+        localStorage.removeItem('smoothr_last_cart_hash');
         if (!hasShownCheckoutError) {
           alert('Failed to start checkout');
           hasShownCheckoutError = true;
         }
+      } else {
+        localStorage.setItem('smoothr_last_cart_hash', cartHash);
       }
     } catch (error) {
       console.error(error);
       err(`\u274C ${error.message}`);
+      localStorage.removeItem('smoothr_last_cart_hash');
       if (!hasShownCheckoutError) {
         alert('Failed to start checkout');
         hasShownCheckoutError = true;


### PR DESCRIPTION
## Summary
- delay setting the cart hash until after a successful gateway response
- clear the cart hash on payment method or gateway errors

## Testing
- `npm test` *(fails: connect ENETUNREACH 104.192.33.49:443)*

------
https://chatgpt.com/codex/tasks/task_e_687a9518696c83258f0cbb06913c9fc8