### PR TITLE
Fix NMI checkout early exit

### DIFF
--- a/storefronts/checkout/gateways/nmi.js
+++ b/storefronts/checkout/gateways/nmi.js
@@ -271,12 +271,16 @@ function configureCollectJS() {
             console.error('[NMI] Invalid total amount')
             alert('Issue with order total. Please refresh.')
             isLocked = false
+            isSubmitting = false
+            payButtons.forEach(enableButton)
             return
           }
         } else {
           console.error('[NMI] Total element missing')
           alert('Order total not found. Please try again.')
           isLocked = false
+          isSubmitting = false
+          payButtons.forEach(enableButton)
           return
         }
 
@@ -294,6 +298,8 @@ function configureCollectJS() {
           console.error('[NMI] Cart is empty')
           alert('Your cart is empty. Add items to proceed.')
           isLocked = false
+          isSubmitting = false
+          payButtons.forEach(enableButton)
           return
         }
 


### PR DESCRIPTION
## Summary
- stop submission lock if NMI checkout aborts early

## Testing
- `npm test` *(fails: connect ENETUNREACH 104.192.33.49:443)*

------
https://chatgpt.com/codex/tasks/task_e_687ac452ab2c8325a57baa3eed4476e6