### PR TITLE
Fix import path for serverClient

### DIFF
--- a/shared/checkout/handleCheckout.ts
+++ b/shared/checkout/handleCheckout.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { supabase } from '@/supabase/serverClient';
+import { supabase } from '../supabase/serverClient';
 import { findOrCreateCustomer } from '@/lib/findOrCreateCustomer';
 import crypto from 'crypto';
 import stripeProvider from './providers/stripe';


### PR DESCRIPTION
## Summary
- fix relative import for supabase service role client

## Testing
- `npm test` *(fails: vitest not found / blocked network)*

------
https://chatgpt.com/codex/tasks/task_e_687e394b70a08325acc846d18ae1d24c