### PR TITLE
Switch SDK to public_store_settings table

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Store integrations use a `gateway` column to specify the active payment provider
 
 The SDK determines the active payment gateway by first checking
 `window.SMOOTHR_CONFIG.active_payment_gateway`. If absent, it loads the value
-from the store's `store_settings` table in Supabase using the configured
+from the store's `public_store_settings` table in Supabase using the configured
 `storeId`. The `[provider]` segment in the route should match this value and
 defaults to `stripe` when no configuration is found.
 

--- a/storefronts/README.md
+++ b/storefronts/README.md
@@ -125,7 +125,7 @@ triggers.
 The script posts the cart to `/api/checkout/[provider]` where `[provider]` is the
 active payment gateway. This single endpoint handles all providers. `initCheckout` chooses the gateway by first checking
 `window.SMOOTHR_CONFIG.active_payment_gateway`. If not set it queries
-`store_settings.settings.active_payment_gateway` in Supabase using the provided
+`public_store_settings.active_payment_gateway` in Supabase using the provided
 `storeId`. The default provider is `stripe`.
 
 Gateway detection relies on `core/utils/resolveGateway()`. It will **throw an

--- a/storefronts/checkout/gateways/stripe.js
+++ b/storefronts/checkout/gateways/stripe.js
@@ -250,15 +250,15 @@ export async function getStoreSettings(storeId) {
   if (!storeId) return null;
   try {
     const { data, error } = await supabase
-      .from('store_settings')
-      .select('settings')
+      .from('public_store_settings')
+      .select('*')
       .eq('store_id', storeId)
       .maybeSingle();
     if (error) {
       warn('Store settings lookup failed:', error.message || error);
       return null;
     }
-    return data?.settings || null;
+    return data || null;
   } catch (e) {
     warn('Store settings fetch error:', e?.message || e);
     return null;

--- a/storefronts/core/index.js
+++ b/storefronts/core/index.js
@@ -23,12 +23,12 @@ import { setSelectedCurrency as setCmsCurrency } from './currency/cms-currency.j
 // Load the store_settings JSON into window.SMOOTHR_CONFIG
 async function loadConfig(storeId) {
   const { data, error } = await supabase
-    .from('store_settings')
-    .select('settings')
+    .from('public_store_settings')
+    .select('*')
     .eq('store_id', storeId)
     .single();
   if (error) throw error;
-  window.SMOOTHR_CONFIG = data.settings;
+  window.SMOOTHR_CONFIG = data || {};
   window.SMOOTHR_CONFIG.storeId = storeId;
 }
 


### PR DESCRIPTION
## Summary
- read config from `public_store_settings` in `core/index.js`
- update checkout `getStoreSettings` helper
- document use of `public_store_settings` in README files

## Testing
- `npm test` *(fails: 15 failed, 75 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687cbdb1d5a0832594bc7a62d45e5ed9