### PR TITLE
Expose public NMI credential view

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,13 +167,22 @@ override this global to customize how order numbers are produced.
 
 To enable NMI create a row in the `store_integrations` table with `gateway`
 set to `nmi` and store both the API key and tokenization key under the
-`settings` column:
+`settings` column. The tokenization key is surfaced to anonymous storefronts
+via the `public_store_integration_credentials` view:
 
 ```json
 {
   "api_key": "<API_KEY>",
   "tokenization_key": "<TOKENIZATION_KEY>"
 }
+```
+
+```sql
+create or replace view public.public_store_integration_credentials as
+select store_id, gateway, settings ->> 'tokenization_key' as tokenization_key
+from public.store_integrations
+where sandbox = false;
+grant select on public.public_store_integration_credentials to anon;
 ```
 
 Activate the gateway by setting

--- a/storefronts/README.md
+++ b/storefronts/README.md
@@ -181,6 +181,8 @@ and place your credentials in the `settings` JSON column:
   "tokenization_key": "<TOKENIZATION_KEY>"
 }
 ```
+The tokenization key is surfaced through the `public_store_integration_credentials`
+view so storefront scripts can fetch it anonymously.
 
 Enable the gateway via `public_store_settings.active_payment_gateway` or set
 `window.SMOOTHR_CONFIG.active_payment_gateway = 'nmi'` on the client. Include

--- a/storefronts/checkout/getPublicCredential.js
+++ b/storefronts/checkout/getPublicCredential.js
@@ -3,6 +3,22 @@ import supabase from '../../supabase/supabaseClient.js';
 export async function getPublicCredential(storeId, integrationId, gateway) {
   if (!storeId || !integrationId) return null;
   try {
+    // Special case for NMI tokenization key which is exposed via a public view
+    if ((integrationId === 'nmi' || gateway === 'nmi')) {
+      const { data, error } = await supabase
+        .from('public_store_integration_credentials')
+        .select('tokenization_key')
+        .eq('store_id', storeId)
+        .eq('gateway', gateway || integrationId)
+        .maybeSingle();
+
+      if (error) {
+        console.warn('[Smoothr] Credential lookup failed:', error.message || error);
+        return null;
+      }
+      return data ? { api_key: data.tokenization_key } : null;
+    }
+
     let query = supabase
       .from('store_integrations')
       .select('api_key, settings')
@@ -25,3 +41,4 @@ export async function getPublicCredential(storeId, integrationId, gateway) {
     return null;
   }
 }
+

--- a/storefronts/checkout/providers/nmi.js
+++ b/storefronts/checkout/providers/nmi.js
@@ -17,6 +17,8 @@ export async function resolveTokenizationKey() {
     const cred = await getPublicCredential(storeId, 'nmi', gateway);
     if (cred?.api_key) {
       cachedKey = cred.api_key;
+    } else if (cred?.tokenization_key) {
+      cachedKey = cred.tokenization_key;
     } else if (cred?.settings?.tokenization_key) {
       warn('tokenization_key is deprecated – update integration to use api_key');
       cachedKey = cred.settings.tokenization_key;

--- a/storefronts/tests/providers/provider-nmi-mount.test.ts
+++ b/storefronts/tests/providers/provider-nmi-mount.test.ts
@@ -50,7 +50,7 @@ beforeEach(async () => {
     return HTMLElement.prototype.appendChild.call(document.head, el);
   });
 
-  getCredMock = vi.fn(async () => ({ settings: { tokenization_key: 'tok_key' } }));
+  getCredMock = vi.fn(async () => ({ tokenization_key: 'tok_key' }));
 
   vi.mock('../../checkout/getPublicCredential.js', () => ({
     getPublicCredential: getCredMock

--- a/supabase/migrations/20250801120000_add_public_store_integration_credentials.sql
+++ b/supabase/migrations/20250801120000_add_public_store_integration_credentials.sql
@@ -1,0 +1,14 @@
+-- Create view to expose NMI tokenization key publicly
+create or replace view public.public_store_integration_credentials as
+select
+  store_id,
+  gateway,
+  settings ->> 'tokenization_key' as tokenization_key
+from
+  public.store_integrations
+where
+  sandbox = false;
+
+alter view public.public_store_integration_credentials owner to postgres;
+
+grant select on public.public_store_integration_credentials to anon;


### PR DESCRIPTION
## Summary
- add migration creating `public_store_integration_credentials`
- fetch tokenization key from view in `getPublicCredential`
- support new response shape in NMI provider
- adjust NMI mount test
- document new view in README files

## Testing
- `npm --workspace storefronts run build`
- `npm --workspace storefronts test` *(fails: Blocked fetch & network errors)*

------
https://chatgpt.com/codex/tasks/task_e_687dbbae7d0c8325b97d3a1349c5f076