### PR TITLE
Add immediate platform config and DOM-ready checkout

### DIFF
--- a/storefronts/platforms/webflow/checkout.js
+++ b/storefronts/platforms/webflow/checkout.js
@@ -38,6 +38,8 @@ export { initCheckout };
 window.SMOOTHR_CONFIG = window.SMOOTHR_CONFIG || {};
 window.SMOOTHR_CONFIG.platform = 'webflow';
 
-document.addEventListener('DOMContentLoaded', () => {
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initCheckout);
+} else {
   initCheckout();
-});
+}


### PR DESCRIPTION
## Summary
- ensure `SMOOTHR_CONFIG.platform` is set before checkout initializes
- initialize checkout immediately when DOM is already loaded

## Testing
- `npm test` *(fails: ENETUNREACH errors and timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_687c7910ea4483258cb08421a1e207ad