### PR TITLE
Use shared Supabase client

### DIFF
--- a/storefronts/core/index.js
+++ b/storefronts/core/index.js
@@ -1,4 +1,4 @@
-import { createClient } from '@supabase/supabase-js';
+import supabase from '../../supabase/supabaseClient.js';
 
 import * as abandonedCart from './abandoned-cart/index.js';
 import * as affiliates from './affiliates/index.js';
@@ -19,12 +19,6 @@ import { initCartBindings } from './cart/addToCart.js';
 import { renderCart } from './cart/renderCart.js';
 import { setSelectedCurrency as setDomCurrency } from '../platforms/webflow/webflow-dom.js';
 import { setSelectedCurrency as setCmsCurrency } from './currency/cms-currency.js';
-
-// Initialize Supabase client using Vite env vars
-const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_ANON_KEY
-);
 
 // Load the store_settings JSON into window.SMOOTHR_CONFIG
 async function loadConfig(storeId) {


### PR DESCRIPTION
## Summary
- refactor storefront core to import the shared Supabase client
- remove duplicated `createClient` initialization

## Testing
- `npm test` *(fails: connect ENETUNREACH 104.192.33.49:443)*
- `npm run bundle:webflow-checkout`


------
https://chatgpt.com/codex/tasks/task_e_687c69e22d40832596bae96f8e6ded6c