### PR TITLE
Use credentials view for NMI tokenization key

### DIFF
--- a/storefronts/README.md
+++ b/storefronts/README.md
@@ -181,14 +181,17 @@ and place your credentials in the `settings` JSON column:
   "tokenization_key": "<TOKENIZATION_KEY>"
 }
 ```
-The tokenization key can be fetched anonymously using the
-`public.get_public_tokenization_key` function:
+The tokenization key can be fetched anonymously from the
+`public_store_integration_credentials` view:
 
 ```js
-const { data: key } = await supabase.rpc('get_public_tokenization_key', {
-  store_id: '<store-id>',
-  gateway: 'nmi'
-});
+const { data } = await supabase
+  .from('public_store_integration_credentials')
+  .select('tokenization_key')
+  .eq('store_id', '<store-id>')
+  .eq('gateway', 'nmi')
+  .maybeSingle();
+const key = data?.tokenization_key;
 ```
 
 Enable the gateway via `public_store_settings.active_payment_gateway` or set

--- a/storefronts/checkout/getPublicCredential.js
+++ b/storefronts/checkout/getPublicCredential.js
@@ -3,17 +3,20 @@ import supabase from '../../supabase/supabaseClient.js';
 export async function getPublicCredential(storeId, integrationId, gateway) {
   if (!storeId || !integrationId) return null;
   try {
-    // Special case for NMI tokenization key exposed via a helper function
+    // Special case for NMI tokenization key exposed via the
+    // public_store_integration_credentials view
     if (integrationId === 'nmi' || gateway === 'nmi') {
-      const { data, error } = await supabase.rpc('get_public_tokenization_key', {
-        store_id: storeId,
-        gateway: gateway || integrationId
-      });
+      const { data, error } = await supabase
+        .from('public_store_integration_credentials')
+        .select('tokenization_key')
+        .eq('store_id', storeId)
+        .eq('gateway', gateway || integrationId)
+        .maybeSingle();
       if (error) {
         console.warn('[Smoothr] Credential lookup failed:', error.message || error);
         return null;
       }
-      return data ? { tokenization_key: data } : null;
+      return data ? { tokenization_key: data.tokenization_key } : null;
     }
 
     let query = supabase


### PR DESCRIPTION
## Summary
- use `public_store_integration_credentials` to fetch tokenization keys
- document new tokenization key endpoint in checkout README

## Testing
- `npm run bundle:webflow-checkout`
- `npm --workspace storefronts run build`
- `wrangler pages deploy dist --project-name smoothr` *(fails: missing CLOUDFLARE_API_TOKEN)*
- `npm test` *(fails: network errors and test failures)*

------
https://chatgpt.com/codex/tasks/task_e_687dcf2911108325a06c10a9e3a915cc