### PR TITLE
Update docs for NMI route

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ the Webflow checkout script.
 The admin dashboard exposes two endpoints for initiating a checkout:
 Store integrations use a `gateway` column to specify the active payment provider. Any prior references to a `provider` column are obsolete.
 
-1. `/api/checkout/[provider]` – processes a posted cart using the configured payment gateway. This single route handles checkouts for all providers (e.g. `stripe` or `authorizeNet`). The `[provider]` segment must match the gateway configured for the store. The request body must include the following fields:
+1. `/api/checkout/[provider]` – processes a posted cart using the configured payment gateway. This single route handles checkouts for all providers (e.g. `stripe` or `authorizeNet`). The `[provider]` segment must match the gateway configured for the store. For NMI this segment is `nmi`, so `/api/checkout/nmi` maps to the same `[provider].ts` handler. The request body must include the following fields:
 
 - `payment_method` – the ID of the payment method to charge
 - `email` – customer email for receipts

--- a/smoothr/pages/api/checkout/[provider].ts
+++ b/smoothr/pages/api/checkout/[provider].ts
@@ -1,3 +1,4 @@
+// For example `/api/checkout/nmi` resolves to this dynamic route.
 import type { NextApiRequest, NextApiResponse } from 'next';
 import '../../../../shared/init';
 import { handleCheckout } from 'shared/checkout/handleCheckout';


### PR DESCRIPTION
## Summary
- add note in `[provider].ts` about `/api/checkout/nmi`
- document NMI route in README

## Testing
- `npm test` *(fails: blocked fetches prevent running tests)*

------
https://chatgpt.com/codex/tasks/task_e_687caee75be08325b18cd3dfb484af24