### PR TITLE
Remove env credential fallbacks

### DIFF
--- a/shared/checkout/providers/nmi.ts
+++ b/shared/checkout/providers/nmi.ts
@@ -54,10 +54,6 @@ export default async function handleNmi(payload: NmiPayload) {
   }
 
   if (!securityKey.trim()) {
-    securityKey = process.env.NMI_SECURITY_KEY || '';
-  }
-
-  if (!securityKey.trim()) {
     console.warn('[Checkout NMI] Missing security key');
     return { success: false, error: 'Missing security key' };
   }

--- a/shared/checkout/providers/paypal.ts
+++ b/shared/checkout/providers/paypal.ts
@@ -18,8 +18,8 @@ interface PayPalPayload {
 }
 
 export default async function handlePayPal(payload: PayPalPayload) {
-  let clientId = process.env.PAYPAL_CLIENT_ID || '';
-  let clientSecret = process.env.PAYPAL_SECRET || process.env.PAYPAL_CLIENT_SECRET || '';
+  let clientId = '';
+  let clientSecret = '';
 
   try {
     const integration = await getStoreIntegration(payload.store_id, 'paypal');

--- a/shared/checkout/providers/stripe.ts
+++ b/shared/checkout/providers/stripe.ts
@@ -35,7 +35,6 @@ export default async function handleStripe(payload: StripePayload) {
   const stripeSecret =
     integration?.settings?.secret_key ||
     integration?.api_key ||
-    process.env.STRIPE_SECRET_KEY ||
     '';
   if (!stripeSecret.trim()) {
     err('Missing Stripe credentials');

--- a/smoothr/pages/api/checkout/paypal/capture-order.ts
+++ b/smoothr/pages/api/checkout/paypal/capture-order.ts
@@ -18,8 +18,8 @@ export default async function handler(
     return res.status(400).json({ error: 'store_id required' });
   }
 
-  let clientId = process.env.PAYPAL_CLIENT_ID || '';
-  let secret = process.env.PAYPAL_SECRET || process.env.PAYPAL_CLIENT_SECRET || '';
+  let clientId = '';
+  let secret = '';
   try {
     const integration = await getStoreIntegration(store_id, 'paypal');
     if (integration) {

--- a/smoothr/pages/api/checkout/paypal/create-order.ts
+++ b/smoothr/pages/api/checkout/paypal/create-order.ts
@@ -11,8 +11,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(400).json({ error: 'store_id required' });
   }
 
-  let clientId = process.env.PAYPAL_CLIENT_ID || '';
-  let secret = process.env.PAYPAL_SECRET || process.env.PAYPAL_CLIENT_SECRET || '';
+  let clientId = '';
+  let secret = '';
   try {
     const integration = await getStoreIntegration(store_id, 'paypal');
     if (integration) {


### PR DESCRIPTION
## Summary
- remove environment variable fallbacks for payment provider credentials
- rely solely on `getStoreIntegration` when obtaining provider credentials

## Testing
- `npm test` *(fails: ENETUNREACH and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_687c8609168c8325a5fc5a71914ba66e