### PR TITLE
Add RLS policy audit and tests

### DIFF
--- a/supabase/rls-policies-audit.sql
+++ b/supabase/rls-policies-audit.sql
@@ -1,0 +1,76 @@
+-- RLS policy audit for Smoothr
+
+-- Table: abandoned_carts
+--   abandoned_carts_admin_select: select (public) 
+--   abandoned_carts_admin_write: all (public) 
+
+-- Table: affiliate_usages
+--   affiliate_usages_admin_select: select (public) 
+--   affiliate_usages_admin_write: all (public) 
+
+-- Table: affiliates
+--   affiliates_admin_select: select (public) 
+--   affiliates_admin_write: all (public) 
+
+-- Table: audit_logs
+--   audit_logs_admin_select: select (public) 
+--   audit_logs_admin_write: all (public) 
+
+-- Table: customer_payment_profiles
+--   customer_payment_profiles_admin: all (public) 
+
+-- Table: customers
+--   customers_self_all: all (public) 
+--   customers_store_admin_select: select (public) 
+
+-- Table: discount_usages
+--   discount_usages_admin_select: select (public) 
+--   discount_usages_admin_write: all (public) 
+
+-- Table: discounts
+--   discounts_admin_select: select (public) 
+--   discounts_admin_write: all (public) 
+
+-- Table: notifications
+--   notifications_admin_select: select (public) 
+--   notifications_admin_write: all (public) 
+
+-- Table: order_items
+--   order_items_customer_select: select (public) 
+
+-- Table: orders
+--   orders_customer_select_insert: select, insert (public) 
+--   orders_customer_unpaid_modify: update, delete (public) 
+--   orders_admin_service_modify: update, delete (public)  -- SUSPICIOUS: uses service_role
+
+-- Table: referrals
+--   referrals_admin_select: select (public) 
+--   referrals_admin_write: all (public) 
+
+-- Table: returns
+--   returns_admin_select: select (public) 
+--   returns_admin_write: all (public) 
+
+-- Table: reviews
+--   reviews_admin_select: select (public) 
+--   reviews_admin_write: all (public) 
+
+-- Table: store_integrations
+--   store_integrations_service_role_admin_select: select (public)  -- SUSPICIOUS: uses service_role
+
+-- Table: store_settings
+--   store_settings_admin_all: all (public) 
+
+-- Table: stores
+--   stores_admin_access: all (public) 
+
+-- Table: subscriptions
+--   subscriptions_admin_select: select (public) 
+--   subscriptions_admin_write: all (public) 
+
+-- Table: user_stores
+--   user_stores_self_all: all (public) 
+
+-- Table: webflow_connections
+--   webflow_connections_admin_select: select (public) 
+--   webflow_connections_admin_write: all (public) 

--- a/supabase/rls-policies.sql
+++ b/supabase/rls-policies.sql
@@ -1,14 +1,442 @@
--- Row level security policies documentation for Smoothr
+drop policy if exists "customer_payment_profiles_admin" on "public"."customer_payment_profiles";
+create policy "customer_payment_profiles_admin"
+on "public"."customer_payment_profiles"
+as permissive
+for all
+to public
+using ((EXISTS ( SELECT 1
+   FROM (customers c
+     JOIN user_stores us ON ((us.customer_id = auth.uid())))
+  WHERE ((c.id = customer_payment_profiles.customer_id) AND (c.store_id = us.store_id) AND (us.role = 'admin'::text)))))
+with check ((EXISTS ( SELECT 1
+   FROM (customers c
+     JOIN user_stores us ON ((us.customer_id = auth.uid())))
+  WHERE ((c.id = customer_payment_profiles.customer_id) AND (c.store_id = us.store_id) AND (us.role = 'admin'::text)))));
 
--- orders_customer_select_insert
---   Customers may read their own orders or create new ones.
---   The row's customer_id must match auth.uid().
 
