### PR TITLE
Fix api_base mapping in config loader

### DIFF
--- a/storefronts/core/index.js
+++ b/storefronts/core/index.js
@@ -32,6 +32,12 @@ async function loadConfig(storeId) {
     ...(window.SMOOTHR_CONFIG || {}),
     ...(data || {})
   };
+  if (
+    'api_base' in window.SMOOTHR_CONFIG &&
+    !window.SMOOTHR_CONFIG.apiBase
+  ) {
+    window.SMOOTHR_CONFIG.apiBase = window.SMOOTHR_CONFIG.api_base;
+  }
   window.SMOOTHR_CONFIG.storeId = storeId;
 }
 


### PR DESCRIPTION
## Summary
- sync Supabase `api_base` to `apiBase` when loading config

## Testing
- `npm --workspace storefronts test` *(fails: Vitest unhandled errors)*

------
https://chatgpt.com/codex/tasks/task_e_687e09168628832589df85b33a596981