### PR TITLE
Stub storeId for tests

### DIFF
--- a/storefronts/vitest.setup.js
+++ b/storefronts/vitest.setup.js
@@ -23,6 +23,14 @@ if (typeof globalThis.document === "undefined") {
     dispatchEvent: vi.fn(),
   };
 }
+// Stub the <script> tag dataset so loadConfig gets a storeId in tests
+if (typeof document !== 'undefined' && !document.currentScript) {
+  Object.defineProperty(document, 'currentScript', {
+    value: { dataset: { storeId: '00000000-0000-0000-0000-000000000000' } },
+    configurable: true,
+    writable: true
+  });
+}
 if (typeof globalThis.window.Smoothr === "undefined") {
   globalThis.window.Smoothr = {};
 }


### PR DESCRIPTION
## Summary
- stub `document.currentScript.dataset.storeId` so SDK tests load config
- make sure placeholder storeId is available in Vitest setup

## Testing
- `npm test -w storefronts --silent` *(fails: Failed Suites 35)*

------
https://chatgpt.com/codex/tasks/task_e_687c488843c883258f63981799358971