### PR TITLE
Align checkout with updated orders schema

### DIFF
--- a/shared/checkout/createOrder.ts
+++ b/shared/checkout/createOrder.ts
@@ -15,6 +15,7 @@ export interface CreateOrderPayload {
   billing?: any;
   store_id: string;
   order_number?: string;
+  customer_id?: string | null;
 }
 
 export async function createOrder(payload: CreateOrderPayload) {
@@ -36,8 +37,6 @@ export async function createOrder(payload: CreateOrderPayload) {
     throw new Error('store_id is required');
   }
 
-  const items = Array.isArray(cart) ? cart : [];
-
   let orderNumber: string | undefined = order_number;
   if (!orderNumber) {
     try {
@@ -56,10 +55,7 @@ export async function createOrder(payload: CreateOrderPayload) {
       payment_provider: gateway,
       total_price,
       store_id,
-      platform: platform || null,
-      customer_email: email,
-      items,
-      raw_data: { email, name, cart, total_price, currency, gateway, platform, shipping, billing },
+      customer_id: payload.customer_id ?? null,
     })
     .select('*')
     .single();

--- a/storefronts/tests/providers/handleCheckout-store-id.test.ts
+++ b/storefronts/tests/providers/handleCheckout-store-id.test.ts
@@ -57,6 +57,10 @@ describe('handleCheckout store_id validation', () => {
     await handleCheckout({ req: req as NextApiRequest, res: res as NextApiResponse });
 
     expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Missing store_id' });
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Missing store_id',
+      field: 'store_id',
+      user_message: 'Configuration error. Please refresh the page and try again.'
+    });
   });
 });

--- a/storefronts/tests/providers/provider-handleCheckout-authorizeNet.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-authorizeNet.test.ts
@@ -65,6 +65,9 @@ vi.mock('../../../shared/supabase/serverClient.ts', () => {
             };
           }
         }
+        if (table === 'order_items' || table === 'discount_usages') {
+          return { insert: vi.fn().mockResolvedValue({ error: null }) };
+        }
         return {};
       }
     }
@@ -109,7 +112,6 @@ describe('handleCheckout authorizeNet', () => {
     };
 
     await handleCheckout({ req: req as NextApiRequest, res: res as NextApiResponse });
-    expect(orderPayload.raw_data.transaction_id).toBe('t123');
     expect(orderPayload.payment_intent_id).toBe('t123');
     expect(orderPayload.status).toBe('paid');
   });

--- a/storefronts/tests/providers/provider-handleCheckout-nmi.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-nmi.test.ts
@@ -85,6 +85,9 @@ vi.mock('../../../shared/supabase/serverClient.ts', () => {
             };
           }
         }
+        if (table === 'order_items' || table === 'discount_usages') {
+          return { insert: vi.fn().mockResolvedValue({ error: null }) };
+        }
         return {};
       }
     }
@@ -133,9 +136,6 @@ describe('handleCheckout nmi', () => {
       expect.objectContaining({ payment_token: 'tok_123', amount: 100 })
     );
     expect(orderPayload.payment_intent_id).toBe('t123');
-    expect(orderPayload.raw_data.transaction_id).toBe('t123');
-    expect(orderPayload.raw_data.transactionResponse).toBeInstanceOf(URLSearchParams);
-    expect(orderPayload.raw_data.transactionResponse.get('transactionid')).toBe('t123');
     expect(orderPayload.status).toBe('paid');
     expect(typeof orderPayload.paid_at).toBe('string');
   });

--- a/supabase/functions/webflow-order-handler.test.ts
+++ b/supabase/functions/webflow-order-handler.test.ts
@@ -82,16 +82,12 @@ describe.skip('webflow-order-handler', () => {
     );
     expect(insertCustomerMock).toHaveBeenCalledWith({ store_id: 'site', email: 'user@example.com' });
     expect(insertOrderMock).toHaveBeenCalledWith({
-      customer_email: 'user@example.com',
-      customer_id: 'cust-1',
-      platform: 'webflow',
       store_id: 'site',
-      raw_data: payload,
-      tracking_number: null,
-      label_url: null,
-      problem_flag: false,
-      flag_reason: null,
-      updated_at: expect.any(String),
+      customer_id: 'cust-1',
+      order_number: payload.orderId,
+      status: 'paid',
+      payment_provider: null,
+      total_price: 10,
     });
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({ success: true, site_id: 'site' });

--- a/supabase/functions/webflow-order-handler/index.ts
+++ b/supabase/functions/webflow-order-handler/index.ts
@@ -63,18 +63,14 @@ export async function handleRequest(req: Request): Promise<Response> {
     }
   }
 
-  // Insert the incoming Webflow order into the existing `orders` table
+  // Insert the incoming Webflow order into the simplified `orders` table
   const { error } = await supabase.from('orders').insert({
-    customer_email: email,
-    customer_id: customerId,
-    platform: payload.platform || 'webflow',
     store_id: siteId,
-    raw_data: payload,
-    tracking_number: null,
-    label_url: null,
-    problem_flag: false,
-    flag_reason: null,
-    updated_at: new Date().toISOString(),
+    customer_id: customerId,
+    order_number: payload.orderId,
+    status: payload.orderStatus || 'paid',
+    payment_provider: payload.processor || null,
+    total_price: payload.total,
   });
 
   if (error) {


### PR DESCRIPTION
## Summary
- simplify order creation payload
- store cart items separately from orders
- update webflow handler to use slimmed down order fields
- adjust checkout tests for new payload

## Testing
- `npm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_687c26d3abc08325841e15adf721ac27