--- orders_customer_unpaid_modify
---   Allows customers to update or delete an order only while
---   it has not been paid (paid_at IS NULL). Prevents tampering
---   after payment occurs.
+drop policy if exists "customers_self_all" on "public"."customers";
+create policy "customers_self_all"
+on "public"."customers"
+as permissive
+for all
+to public
+using ((id = auth.uid()))
+with check ((id = auth.uid()));
 
--- orders_admin_service_modify
---   Admins and the service role can update or delete any order,
---   even after payment, to support refunds and manual corrections.
+
+drop policy if exists "customers_store_admin_select" on "public"."customers";
+create policy "customers_store_admin_select"
+on "public"."customers"
+as permissive
+for select
+to public
+using ((EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.store_id = customers.store_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text)))));
+
+
+drop policy if exists "order_items_customer_select" on "public"."order_items";
+create policy "order_items_customer_select"
+on "public"."order_items"
+as permissive
+for select
+to public
+using ((EXISTS ( SELECT 1
+   FROM orders o
+  WHERE ((o.id = order_items.order_id) AND (o.customer_id = auth.uid())))));
+
+
+drop policy if exists "orders_customer_select_insert" on "public"."orders";
+create policy "orders_customer_select_insert"
+on "public"."orders"
+as permissive
+for select, insert
+to public
+using ((customer_id = auth.uid()))
+with check ((customer_id = auth.uid()));
+
+
+drop policy if exists "orders_customer_unpaid_modify" on "public"."orders";
+create policy "orders_customer_unpaid_modify"
+on "public"."orders"
+as permissive
+for update, delete
+to public
+using (((customer_id = auth.uid()) AND (paid_at IS NULL)))
+with check (((customer_id = auth.uid()) AND (paid_at IS NULL)));
+
+
+drop policy if exists "orders_admin_service_modify" on "public"."orders";
+create policy "orders_admin_service_modify"
+on "public"."orders"
+as permissive
+for update, delete
+to public
+using (((auth.role() = 'service_role') OR (EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.store_id = orders.store_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text))))))
+with check (((auth.role() = 'service_role') OR (EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.store_id = orders.store_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text))))));
+
+
+drop policy if exists "store_integrations_service_role_admin_select" on "public"."store_integrations";
+create policy "store_integrations_service_role_admin_select"
+on "public"."store_integrations"
+as permissive
+for select
+to public
+using (((auth.role() = 'service_role') OR (EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.store_id = store_integrations.store_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text))))));
+
+
+drop policy if exists "stores_admin_access" on "public"."stores";
+create policy "stores_admin_access"
+on "public"."stores"
+as permissive
+for all
+to public
+using ((owner_customer_id = auth.uid()))
+with check ((owner_customer_id = auth.uid()));
+
+
+drop policy if exists "user_stores_self_all" on "public"."user_stores";
+create policy "user_stores_self_all"
+on "public"."user_stores"
+as permissive
+for all
+to public
+using ((customer_id = auth.uid()))
+with check ((customer_id = auth.uid()));
+
+
+drop policy if exists "store_settings_admin_all" on "public"."store_settings";
+create policy "store_settings_admin_all"
+on "public"."store_settings"
+as permissive
+for all
+to public
+using ((EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.store_id = store_settings.store_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text)))))
+with check ((EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.store_id = store_settings.store_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text))));
+
+
+drop policy if exists "abandoned_carts_admin_select" on "public"."abandoned_carts";
+create policy "abandoned_carts_admin_select"
+on "public"."abandoned_carts"
+as permissive
+for select
+to public
+using ((EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.store_id = abandoned_carts.store_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text)))));
+
+
+drop policy if exists "abandoned_carts_admin_write" on "public"."abandoned_carts";
+create policy "abandoned_carts_admin_write"
+on "public"."abandoned_carts"
+as permissive
+for all
+to public
+using ((EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.store_id = abandoned_carts.store_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text)))))
+with check ((EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.store_id = abandoned_carts.store_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text))));
+
+
+drop policy if exists "affiliate_usages_admin_select" on "public"."affiliate_usages";
+create policy "affiliate_usages_admin_select"
+on "public"."affiliate_usages"
+as permissive
+for select
+to public
+using ((EXISTS ( SELECT 1
+   FROM affiliates a
+     JOIN user_stores us ON ((us.store_id = a.store_id))
+  WHERE ((a.id = affiliate_usages.affiliate_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text)))));
+
+
+drop policy if exists "affiliate_usages_admin_write" on "public"."affiliate_usages";
+create policy "affiliate_usages_admin_write"
+on "public"."affiliate_usages"
+as permissive
+for all
+to public
+using ((EXISTS ( SELECT 1
+   FROM affiliates a
+     JOIN user_stores us ON ((us.store_id = a.store_id))
+  WHERE ((a.id = affiliate_usages.affiliate_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text)))))
+with check ((EXISTS ( SELECT 1
+   FROM affiliates a
+     JOIN user_stores us ON ((us.store_id = a.store_id))
+  WHERE ((a.id = affiliate_usages.affiliate_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text))));
+
+
+drop policy if exists "affiliates_admin_select" on "public"."affiliates";
+create policy "affiliates_admin_select"
+on "public"."affiliates"
+as permissive
+for select
+to public
+using ((EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.store_id = affiliates.store_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text)))));
+
+
+drop policy if exists "affiliates_admin_write" on "public"."affiliates";
+create policy "affiliates_admin_write"
+on "public"."affiliates"
+as permissive
+for all
+to public
+using ((EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.store_id = affiliates.store_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text)))))
+with check ((EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.store_id = affiliates.store_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text))));
+
+
+drop policy if exists "audit_logs_admin_select" on "public"."audit_logs";
+create policy "audit_logs_admin_select"
+on "public"."audit_logs"
+as permissive
+for select
+to public
+using ((EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.customer_id = auth.uid()) AND (us.role = 'admin'::text)))));
+
+
+drop policy if exists "audit_logs_admin_write" on "public"."audit_logs";
+create policy "audit_logs_admin_write"
+on "public"."audit_logs"
+as permissive
+for all
+to public
+using ((EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.customer_id = auth.uid()) AND (us.role = 'admin'::text)))))
+with check ((EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.customer_id = auth.uid()) AND (us.role = 'admin'::text))));
+
+
+drop policy if exists "discount_usages_admin_select" on "public"."discount_usages";
+create policy "discount_usages_admin_select"
+on "public"."discount_usages"
+as permissive
+for select
+to public
+using ((EXISTS ( SELECT 1
+   FROM discounts d
+     JOIN user_stores us ON ((us.store_id = d.store_id))
+  WHERE ((d.id = discount_usages.discount_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text)))));
+
+
+drop policy if exists "discount_usages_admin_write" on "public"."discount_usages";
+create policy "discount_usages_admin_write"
+on "public"."discount_usages"
+as permissive
+for all
+to public
+using ((EXISTS ( SELECT 1
+   FROM discounts d
+     JOIN user_stores us ON ((us.store_id = d.store_id))
+  WHERE ((d.id = discount_usages.discount_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text)))))
+with check ((EXISTS ( SELECT 1
+   FROM discounts d
+     JOIN user_stores us ON ((us.store_id = d.store_id))
+  WHERE ((d.id = discount_usages.discount_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text))));
+
+
+drop policy if exists "discounts_admin_select" on "public"."discounts";
+create policy "discounts_admin_select"
+on "public"."discounts"
+as permissive
+for select
+to public
+using ((EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.store_id = discounts.store_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text)))));
+
+
+drop policy if exists "discounts_admin_write" on "public"."discounts";
+create policy "discounts_admin_write"
+on "public"."discounts"
+as permissive
+for all
+to public
+using ((EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.store_id = discounts.store_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text)))))
+with check ((EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.store_id = discounts.store_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text))));
+
+
+drop policy if exists "notifications_admin_select" on "public"."notifications";
+create policy "notifications_admin_select"
+on "public"."notifications"
+as permissive
+for select
+to public
+using ((EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.store_id = notifications.store_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text)))));
+
+
+drop policy if exists "notifications_admin_write" on "public"."notifications";
+create policy "notifications_admin_write"
+on "public"."notifications"
+as permissive
+for all
+to public
+using ((EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.store_id = notifications.store_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text)))))
+with check ((EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.store_id = notifications.store_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text))));
+
+
+drop policy if exists "referrals_admin_select" on "public"."referrals";
+create policy "referrals_admin_select"
+on "public"."referrals"
+as permissive
+for select
+to public
+using (((referrer_id = auth.uid()) OR (EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.customer_id = auth.uid()) AND (us.role = 'admin'::text))))));
+
+
+drop policy if exists "referrals_admin_write" on "public"."referrals";
+create policy "referrals_admin_write"
+on "public"."referrals"
+as permissive
+for all
+to public
+using (((referrer_id = auth.uid()) OR (EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.customer_id = auth.uid()) AND (us.role = 'admin'::text))))) )
+with check (((referrer_id = auth.uid()) OR (EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.customer_id = auth.uid()) AND (us.role = 'admin'::text))))));
+
+
+drop policy if exists "returns_admin_select" on "public"."returns";
+create policy "returns_admin_select"
+on "public"."returns"
+as permissive
+for select
+to public
+using ((EXISTS ( SELECT 1
+   FROM orders o
+     JOIN user_stores us ON ((us.store_id = o.store_id))
+  WHERE ((o.id = returns.order_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text)))));
+
+
+drop policy if exists "returns_admin_write" on "public"."returns";
+create policy "returns_admin_write"
+on "public"."returns"
+as permissive
+for all
+to public
+using ((EXISTS ( SELECT 1
+   FROM orders o
+     JOIN user_stores us ON ((us.store_id = o.store_id))
+  WHERE ((o.id = returns.order_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text)))))
+with check ((EXISTS ( SELECT 1
+   FROM orders o
+     JOIN user_stores us ON ((us.store_id = o.store_id))
+  WHERE ((o.id = returns.order_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text))));
+
+
+drop policy if exists "reviews_admin_select" on "public"."reviews";
+create policy "reviews_admin_select"
+on "public"."reviews"
+as permissive
+for select
+to public
+using ((EXISTS ( SELECT 1
+   FROM orders o
+     JOIN user_stores us ON ((us.store_id = o.store_id))
+  WHERE ((o.id = reviews.order_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text)))));
+
+
+drop policy if exists "reviews_admin_write" on "public"."reviews";
+create policy "reviews_admin_write"
+on "public"."reviews"
+as permissive
+for all
+to public
+using ((EXISTS ( SELECT 1
+   FROM orders o
+     JOIN user_stores us ON ((us.store_id = o.store_id))
+  WHERE ((o.id = reviews.order_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text)))))
+with check ((EXISTS ( SELECT 1
+   FROM orders o
+     JOIN user_stores us ON ((us.store_id = o.store_id))
+  WHERE ((o.id = reviews.order_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text))));
+
+
+drop policy if exists "subscriptions_admin_select" on "public"."subscriptions";
+create policy "subscriptions_admin_select"
+on "public"."subscriptions"
+as permissive
+for select
+to public
+using ((EXISTS ( SELECT 1
+   FROM customers c
+     JOIN user_stores us ON ((us.store_id = c.store_id))
+  WHERE ((c.id = subscriptions.customer_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text)))));
+
+
+drop policy if exists "subscriptions_admin_write" on "public"."subscriptions";
+create policy "subscriptions_admin_write"
+on "public"."subscriptions"
+as permissive
+for all
+to public
+using ((EXISTS ( SELECT 1
+   FROM customers c
+     JOIN user_stores us ON ((us.store_id = c.store_id))
+  WHERE ((c.id = subscriptions.customer_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text)))))
+with check ((EXISTS ( SELECT 1
+   FROM customers c
+     JOIN user_stores us ON ((us.store_id = c.store_id))
+  WHERE ((c.id = subscriptions.customer_id) AND (us.customer_id = auth.uid()) AND (us.role = 'admin'::text))));
+
+
+drop policy if exists "webflow_connections_admin_select" on "public"."webflow_connections";
+create policy "webflow_connections_admin_select"
+on "public"."webflow_connections"
+as permissive
+for select
+to public
+using (((customer_id = auth.uid()) OR (EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.customer_id = auth.uid()) AND (us.role = 'admin'::text))))));
+
+
+drop policy if exists "webflow_connections_admin_write" on "public"."webflow_connections";
+create policy "webflow_connections_admin_write"
+on "public"."webflow_connections"
+as permissive
+for all
+to public
+using (((customer_id = auth.uid()) OR (EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.customer_id = auth.uid()) AND (us.role = 'admin'::text))))) )
+with check (((customer_id = auth.uid()) OR (EXISTS ( SELECT 1
+   FROM user_stores us
+  WHERE ((us.customer_id = auth.uid()) AND (us.role = 'admin'::text))))));
+
+

