### PR TITLE
Fix supabase import in checkout handler

### DIFF
--- a/shared/checkout/handleCheckout.ts
+++ b/shared/checkout/handleCheckout.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { supabase } from '../supabase/serverClient';
+import supabase from '../supabase/serverClient';
 import { findOrCreateCustomer } from '@/lib/findOrCreateCustomer';
 import crypto from 'crypto';
 import stripeProvider from './providers/stripe';


### PR DESCRIPTION
## Summary
- fix incorrect supabase import in `handleCheckout`

## Testing
- `npm test` *(fails: vitest not found, network issues during tests)*

------
https://chatgpt.com/codex/tasks/task_e_687e3aebeb88832598c22c119e357c37