### PR TITLE
Update pay button handling in checkout

### DIFF
--- a/storefronts/checkout/checkout.js
+++ b/storefronts/checkout/checkout.js
@@ -153,7 +153,7 @@ export async function initCheckout(config) {
       }
 
       isSubmitting = true;
-      disableButton(btn);
+      payButtons.forEach(disableButton);
 
       // Clear any previous error messages
       clearErrorMessages();
@@ -165,7 +165,7 @@ export async function initCheckout(config) {
       const validationErrors = validateFormData(formData);
       if (validationErrors.length > 0) {
         showValidationErrors(validationErrors);
-        enableButton(btn);
+        payButtons.forEach(enableButton);
         isSubmitting = false;
         return;
       }
@@ -188,14 +188,14 @@ export async function initCheckout(config) {
 
       if (lastSubmission.hash === cartHash && lastSubmission.success && (Date.now() - lastSubmission.timestamp) < 60000) {
         showUserMessage("You've already submitted this order. Please check your email for confirmation.", 'warning');
-        enableButton(btn);
+        payButtons.forEach(enableButton);
         isSubmitting = false;
         return;
       }
 
       if (!gateway.ready()) {
         showUserMessage('Payment system is loading. Please wait a moment and try again.', 'error');
-        enableButton(btn);
+        payButtons.forEach(enableButton);
         isSubmitting = false;
         return;
       }
@@ -209,14 +209,14 @@ export async function initCheckout(config) {
         if (pmError || !token) {
           const errorMessage = getPaymentMethodErrorMessage(pmError, provider);
           showUserMessage(errorMessage, 'error');
-          enableButton(btn);
+          payButtons.forEach(enableButton);
           isSubmitting = false;
           return;
         }
 
         if (provider === 'authorizeNet' && (!token?.dataDescriptor || !token?.dataValue)) {
           showUserMessage('Please check your payment details and try again.', 'error');
-          enableButton(btn);
+          payButtons.forEach(enableButton);
           isSubmitting = false;
           return;
         }
@@ -286,7 +286,7 @@ export async function initCheckout(config) {
         }));
 
       } finally {
-        enableButton(btn);
+        payButtons.forEach(enableButton);
         isSubmitting = false;
         log('submit handler complete');
       }


### PR DESCRIPTION
## Summary
- disable all pay buttons while a checkout submission is in progress
- re-enable all pay buttons on validation or network failures and on completion

## Testing
- `npm test` *(fails: 4 failed, 31 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687ab69663a483259a5ab8caf9698909