### PR TITLE
Restrict order RLS

### DIFF
--- a/supabase/rls-policies.sql
+++ b/supabase/rls-policies.sql
@@ -1,0 +1,14 @@
+-- Row level security policies documentation for Smoothr
+
+-- orders_customer_select_insert
+--   Customers may read their own orders or create new ones.
+--   The row's customer_id must match auth.uid().
+
+-- orders_customer_unpaid_modify
+--   Allows customers to update or delete an order only while
+--   it has not been paid (paid_at IS NULL). Prevents tampering
+--   after payment occurs.
+
+-- orders_admin_service_modify
+--   Admins and the service role can update or delete any order,
+--   even after payment, to support refunds and manual corrections.


### PR DESCRIPTION
## Summary
- tighten RLS for orders
- add doc outlining policies

## Testing
- `npm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_687cc51eacb883259e8bf32b114ee380