### PR TITLE
Fix supabase env var injection

### DIFF
--- a/storefronts/scripts/bundle-webflow-checkout.js
+++ b/storefronts/scripts/bundle-webflow-checkout.js
@@ -40,6 +40,8 @@ try {
     target: 'es2018',
     define: {
       'process.env.NODE_ENV': '"production"',
+      'process.env.NEXT_PUBLIC_SUPABASE_URL': JSON.stringify(supabaseUrl),
+      'process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY': JSON.stringify(supabaseAnonKey),
       __NEXT_PUBLIC_SUPABASE_URL__: JSON.stringify(supabaseUrl),
       __NEXT_PUBLIC_SUPABASE_ANON_KEY__: JSON.stringify(supabaseAnonKey)
     }

--- a/storefronts/vite.config.js
+++ b/storefronts/vite.config.js
@@ -9,9 +9,9 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
   return {
     define: {
-      // Map Cloudflare’s NEXT_PUBLIC_* secrets into Vite’s import.meta.env.VITE_*
-      'import.meta.env.VITE_SUPABASE_URL': JSON.stringify(env.NEXT_PUBLIC_SUPABASE_URL),
-      'import.meta.env.VITE_SUPABASE_ANON_KEY': JSON.stringify(env.NEXT_PUBLIC_SUPABASE_ANON_KEY),
+      // Map Cloudflare’s NEXT_PUBLIC_* secrets into process.env
+      'process.env.NEXT_PUBLIC_SUPABASE_URL': JSON.stringify(env.NEXT_PUBLIC_SUPABASE_URL),
+      'process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY': JSON.stringify(env.NEXT_PUBLIC_SUPABASE_ANON_KEY),
       __NEXT_PUBLIC_SUPABASE_OAUTH_REDIRECT_URL__: JSON.stringify(
         env.NEXT_PUBLIC_SUPABASE_OAUTH_REDIRECT_URL
       ),

--- a/storefronts/vitest.config.js
+++ b/storefronts/vitest.config.js
@@ -18,8 +18,8 @@ export default defineConfig(({ mode }) => {
       }
     },
     define: {
-      'import.meta.env.VITE_SUPABASE_URL': JSON.stringify(env.NEXT_PUBLIC_SUPABASE_URL),
-      'import.meta.env.VITE_SUPABASE_ANON_KEY': JSON.stringify(env.NEXT_PUBLIC_SUPABASE_ANON_KEY)
+      'process.env.NEXT_PUBLIC_SUPABASE_URL': JSON.stringify(env.NEXT_PUBLIC_SUPABASE_URL),
+      'process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY': JSON.stringify(env.NEXT_PUBLIC_SUPABASE_ANON_KEY)
     }
   };
 });


### PR DESCRIPTION
## Summary
- map NEXT_PUBLIC_SUPABASE secrets to `process.env` in Vite and Vitest
- define those keys for esbuild when bundling Webflow checkout

## Testing
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=anon-key npm run build` (in `storefronts`)
- `npm test` *(fails: Missing data-store-id on <script> tag, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687e73c49e948325a029a87d84813b54