### PR TITLE
Use credentials view for NMI tokenization key

### DIFF
--- a/storefronts/README.md
+++ b/storefronts/README.md
@@ -63,9 +63,9 @@ smoothr.orders.renderOrders();
 
 Define a global `SMOOTHR_CONFIG` before loading the SDK to set the base
 currency, provide custom exchange rates, or override the live rates endpoint.
-The SDK populates `window.SMOOTHR_CONFIG` from your store's
-`public_store_settings` table when it initializes, so defining the object lets
-you override any of those values at runtime.
+When the SDK initializes it merges settings from your store's
+`public_store_settings` table into the object, so values you define beforehand
+remain in place.
 
 ```html
 <script>
@@ -181,14 +181,17 @@ and place your credentials in the `settings` JSON column:
   "tokenization_key": "<TOKENIZATION_KEY>"
 }
 ```
-The tokenization key can be fetched anonymously using the
-`public.get_public_tokenization_key` function:
+The tokenization key can be fetched anonymously from the
+`public_store_integration_credentials` view:
 
 ```js
-const { data: key } = await supabase.rpc('get_public_tokenization_key', {
-  store_id: '<store-id>',
-  gateway: 'nmi'
-});
+const { data } = await supabase
+  .from('public_store_integration_credentials')
+  .select('tokenization_key')
+  .eq('store_id', '<store-id>')
+  .eq('gateway', 'nmi')
+  .maybeSingle();
+const key = data?.tokenization_key;
 ```
 
 Enable the gateway via `public_store_settings.active_payment_gateway` or set

--- a/storefronts/checkout/getPublicCredential.js
+++ b/storefronts/checkout/getPublicCredential.js
@@ -3,17 +3,20 @@ import supabase from '../../supabase/supabaseClient.js';
 export async function getPublicCredential(storeId, integrationId, gateway) {
   if (!storeId || !integrationId) return null;
   try {
-    // Special case for NMI tokenization key exposed via a helper function
+    // Special case for NMI tokenization key exposed via the
+    // public_store_integration_credentials view
     if (integrationId === 'nmi' || gateway === 'nmi') {
-      const { data, error } = await supabase.rpc('get_public_tokenization_key', {
-        store_id: storeId,
-        gateway: gateway || integrationId
-      });
+      const { data, error } = await supabase
+        .from('public_store_integration_credentials')
+        .select('tokenization_key')
+        .eq('store_id', storeId)
+        .eq('gateway', gateway || integrationId)
+        .maybeSingle();
       if (error) {
         console.warn('[Smoothr] Credential lookup failed:', error.message || error);
         return null;
       }
-      return data ? { tokenization_key: data } : null;
+      return data ? { tokenization_key: data.tokenization_key } : null;
     }
 
     let query = supabase

--- a/storefronts/core/index.js
+++ b/storefronts/core/index.js
@@ -28,7 +28,10 @@ async function loadConfig(storeId) {
     .eq('store_id', storeId)
     .single();
   if (error) throw error;
-  window.SMOOTHR_CONFIG = data || {};
+  window.SMOOTHR_CONFIG = {
+    ...(window.SMOOTHR_CONFIG || {}),
+    ...(data || {})
+  };
   window.SMOOTHR_CONFIG.storeId = storeId;
 }
 

--- a/storefronts/tests/sdk/load-config-merge.test.js
+++ b/storefronts/tests/sdk/load-config-merge.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../../../supabase/supabaseClient.js', () => {
+  const single = vi.fn(async () => ({ data: { foo: 'bar' }, error: null }));
+  const eq = vi.fn(() => ({ single }));
+  const select = vi.fn(() => ({ eq }));
+  const from = vi.fn(() => ({ select }));
+  return { default: { from } };
+});
+
+beforeEach(() => {
+  vi.resetModules();
+  global.fetch = vi.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve({ rates: {} }) })
+  );
+  global.window = {
+    location: { origin: '', href: '', hostname: '' },
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    SMOOTHR_CONFIG: { apiBase: 'https://example.com' }
+  };
+  global.document = {
+    addEventListener: vi.fn(),
+    querySelectorAll: vi.fn(() => []),
+    querySelector: vi.fn(() => null)
+  };
+  global.localStorage = {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+    removeItem: vi.fn()
+  };
+});
+
+describe('loadConfig merge', () => {
+  it('preserves existing config values', async () => {
+    await import('../../core/index.js');
+    expect(global.window.SMOOTHR_CONFIG).toEqual(
+      expect.objectContaining({
+        apiBase: 'https://example.com',
+        foo: 'bar',
+        storeId: '00000000-0000-0000-0000-000000000000'
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- use `public_store_integration_credentials` to fetch tokenization keys
- document new tokenization key endpoint in checkout README
- merge config settings on SDK bootstrap so overrides persist

## Testing
- `npm run bundle:webflow-checkout`
- `npm --workspace storefronts run build`
- `wrangler pages deploy dist --project-name smoothr` *(fails: command not found)*
- `npm test` *(fails: multiple test errors and network issues)*

------
https://chatgpt.com/codex/tasks/task_e_687dcf2911108325a06c10a9e3a915cc