### PR TITLE
Replace CollectJS.startPayment with tokenize

### DIFF
--- a/storefronts/checkout/gateways/nmi.js
+++ b/storefronts/checkout/gateways/nmi.js
@@ -356,9 +356,7 @@ function configureCollectJS() {
         if (isSubmitting) return false
         isSubmitting = true
         payButtons.forEach(disableButton)
-        if (typeof CollectJS.startPaymentRequest === 'function') {
-          CollectJS.startPaymentRequest()
-        } else if (typeof CollectJS.tokenize === 'function') {
+        if (typeof CollectJS.tokenize === 'function') {
           CollectJS.tokenize()
         } else {
           console.error('[NMI] No CollectJS tokenization method found')


### PR DESCRIPTION
## Summary
- switch NMI integration to use `CollectJS.tokenize()`

## Testing
- `npm test` *(fails: ENETUNREACH, Missing store_id, handleNmi errors, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687ac55d37dc8325ac3f147a57658272