### PR TITLE
fix supabase imports

### DIFF
--- a/storefronts/checkout/gateways/stripe.js
+++ b/storefronts/checkout/gateways/stripe.js
@@ -1,5 +1,5 @@
 import forceStripeIframeStyle from './forceStripeIframeStyle.js';
-import supabase from '../../../supabase/supabaseClient.js';
+import { supabase } from '../../../shared/supabase/serverClient';
 import { getPublicCredential } from '../getPublicCredential.js';
 import { handleSuccessRedirect } from '../utils/handleSuccessRedirect.js';
 let fieldsMounted = false;

--- a/storefronts/checkout/getPublicCredential.js
+++ b/storefronts/checkout/getPublicCredential.js
@@ -1,4 +1,4 @@
-import supabase from '../../supabase/supabaseClient.js';
+import { supabase } from '../../shared/supabase/serverClient';
 
 export async function getPublicCredential(storeId, integrationId, gateway) {
   if (!storeId || !integrationId) return null;

--- a/storefronts/core/auth/index.js
+++ b/storefronts/core/auth/index.js
@@ -1,4 +1,4 @@
-import supabase from '../../../supabase/supabaseClient.js';
+import { supabase } from '../../../shared/supabase/serverClient';
 import {
   initAuth,
   initPasswordResetConfirmation,

--- a/storefronts/core/discounts.ts
+++ b/storefronts/core/discounts.ts
@@ -1,4 +1,4 @@
-import supabase from '../../supabase/supabaseClient.js';
+import { supabase } from '../../shared/supabase/serverClient';
 
 const debug = typeof window !== 'undefined' && window.SMOOTHR_CONFIG?.debug;
 const log = (...args: any[]) => debug && console.log('[Smoothr Discounts]', ...args);

--- a/storefronts/core/index.js
+++ b/storefronts/core/index.js
@@ -1,4 +1,4 @@
-import supabase from '../../supabase/supabaseClient.js';
+import { supabase } from '../../shared/supabase/serverClient';
 
 import * as abandonedCart from './abandoned-cart/index.js';
 import * as affiliates from './affiliates/index.js';

--- a/storefronts/core/orders/index.js
+++ b/storefronts/core/orders/index.js
@@ -2,7 +2,7 @@
  * Handles order workflows and UI widgets for the storefront.
  */
 
-import supabase from '../../../supabase/supabaseClient.js';
+import { supabase } from '../../../shared/supabase/serverClient';
 
 const debug = window.SMOOTHR_CONFIG?.debug;
 const log = (...args) => debug && console.log('[Smoothr Orders]', ...args);

--- a/storefronts/tests/platforms/authorizeNet-gateway.test.js
+++ b/storefronts/tests/platforms/authorizeNet-gateway.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-vi.mock('../../../supabase/supabaseClient.js', () => {
+vi.mock('../../../shared/supabase/serverClient.ts', () => {
   const maybeSingle = vi.fn(async () => ({
     data: { settings: { client_key: 'client', api_login_id: 'id' } },
     error: null
@@ -9,7 +9,7 @@ vi.mock('../../../supabase/supabaseClient.js', () => {
   const eq1 = vi.fn(() => ({ eq: eq2 }));
   const select = vi.fn(() => ({ eq: eq1 }));
   const from = vi.fn(() => ({ select }));
-  return { default: { from } };
+  return { supabase: { from } };
 });
 
 let createPaymentMethod;

--- a/storefronts/tests/sdk/load-config-api-base.test.js
+++ b/storefronts/tests/sdk/load-config-api-base.test.js
@@ -1,11 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-vi.mock('../../../supabase/supabaseClient.js', () => {
+vi.mock('../../../shared/supabase/serverClient.ts', () => {
   const single = vi.fn(async () => ({ data: { api_base: 'https://example.com' }, error: null }));
   const eq = vi.fn(() => ({ single }));
   const select = vi.fn(() => ({ eq }));
   const from = vi.fn(() => ({ select }));
-  return { default: { from } };
+  return { supabase: { from } };
 });
 
 beforeEach(() => {

--- a/storefronts/tests/sdk/load-config-merge.test.js
+++ b/storefronts/tests/sdk/load-config-merge.test.js
@@ -1,11 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-vi.mock('../../../supabase/supabaseClient.js', () => {
+vi.mock('../../../shared/supabase/serverClient.ts', () => {
   const single = vi.fn(async () => ({ data: { foo: 'bar' }, error: null }));
   const eq = vi.fn(() => ({ single }));
   const select = vi.fn(() => ({ eq }));
   const from = vi.fn(() => ({ select }));
-  return { default: { from } };
+  return { supabase: { from } };
 });
 
 beforeEach(() => {

--- a/supabase/authHelpers.js
+++ b/supabase/authHelpers.js
@@ -1,4 +1,4 @@
-import supabase from './supabaseClient.js';
+import { supabase } from '../shared/supabase/serverClient';
 
 const debug = typeof window !== 'undefined' && window.SMOOTHR_CONFIG?.debug;
 const log = (...args) => debug && console.log('[Smoothr Auth]', ...args);

--- a/supabase/functions/store-tables.test.ts
+++ b/supabase/functions/store-tables.test.ts
@@ -6,7 +6,7 @@ let settingsBuilder: any
 let integrationsBuilder: any
 
 async function loadClient() {
-  supabase = (await import('../supabaseClient.js')).default
+  supabase = (await import('../../shared/supabase/serverClient.ts')).supabase
 }
 
 describe('store tables queries', () => {

--- a/supabase/functions/supabaseClientHeaders.test.ts
+++ b/supabase/functions/supabaseClientHeaders.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect } from 'vitest'
-import supabase, { DEFAULT_SUPABASE_KEY } from '../supabaseClient.js'
+import { supabase } from '../../shared/supabase/serverClient'
 
 describe('supabase client headers', () => {
   it('includes default authorization headers', () => {
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY
     expect((supabase as any).headers).toEqual(
       expect.objectContaining({
-        apikey: DEFAULT_SUPABASE_KEY,
-        Authorization: `Bearer ${DEFAULT_SUPABASE_KEY}`,
+        apikey: key,
+        Authorization: `Bearer ${key}`,
       })
     )
   })


### PR DESCRIPTION
## Summary
- update leftover SDK imports to use named `supabase` export
- adjust vitest mocks and tests for serverClient

## Testing
- `npm test` *(fails: Missing Supabase credentials)*

------
https://chatgpt.com/codex/tasks/task_e_687e5ba9782c8325bdcd4b0a90345795