### PR TITLE
Update gateway coalesce in credentials view

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,10 @@ override this global to customize how order numbers are produced.
 ### NMI Integration
 
 To enable NMI create a row in the `store_integrations` table with `gateway`
-set to `nmi` and store both the API key and tokenization key under the
-`settings` column. The tokenization key is exposed anonymously through the
-`public_store_integration_credentials` view:
+set to `nmi` (or set `settings.gateway` to `nmi`) and store both the API key
+and tokenization key under the `settings` column. The tokenization key is
+exposed anonymously through the `public_store_integration_credentials` view,
+which coalesces the `gateway` column with `settings.gateway`:
 
 ```json
 {

--- a/storefronts/README.md
+++ b/storefronts/README.md
@@ -173,7 +173,9 @@ setting on the client by defining the following snippet before loading the SDK:
 
 A Network Merchants (NMI) integration is also supported. Create a new record in
 `store_integrations` with either `gateway` or `settings.gateway` set to `nmi`
-and place your credentials in the `settings` JSON column:
+and place your credentials in the `settings` JSON column. The
+`public_store_integration_credentials` view coalesces the `gateway` column with
+`settings.gateway` so either approach works:
 
 ```json
 {

--- a/supabase/migrations/20250801120000_add_public_store_integration_credentials.sql
+++ b/supabase/migrations/20250801120000_add_public_store_integration_credentials.sql
@@ -2,7 +2,7 @@
 create or replace view public.public_store_integration_credentials as
 select
   store_id,
-  gateway,
+  coalesce(gateway, settings ->> 'gateway') as gateway,
   settings ->> 'tokenization_key' as tokenization_key
 from
   public.store_integrations


### PR DESCRIPTION
## Summary
- coalesce gateway in public_store_integration_credentials view
- explain gateway coalescing in README docs

## Testing
- `npm test` *(fails: blocked network requests)*

------
https://chatgpt.com/codex/tasks/task_e_687de1499ecc8325a796d7e04141b396