### PR TITLE
Switch to gateway column

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ resolveGateway({ active_payment_gateway: 'bogus' });
 ```
 
 To enable Authorize.net create a row in the `store_integrations` table with
-`provider` set to `authorizeNet` and store your API credentials under the
+`gateway` set to `authorizeNet` and store your API credentials under the
 `settings` column:
 
 ```json
@@ -162,7 +162,7 @@ override this global to customize how order numbers are produced.
 
 ### NMI Integration
 
-To enable NMI create a row in the `store_integrations` table with `provider`
+To enable NMI create a row in the `store_integrations` table with `gateway`
 set to `nmi` and store both the API key and tokenization key under the
 `settings` column:
 
@@ -198,7 +198,7 @@ a Stripe `payment_method`.
 
 ### PayPal Integration
 
-To enable PayPal create a row in the `store_integrations` table with `provider`
+To enable PayPal create a row in the `store_integrations` table with `gateway`
 set to `paypal` and store your REST credentials under the `settings` column:
 
 ```json

--- a/shared/checkout/getStoreIntegration.ts
+++ b/shared/checkout/getStoreIntegration.ts
@@ -6,7 +6,7 @@ export async function getStoreIntegration(storeId: string, integrationId: string
     .from('store_integrations')
     .select('api_key, settings')
     .eq('store_id', storeId)
-    .eq('provider', integrationId)
+    .eq('gateway', integrationId)
     .maybeSingle();
   if (error) {
     console.warn('[getStoreIntegration]', error.message || error);

--- a/smoothr/pages/api/get-payment-key.js
+++ b/smoothr/pages/api/get-payment-key.js
@@ -33,7 +33,7 @@ export default async function handler(req, res) {
       .from('store_integrations')
       .select('settings')
       .eq('store_id', storeId)
-      .eq('provider', provider)
+      .eq('gateway', provider)
       .single();
 
     if (error) {

--- a/storefronts/README.md
+++ b/storefronts/README.md
@@ -144,7 +144,7 @@ resolveGateway({});
 ```
 
 To integrate Authorize.net create a record in the `store_integrations` table
-with `provider` set to `authorizeNet` and save your credentials in the
+with `gateway` set to `authorizeNet` and save your credentials in the
 `settings` JSON column:
 
 ```json
@@ -169,7 +169,7 @@ setting on the client by defining the following snippet before loading the SDK:
 ```
 
 A Network Merchants (NMI) integration is also supported. Create a new record in
-`store_integrations` with either `provider` or `settings.gateway` set to `nmi`
+`store_integrations` with either `gateway` or `settings.gateway` set to `nmi`
 and place your credentials in the `settings` JSON column:
 
 ```json

--- a/storefronts/checkout/gateways/stripe.js
+++ b/storefronts/checkout/gateways/stripe.js
@@ -98,7 +98,7 @@ async function resolveStripeKey() {
             .from('store_integrations')
             .select('api_key, settings')
             .eq('store_id', storeId)
-            .eq('provider', 'stripe')
+            .eq('gateway', 'stripe')
             .maybeSingle();
           if (error) {
             warn('Integration lookup failed:', error.message || error);

--- a/storefronts/checkout/getPublicCredential.js
+++ b/storefronts/checkout/getPublicCredential.js
@@ -9,10 +9,10 @@ export async function getPublicCredential(storeId, integrationId, gateway) {
       .eq('store_id', storeId);
     if (gateway) {
       query = query.or(
-        `provider.eq.${integrationId},settings->>gateway.eq.${gateway}`
+        `gateway.eq.${integrationId},settings->>gateway.eq.${gateway}`
       );
     } else {
-      query = query.eq('provider', integrationId);
+      query = query.eq('gateway', integrationId);
     }
     const { data, error } = await query.maybeSingle();
     if (error) {


### PR DESCRIPTION
## Summary
- update Supabase queries to use the new `gateway` column
- update docs to reference `gateway`

## Testing
- `npm test` *(fails: connect ENETUNREACH 104.192.33.49:443)*

------
https://chatgpt.com/codex/tasks/task_e_687c24f2471c8325958664d31a5e67ce