### PR TITLE
Refactor Supabase client creation

### DIFF
--- a/shared/checkout/getStoreIntegration.ts
+++ b/shared/checkout/getStoreIntegration.ts
@@ -1,7 +1,8 @@
-import supabase from '../supabase/serverClient';
+import { createServerSupabaseClient } from '../supabase/serverClient';
 
 export async function getStoreIntegration(storeId: string, integrationId: string) {
   if (!storeId || !integrationId) return null;
+  const supabase = createServerSupabaseClient();
   const { data, error } = await supabase
     .from('store_integrations')
     .select('api_key, settings')

--- a/shared/checkout/handleCheckout.ts
+++ b/shared/checkout/handleCheckout.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import supabase from '../supabase/serverClient';
+import { createServerSupabaseClient } from '../supabase/serverClient';
 import { findOrCreateCustomer } from '@/lib/findOrCreateCustomer';
 import crypto from 'crypto';
 import stripeProvider from './providers/stripe';
@@ -73,6 +73,7 @@ export async function handleCheckout({ req, res }: { req: NextApiRequest; res: N
   console.log('[handleCheckout] Invoked');
   console.log('[handleCheckout] body:', JSON.stringify(req.body, null, 2));
   try {
+  const supabase = createServerSupabaseClient();
 
   const origin = req.headers.origin as string | undefined;
   if (!origin) {

--- a/shared/init.ts
+++ b/shared/init.ts
@@ -1,4 +1,4 @@
-import supabase from './supabase/serverClient';
+import { createServerSupabaseClient } from './supabase/serverClient';
 
 const debug = process.env.SMOOTHR_DEBUG === 'true';
 const log = (...args: any[]) => debug && console.log('[generateOrderNumber]', ...args);
@@ -7,6 +7,8 @@ const err = (...args: any[]) => debug && console.error('[generateOrderNumber]', 
 if (!globalThis.generateOrderNumber) {
   globalThis.generateOrderNumber = async (storeId: string) => {
     log('CALLED — storeId:', storeId);
+
+    const supabase = createServerSupabaseClient();
 
     if (!storeId) {
       err('storeId is undefined or missing!');

--- a/shared/supabase/serverClient.ts
+++ b/shared/supabase/serverClient.ts
@@ -9,13 +9,17 @@ if (!supabaseUrl || !supabaseKey) {
   );
 }
 
-const supabase = createClient(supabaseUrl, supabaseKey, {
-  global: {
-    headers: {
-      apikey: supabaseKey,
-      Authorization: `Bearer ${supabaseKey}`,
+export function createServerSupabaseClient() {
+  return createClient(supabaseUrl, supabaseKey, {
+    global: {
+      headers: {
+        apikey: supabaseKey,
+        Authorization: `Bearer ${supabaseKey}`,
+      },
     },
-  },
-});
+  });
+}
+
+const supabase = createServerSupabaseClient();
 
 export default supabase;

--- a/smoothr/pages/api/create-order.ts
+++ b/smoothr/pages/api/create-order.ts
@@ -1,12 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import 'shared/init';
-import supabase from 'shared/supabase/serverClient';
+import { createServerSupabaseClient } from 'shared/supabase/serverClient';
 import { createOrder } from 'shared/checkout/createOrder';
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
 ) {
+  const supabase = createServerSupabaseClient();
   if (req.method === 'OPTIONS') {
     return res
       .status(200)

--- a/storefronts/tests/providers/handleCheckout-store-id.test.ts
+++ b/storefronts/tests/providers/handleCheckout-store-id.test.ts
@@ -4,20 +4,19 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 let handleCheckout: any;
 
 vi.mock('../../../shared/supabase/serverClient.ts', () => {
-  return {
-    default: {
-      from: (table: string) => {
-        if (table === 'stores') {
-          return {
-            select: vi.fn(() => ({
-              or: vi.fn(async () => ({ data: [{ id: 'store-1' }], error: null }))
-            }))
-          };
-        }
-        return {};
+  const client = {
+    from: (table: string) => {
+      if (table === 'stores') {
+        return {
+          select: vi.fn(() => ({
+            or: vi.fn(async () => ({ data: [{ id: 'store-1' }], error: null }))
+          }))
+        };
       }
-    }
+      return {};
+    },
   };
+  return { default: client, createServerSupabaseClient: () => client };
 });
 
 async function loadModule() {

--- a/storefronts/tests/providers/provider-handleCheckout-authorizeNet.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-authorizeNet.test.ts
@@ -15,9 +15,8 @@ vi.mock('../../../smoothr/lib/findOrCreateCustomer.ts', () => {
 vi.mock('../../../shared/supabase/serverClient.ts', () => {
   let storeFromCall = 0;
   let ordersCall = 0;
-  return {
-    default: {
-      from: (table: string) => {
+  const client = {
+    from: (table: string) => {
         if (table === 'stores') {
           storeFromCall++;
           if (storeFromCall === 1) {
@@ -71,6 +70,10 @@ vi.mock('../../../shared/supabase/serverClient.ts', () => {
         return {};
       }
     }
+  };
+  return {
+    default: client,
+    createServerSupabaseClient: () => client,
   };
 });
 

--- a/storefronts/tests/providers/provider-handleCheckout-nmi-missing-token.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-nmi-missing-token.test.ts
@@ -14,9 +14,8 @@ vi.mock('../../../smoothr/lib/findOrCreateCustomer.ts', () => {
 });
 
 vi.mock('../../../shared/supabase/serverClient.ts', () => {
-  return {
-    default: {
-      from: (table: string) => {
+  const client = {
+    from: (table: string) => {
         if (table === 'stores') {
           return {
             select: vi.fn(() => ({
@@ -37,6 +36,7 @@ vi.mock('../../../shared/supabase/serverClient.ts', () => {
       }
     }
   };
+  return { default: client, createServerSupabaseClient: () => client };
 });
 
 async function loadModule() {

--- a/storefronts/tests/providers/provider-handleCheckout-nmi.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-nmi.test.ts
@@ -21,9 +21,8 @@ vi.mock('../../../smoothr/lib/findOrCreateCustomer.ts', () => {
 });
 
 vi.mock('../../../shared/supabase/serverClient.ts', () => {
-  return {
-    default: {
-      from: (table: string) => {
+  const client = {
+    from: (table: string) => {
         if (table === 'stores') {
           storeFromCall++;
           if (storeFromCall === 1) {
@@ -92,6 +91,7 @@ vi.mock('../../../shared/supabase/serverClient.ts', () => {
       }
     }
   };
+  return { default: client, createServerSupabaseClient: () => client };
 });
 
 async function loadModule() {

--- a/supabase/functions/createOrder.test.ts
+++ b/supabase/functions/createOrder.test.ts
@@ -27,6 +27,7 @@ describe('createOrder', () => {
 
     vi.mock('../../shared/supabase/serverClient.ts', () => ({
       default: { from: fromMock },
+      createServerSupabaseClient: () => ({ from: fromMock }),
     }));
 
     await loadModule();


### PR DESCRIPTION
## Summary
- export `createServerSupabaseClient()` helper
- use new helper in checkout utilities and API route
- update tests to provide the helper when mocking

## Testing
- `npm test` *(fails: connect ENETUNREACH)*
- `npm run test:supabase`

------
https://chatgpt.com/codex/tasks/task_e_687cb35c96b4832580216b0aab1dfe96