### PR TITLE
Add browser Supabase client

### DIFF
--- a/shared/supabase/browserClient.ts
+++ b/shared/supabase/browserClient.ts
@@ -1,0 +1,8 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  import.meta.env.VITE_SUPABASE_URL,
+  import.meta.env.VITE_SUPABASE_ANON_KEY
+);
+
+export { supabase };

--- a/storefronts/checkout/gateways/stripe.js
+++ b/storefronts/checkout/gateways/stripe.js
@@ -1,5 +1,5 @@
 import forceStripeIframeStyle from './forceStripeIframeStyle.js';
-import { supabase } from '../../../shared/supabase/serverClient';
+import { supabase } from '../../../shared/supabase/browserClient';
 import { getPublicCredential } from '../getPublicCredential.js';
 import { handleSuccessRedirect } from '../utils/handleSuccessRedirect.js';
 let fieldsMounted = false;

--- a/storefronts/checkout/getPublicCredential.js
+++ b/storefronts/checkout/getPublicCredential.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../shared/supabase/serverClient';
+import { supabase } from '../../shared/supabase/browserClient';
 
 export async function getPublicCredential(storeId, integrationId, gateway) {
   if (!storeId || !integrationId) return null;

--- a/storefronts/core/auth/index.js
+++ b/storefronts/core/auth/index.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../shared/supabase/serverClient';
+import { supabase } from '../../../shared/supabase/browserClient';
 import {
   initAuth,
   initPasswordResetConfirmation,

--- a/storefronts/core/discounts.ts
+++ b/storefronts/core/discounts.ts
@@ -1,4 +1,4 @@
-import { supabase } from '../../shared/supabase/serverClient';
+import { supabase } from '../../shared/supabase/browserClient';
 
 const debug = typeof window !== 'undefined' && window.SMOOTHR_CONFIG?.debug;
 const log = (...args: any[]) => debug && console.log('[Smoothr Discounts]', ...args);

--- a/storefronts/core/index.js
+++ b/storefronts/core/index.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../shared/supabase/serverClient';
+import { supabase } from '../../shared/supabase/browserClient';
 
 import * as abandonedCart from './abandoned-cart/index.js';
 import * as affiliates from './affiliates/index.js';

--- a/storefronts/core/orders/index.js
+++ b/storefronts/core/orders/index.js
@@ -2,7 +2,7 @@
  * Handles order workflows and UI widgets for the storefront.
  */
 
-import { supabase } from '../../../shared/supabase/serverClient';
+import { supabase } from '../../../shared/supabase/browserClient';
 
 const debug = window.SMOOTHR_CONFIG?.debug;
 const log = (...args) => debug && console.log('[Smoothr Orders]', ...args);

--- a/storefronts/tests/platforms/authorizeNet-gateway.test.js
+++ b/storefronts/tests/platforms/authorizeNet-gateway.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-vi.mock('../../../shared/supabase/serverClient', () => {
+vi.mock('../../../shared/supabase/browserClient', () => {
   
   const maybeSingle = vi.fn(async () => ({
     data: { settings: { client_key: 'client', api_login_id: 'id' } },

--- a/storefronts/tests/providers/handleCheckout-store-id.test.ts
+++ b/storefronts/tests/providers/handleCheckout-store-id.test.ts
@@ -16,7 +16,7 @@ vi.mock('../../../shared/supabase/serverClient', () => {
       return {};
     },
   };
-  return { supabase: client, createServerSupabaseClient: () => client };
+  return { supabase: client, createServerSupabaseClient: () => client, testMarker: '✅ serverClient loaded' };
 });
 
 async function loadModule() {

--- a/storefronts/tests/providers/provider-handleCheckout-authorizeNet.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-authorizeNet.test.ts
@@ -73,6 +73,7 @@ vi.mock('../../../shared/supabase/serverClient', () => {
   return {
     supabase: client,
     createServerSupabaseClient: () => client,
+    testMarker: '✅ serverClient loaded'
   };
 });
 

--- a/storefronts/tests/providers/provider-handleCheckout-nmi-missing-token.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-nmi-missing-token.test.ts
@@ -35,7 +35,7 @@ vi.mock('../../../shared/supabase/serverClient', () => {
         return {};
       }
   };
-  return { supabase: client, createServerSupabaseClient: () => client };
+  return { supabase: client, createServerSupabaseClient: () => client, testMarker: '✅ serverClient loaded' };
 });
 
 async function loadModule() {

--- a/storefronts/tests/providers/provider-handleCheckout-nmi.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-nmi.test.ts
@@ -90,7 +90,7 @@ vi.mock('../../../shared/supabase/serverClient', () => {
         return {};
       }
   };
-  return { supabase: client, createServerSupabaseClient: () => client };
+  return { supabase: client, createServerSupabaseClient: () => client, testMarker: '✅ serverClient loaded' };
 });
 
 async function loadModule() {

--- a/storefronts/tests/providers/provider-handleCheckout-settings-error.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-settings-error.test.ts
@@ -44,7 +44,7 @@ vi.mock('../../../shared/supabase/serverClient', () => {
       return { select: vi.fn(() => ({ eq: vi.fn(() => ({ eq: vi.fn(() => ({ single: vi.fn(async () => ({ data: null, error: null })) })) })) })) };
     }
   };
-  return { supabase: client, createServerSupabaseClient: () => client };
+  return { supabase: client, createServerSupabaseClient: () => client, testMarker: '✅ serverClient loaded' };
 });
 
 async function loadModule() {

--- a/storefronts/tests/sdk/load-config-api-base.test.js
+++ b/storefronts/tests/sdk/load-config-api-base.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-vi.mock('../../../shared/supabase/serverClient', () => {
+vi.mock('../../../shared/supabase/browserClient', () => {
 
   const single = vi.fn(async () => ({ data: { api_base: 'https://example.com' }, error: null }));
   const eq = vi.fn(() => ({ single }));

--- a/storefronts/tests/sdk/load-config-merge.test.js
+++ b/storefronts/tests/sdk/load-config-merge.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-vi.mock('../../../shared/supabase/serverClient', () => {
+vi.mock('../../../shared/supabase/browserClient', () => {
 
   const single = vi.fn(async () => ({ data: { foo: 'bar' }, error: null }));
   const eq = vi.fn(() => ({ single }));

--- a/storefronts/vitest.config.js
+++ b/storefronts/vitest.config.js
@@ -1,17 +1,25 @@
 import { defineConfig } from 'vitest/config';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { loadEnv } from 'vite';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-export default defineConfig({
-  test: {
-    environment: 'happy-dom',
-    setupFiles: './vitest.setup.js'
-  },
-  resolve: {
-    alias: {
-      '@': resolve(__dirname, '../smoothr')
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, __dirname, '');
+  return {
+    test: {
+      environment: 'happy-dom',
+      setupFiles: './vitest.setup.js'
+    },
+    resolve: {
+      alias: {
+        '@': resolve(__dirname, '../smoothr')
+      }
+    },
+    define: {
+      'import.meta.env.VITE_SUPABASE_URL': JSON.stringify(env.NEXT_PUBLIC_SUPABASE_URL),
+      'import.meta.env.VITE_SUPABASE_ANON_KEY': JSON.stringify(env.NEXT_PUBLIC_SUPABASE_ANON_KEY)
     }
-  }
+  };
 });

--- a/supabase/authHelpers.js
+++ b/supabase/authHelpers.js
@@ -1,4 +1,4 @@
-import { supabase } from '../shared/supabase/serverClient';
+import { supabase } from '../shared/supabase/browserClient';
 
 const debug = typeof window !== 'undefined' && window.SMOOTHR_CONFIG?.debug;
 const log = (...args) => debug && console.log('[Smoothr Auth]', ...args);


### PR DESCRIPTION
## Summary
- add browserSupabase client using import.meta.env
- switch browser modules to the browser client
- mock the right client in tests
- provide Vite env vars for Vitest

## Testing
- `npm run bundle:webflow-checkout`
- `npm test` *(fails: ENETUNREACH errors)*

------
https://chatgpt.com/codex/tasks/task_e_687e6ba407b88325af5e05781b38f5c0