### PR TITLE
Refine deduplication for paid orders

### DIFF
--- a/shared/checkout/handleCheckout.ts
+++ b/shared/checkout/handleCheckout.ts
@@ -342,7 +342,7 @@ export async function handleCheckout({ req, res }: { req: NextApiRequest; res: N
     if (existingOrders && existingOrders.length > 0) {
       const existing = existingOrders[0];
       const ageMs = Date.now() - new Date(existing.created_at as string).getTime();
-      if (existing.status === 'paid') {
+      if (existing.status === 'paid' && ageMs < dedupWindowMs) {
         warn('Duplicate paid order detected', { order_id: existing.id });
         res.status(409).json({ 
           error: 'Order already completed',


### PR DESCRIPTION
## Summary
- tweak dedup check so paid orders are only rejected if recent

## Testing
- `npm test` *(fails: connect ENETUNREACH for external resources)*

------
https://chatgpt.com/codex/tasks/task_e_687ab543a4a883258f2aa54b6fd6af9b