### PR TITLE
Replace user_id with customer_id in Webflow OAuth callback

### DIFF
--- a/smoothr/pages/api/webflow/oauth-callback.ts
+++ b/smoothr/pages/api/webflow/oauth-callback.ts
@@ -18,7 +18,7 @@ export default async function handler(req: any, res: any) {
   }
 
   const code = req.query.code as string | undefined;
-  const user_id = req.query.state as string | undefined;
+  const customer_id = req.query.state as string | undefined;
 
   if (!code) {
     res.status(400).json({ error: 'Missing code' });
@@ -52,9 +52,9 @@ export default async function handler(req: any, res: any) {
       site_id: string;
     };
 
-    if (user_id) {
+    if (customer_id) {
       await supabase.from('webflow_connections').insert({
-        user_id,
+        customer_id,
         site_id,
         access_token,
       });


### PR DESCRIPTION
## Summary
- use `customer_id` instead of `user_id` when storing Webflow connection info

## Testing
- `npm test` *(fails: connect ENETUNREACH 104.192.33.49:443)*

------
https://chatgpt.com/codex/tasks/task_e_687c2ac9f63c832595171ed9c4fcf15e