--- a/supabase/tests/rls.test.ts
+++ b/supabase/tests/rls.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+
+interface User { id: string; role?: string }
+interface UserStore { store_id: string; customer_id: string; role: string }
+interface Order { id: string; store_id: string; customer_id: string; paid_at: string | null }
+interface StoreIntegration { store_id: string }
+
+function isAdmin(user: User, storeId: string, userStores: UserStore[]): boolean {
+  return userStores.some(u => u.store_id === storeId && u.customer_id === user.id && u.role === 'admin')
+}
+
+function orders_customer_select_insert(order: Order, user: User) {
+  return order.customer_id === user.id
+}
+
+function orders_customer_unpaid_modify(order: Order, user: User) {
+  return order.customer_id === user.id && order.paid_at === null
+}
+
+function orders_admin_service_modify(order: Order, user: User, userStores: UserStore[]) {
+  return user.role === 'service_role' || isAdmin(user, order.store_id, userStores)
+}
+
+function store_integrations_service_role_admin_select(rec: StoreIntegration, user: User, userStores: UserStore[]) {
+  return user.role === 'service_role' || isAdmin(user, rec.store_id, userStores)
+}
+
+describe('RLS policy simulation', () => {
+  const customer: User = { id: 'c1' }
+  const admin: User = { id: 'a1' }
+  const service: User = { id: 'svc', role: 'service_role' }
+  const userStores: UserStore[] = [{ store_id: 's1', customer_id: 'a1', role: 'admin' }]
+
+  const unpaidOrder: Order = { id: 'o1', store_id: 's1', customer_id: 'c1', paid_at: null }
+  const paidOrder: Order = { id: 'o2', store_id: 's1', customer_id: 'c1', paid_at: '2024-01-01' }
+
+  it('customer can read own order', () => {
+    expect(orders_customer_select_insert(unpaidOrder, customer)).toBe(true)
+  })
+
+  it('customer cannot read others order', () => {
+    expect(orders_customer_select_insert({ ...unpaidOrder, customer_id: 'c2' }, customer)).toBe(false)
+  })
+
+  it('customer can update unpaid order', () => {
+    expect(orders_customer_unpaid_modify(unpaidOrder, customer)).toBe(true)
+  })
+
+  it('customer cannot update paid order', () => {
+    expect(orders_customer_unpaid_modify(paidOrder, customer)).toBe(false)
+  })
+
+  it('admin can update any order', () => {
+    expect(orders_admin_service_modify(paidOrder, admin, userStores)).toBe(true)
+  })
+
+  it('service role can update any order', () => {
+    expect(orders_admin_service_modify(paidOrder, service, [])).toBe(true)
+  })
+
+  it('non-admin cannot read store integrations', () => {
+    expect(store_integrations_service_role_admin_select({ store_id: 's1' }, customer, userStores)).toBe(false)
+  })
+
+  it('admin can read store integrations', () => {
+    expect(store_integrations_service_role_admin_select({ store_id: 's1' }, admin, userStores)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- script all RLS policies so they can be reapplied on reset
- generate audit summary of every policy grouped by table
- add simple tests simulating access rules

## Testing
- `npx vitest run supabase/tests --run --silent`

------
https://chatgpt.com/codex/tasks/task_e_687cc65896548325b754946cc9f71b6a