### PR TITLE
Patch script lookup

### DIFF
--- a/storefronts/core/index.js
+++ b/storefronts/core/index.js
@@ -79,8 +79,11 @@ export default Smoothr;
 
 // Bootstrap SDK: load config and then initialize everything
 (async function initSmoothr() {
-  // Read storeId from the <script> tag that loaded this module
-  const currentScript = document.currentScript;
+  // Try to find the script tag containing the store ID
+  const currentScript =
+    document.currentScript ||
+    document.querySelector('script[src*="smoothr-sdk"][data-store-id]');
+
   const storeId = currentScript?.dataset?.storeId;
   if (!storeId) {
     throw new Error('Missing data-store-id on <script> tag');


### PR DESCRIPTION
## Summary
- fix store-id detection by querying for script tag

## Testing
- `npm test` *(fails: vitest not found / network)*

------
https://chatgpt.com/codex/tasks/task_e_687c4c54b0508325a14cd2e2f65d4d6e