### PR TITLE
Add debug log for serverClient

### DIFF
--- a/shared/supabase/serverClient.ts
+++ b/shared/supabase/serverClient.ts
@@ -1,5 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 
+console.log('[Smoothr] Loaded serverClient.ts from shared/supabase ✅');
+
 const supabaseUrl = process.env.SUPABASE_URL;
 const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 


### PR DESCRIPTION
## Summary
- add visible console log at runtime for serverClient

## Testing
- `npm test` *(fails: vitest could not resolve imports and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_687e418591c0832589afdd9a5f2e1701