### PR TITLE
Update tests for public_store_settings table

### DIFF
--- a/storefronts/tests/providers/provider-handleCheckout-authorizeNet.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-authorizeNet.test.ts
@@ -28,11 +28,11 @@ vi.mock('../../../shared/supabase/serverClient.ts', () => {
           }
           return {};
         }
-        if (table === 'store_settings') {
+        if (table === 'public_store_settings') {
           return {
             select: vi.fn(() => ({
               eq: vi.fn(() => ({
-                maybeSingle: vi.fn(async () => ({ data: { settings: { active_payment_gateway: 'authorizeNet' } }, error: null }))
+                maybeSingle: vi.fn(async () => ({ data: { active_payment_gateway: 'authorizeNet' }, error: null }))
               }))
             }))
           };
@@ -69,7 +69,6 @@ vi.mock('../../../shared/supabase/serverClient.ts', () => {
         }
         return {};
       }
-    }
   };
   return {
     default: client,

--- a/storefronts/tests/providers/provider-handleCheckout-nmi-missing-token.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-nmi-missing-token.test.ts
@@ -23,18 +23,17 @@ vi.mock('../../../shared/supabase/serverClient.ts', () => {
             }))
           };
         }
-        if (table === 'store_settings') {
+        if (table === 'public_store_settings') {
           return {
             select: vi.fn(() => ({
               eq: vi.fn(() => ({
-                maybeSingle: vi.fn(async () => ({ data: { settings: { active_payment_gateway: 'nmi' } }, error: null }))
+                maybeSingle: vi.fn(async () => ({ data: { active_payment_gateway: 'nmi' }, error: null }))
               }))
             }))
           };
         }
         return {};
       }
-    }
   };
   return { default: client, createServerSupabaseClient: () => client };
 });

--- a/storefronts/tests/providers/provider-handleCheckout-nmi.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-nmi.test.ts
@@ -45,11 +45,11 @@ vi.mock('../../../shared/supabase/serverClient.ts', () => {
             };
           }
         }
-        if (table === 'store_settings') {
+        if (table === 'public_store_settings') {
           return {
             select: vi.fn(() => ({
               eq: vi.fn(() => ({
-                maybeSingle: vi.fn(async () => ({ data: { settings: { active_payment_gateway: 'nmi' } }, error: null }))
+                maybeSingle: vi.fn(async () => ({ data: { active_payment_gateway: 'nmi' }, error: null }))
               }))
             }))
           };
@@ -89,7 +89,6 @@ vi.mock('../../../shared/supabase/serverClient.ts', () => {
         }
         return {};
       }
-    }
   };
   return { default: client, createServerSupabaseClient: () => client };
 });

--- a/storefronts/tests/providers/provider-handleCheckout-settings-error.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-settings-error.test.ts
@@ -23,7 +23,7 @@ vi.mock('../../../shared/supabase/serverClient.ts', () => {
           }))
         };
       }
-      if (table === 'store_settings') {
+      if (table === 'public_store_settings') {
         return {
           select: vi.fn(() => ({
             eq: vi.fn(() => ({

--- a/supabase/functions/store-tables.test.ts
+++ b/supabase/functions/store-tables.test.ts
@@ -23,7 +23,7 @@ describe('store tables queries', () => {
     }
     createClientMock = vi.fn(() => ({
       from: (table: string) =>
-        table === 'store_settings' ? settingsBuilder : integrationsBuilder,
+        table === 'public_store_settings' ? settingsBuilder : integrationsBuilder,
     }))
     vi.mock('@supabase/supabase-js', () => ({ createClient: createClientMock }))
     await loadClient()
@@ -36,14 +36,14 @@ describe('store tables queries', () => {
 
   it('returns settings and integrations data', async () => {
     const storeId = 'store-123'
-    const settingsRow = { id: 's1', store_id: storeId }
+    const settingsRow = { store_id: storeId }
     const integrationRow = { id: 'i1', store_id: storeId }
 
     settingsBuilder.maybeSingle.mockResolvedValue({ data: settingsRow, error: null })
     integrationsBuilder.maybeSingle.mockResolvedValue({ data: integrationRow, error: null })
 
     const { data: settings, error: settingsError } = await supabase
-      .from('store_settings')
+      .from('public_store_settings')
       .select('*')
       .eq('store_id', storeId)
       .maybeSingle()


### PR DESCRIPTION
## Summary
- update mock table names in provider tests
- update mock table name and row shape in `store-tables.test.ts`

## Testing
- `npm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_687cec06aebc8325823f30bb3e4ceb6a