### PR TITLE
Query new store settings table for checkout

### DIFF
--- a/shared/checkout/handleCheckout.ts
+++ b/shared/checkout/handleCheckout.ts
@@ -325,8 +325,8 @@ export async function handleCheckout({ req, res }: { req: NextApiRequest; res: N
   }
 
   const { data: storeSettings, error: settingsError } = await supabase
-    .from('store_settings')
-    .select('settings')
+    .from('public_store_settings')
+    .select('active_payment_gateway')
     .eq('store_id', store_id)
     .maybeSingle();
 
@@ -338,7 +338,7 @@ export async function handleCheckout({ req, res }: { req: NextApiRequest; res: N
     return;
   }
 
-  const provider = storeSettings?.settings?.active_payment_gateway as string;
+  const provider = (storeSettings?.active_payment_gateway || '') as string;
   log('Selected provider:', provider);
 
   const providers: Record<string, any> = {


### PR DESCRIPTION
## Summary
- fetch checkout settings from `public_store_settings`
- read the plain `active_payment_gateway` column

## Testing
- `npm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_687ceae46c588325b4cde640328856f1