### PR TITLE
Restrict store integration SELECT policy

### DIFF
--- a/supabase/migrations/20250720095159_remote_schema.sql
+++ b/supabase/migrations/20250720095159_remote_schema.sql
@@ -625,12 +625,14 @@ using ((customer_id = auth.uid()))
 with check ((customer_id = auth.uid()));
 
 
-create policy "Allow anon SELECT for public payment gateways"
+create policy "store_integrations_service_role_admin_select"
 on "public"."store_integrations"
 as permissive
 for select
-to anon
-using (((gateway = ANY (ARRAY['nmi'::text, 'stripe'::text])) AND (api_key IS NOT NULL)));
+to public
+using (((auth.role() = 'service_role') OR (EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.store_id = store_integrations.store_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text))))));
 
 
 create policy "stores_admin_access"


### PR DESCRIPTION
## Summary
- replace `Allow anon SELECT for public payment gateways` policy
- new policy `store_integrations_service_role_admin_select` only allows access for the `service_role` or store admins via `user_stores`

## Testing
- `npm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_687cc27732f48325801087324f434073