### PR TITLE
fix

### DIFF
--- a/smoothr/pages/api/webhooks/stripe.ts
+++ b/smoothr/pages/api/webhooks/stripe.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import Stripe from "stripe";
-import supabase from "shared/supabase/serverClient";
+import { supabase } from "shared/supabase/serverClient";
 
 const debug = process.env.SMOOTHR_DEBUG === "true";
 const log = (...args: any[]) => debug && console.log("[Stripe Webhook]", ...args);


### PR DESCRIPTION
## Summary
- swap default import for named Supabase import

## Testing
- `npm test` *(fails: Failed to resolve import "../../supabase/supabaseClient.js" from "core/auth/index.js")*

------
https://chatgpt.com/codex/tasks/task_e_687e59d19424832587da483ff07bedf3