### PR TITLE
Add tokenization key function

### DIFF
--- a/storefronts/README.md
+++ b/storefronts/README.md
@@ -181,8 +181,15 @@ and place your credentials in the `settings` JSON column:
   "tokenization_key": "<TOKENIZATION_KEY>"
 }
 ```
-The tokenization key is surfaced through the `public_store_integration_credentials`
-view so storefront scripts can fetch it anonymously.
+The tokenization key can be fetched anonymously using the
+`public.get_public_tokenization_key` function:
+
+```js
+const { data: key } = await supabase.rpc('get_public_tokenization_key', {
+  store_id: '<store-id>',
+  gateway: 'nmi'
+});
+```
 
 Enable the gateway via `public_store_settings.active_payment_gateway` or set
 `window.SMOOTHR_CONFIG.active_payment_gateway = 'nmi'` on the client. Include

--- a/storefronts/checkout/getPublicCredential.js
+++ b/storefronts/checkout/getPublicCredential.js
@@ -3,20 +3,17 @@ import supabase from '../../supabase/supabaseClient.js';
 export async function getPublicCredential(storeId, integrationId, gateway) {
   if (!storeId || !integrationId) return null;
   try {
-    // Special case for NMI tokenization key which is exposed via a public view
-    if ((integrationId === 'nmi' || gateway === 'nmi')) {
-      const { data, error } = await supabase
-        .from('public_store_integration_credentials')
-        .select('tokenization_key')
-        .eq('store_id', storeId)
-        .eq('gateway', gateway || integrationId)
-        .maybeSingle();
-
+    // Special case for NMI tokenization key exposed via a helper function
+    if (integrationId === 'nmi' || gateway === 'nmi') {
+      const { data, error } = await supabase.rpc('get_public_tokenization_key', {
+        store_id: storeId,
+        gateway: gateway || integrationId
+      });
       if (error) {
         console.warn('[Smoothr] Credential lookup failed:', error.message || error);
         return null;
       }
-      return data ? { api_key: data.tokenization_key } : null;
+      return data ? { tokenization_key: data } : null;
     }
 
     let query = supabase

--- a/supabase/migrations/20250801121000_add_get_public_tokenization_key.sql
+++ b/supabase/migrations/20250801121000_add_get_public_tokenization_key.sql
@@ -1,0 +1,21 @@
+-- Function to expose tokenization keys publicly
+create or replace function public.get_public_tokenization_key(
+  store_id uuid,
+  gateway text
+)
+returns text
+language sql
+security definer
+as $$
+  select settings ->> 'tokenization_key'
+  from public.store_integrations
+  where store_id = get_public_tokenization_key.store_id
+    and sandbox = false
+    and (
+      gateway = get_public_tokenization_key.gateway or
+      settings ->> 'gateway' = get_public_tokenization_key.gateway
+    )
+  limit 1
+$$;
+
+grant execute on function public.get_public_tokenization_key(uuid, text) to anon;


### PR DESCRIPTION
## Summary
- expose tokenization key via new `get_public_tokenization_key` function
- use the function in the checkout credential helper
- document the new function and usage in READMEs

## Testing
- `npm test` *(fails: ENETUNREACH and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_687dc83015188325b78f8a63bd43040e