### PR TITLE
Use api_key for NMI tokenization

### DIFF
--- a/storefronts/checkout/providers/nmi.js
+++ b/storefronts/checkout/providers/nmi.js
@@ -15,7 +15,14 @@ export async function resolveTokenizationKey() {
 
   try {
     const cred = await getPublicCredential(storeId, 'nmi', gateway);
-    cachedKey = cred?.settings?.tokenization_key || null;
+    if (cred?.api_key) {
+      cachedKey = cred.api_key;
+    } else if (cred?.settings?.tokenization_key) {
+      warn('tokenization_key is deprecated – update integration to use api_key');
+      cachedKey = cred.settings.tokenization_key;
+    } else {
+      cachedKey = null;
+    }
   } catch (e) {
     warn('Integration fetch error:', e?.message || e);
     cachedKey = null;


### PR DESCRIPTION
## Summary
- support new `api_key` for NMI tokenization key

## Testing
- `npm test` *(fails: connect ENETUNREACH 104.192.33.49:443)*

------
https://chatgpt.com/codex/tasks/task_e_687c8415ab3c8325b88a8463ed452a6d