### PR TITLE
Fix NMI click handler

### DIFF
--- a/storefronts/checkout/gateways/nmi.js
+++ b/storefronts/checkout/gateways/nmi.js
@@ -188,7 +188,6 @@ function configureCollectJS() {
 
     CollectJS.configure({
       variant: 'inline',
-      paymentSelector: '[data-smoothr-pay]',
       fields: {
         ccnumber: { 
           selector:    '[data-smoothr-card-number]',
@@ -351,7 +350,15 @@ function configureCollectJS() {
         if (isSubmitting) return false
         isSubmitting = true
         payButtons.forEach(disableButton)
-        CollectJS.startPayment()
+        if (typeof CollectJS.startPaymentRequest === 'function') {
+          CollectJS.startPaymentRequest()
+        } else if (typeof CollectJS.tokenize === 'function') {
+          CollectJS.tokenize()
+        } else {
+          console.error('[NMI] No CollectJS tokenization method found')
+          isSubmitting = false
+          payButtons.forEach(enableButton)
+        }
         return false
       })
     })


### PR DESCRIPTION
## Summary
- stop CollectJS from binding its own handler
- call CollectJS.tokenize or startPaymentRequest manually

## Testing
- `npm test` *(fails: connect ENETUNREACH secure.nmi.com)*

------
https://chatgpt.com/codex/tasks/task_e_687ac30290308325a6ec2ec1fa3bc003