### PR TITLE
Use api_key from store integrations

### DIFF
--- a/smoothr/pages/api/get-payment-key.js
+++ b/smoothr/pages/api/get-payment-key.js
@@ -31,7 +31,7 @@ export default async function handler(req, res) {
     console.log('[API] Querying store_integrations for store:', storeId, 'provider:', provider);
     const { data, error } = await supabase
       .from('store_integrations')
-      .select('settings')
+      .select('api_key')
       .eq('store_id', storeId)
       .eq('gateway', provider)
       .single();
@@ -41,13 +41,9 @@ export default async function handler(req, res) {
       return res.status(500).json({ error: 'Failed to fetch key', details: error.message });
     }
 
-    if (data && data.settings) {
-      const settings = typeof data.settings === 'string' ? JSON.parse(data.settings) : data.settings;
-      const tokenizationKey = settings.tokenization_key || settings.api_key; // Fallback to api_key if tokenization_key missing
-      if (tokenizationKey) {
-        console.log('[API] Key fetched successfully for store:', storeId, 'key:', tokenizationKey);
-        return res.status(200).json({ tokenization_key: tokenizationKey });
-      }
+    if (data && data.api_key) {
+      console.log('[API] Key fetched successfully for store:', storeId);
+      return res.status(200).json({ tokenization_key: data.api_key });
     }
 
     console.error('[API] No key found for store:', storeId, 'provider:', provider, 'data:', data);


### PR DESCRIPTION
## Summary
- read the `api_key` column when fetching store integrations
- respond with that key instead of using the legacy tokenization value

## Testing
- `npm test` *(fails: ENETUNREACH errors when trying to fetch external resources)*

------
https://chatgpt.com/codex/tasks/task_e_687c8508a7688325a4faf6d2f0ec083c