### PR TITLE
Add build check for import.meta.env

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ manual build step is required.
 Use `npm run bundle:webflow-checkout` from the repository root to rebuild only
 the Webflow checkout script.
 
+During the build a helper script (`storefronts/scripts/check-sdk.js`) verifies
+that required exports exist and that no compiled file still contains
+`import.meta.env`. The build fails if any such reference is found.
+
 ## Checkout API
 
 The admin dashboard exposes two endpoints for initiating a checkout:
@@ -257,7 +261,8 @@ successful deployment with the commit hash and UTC timestamp.
 All pushes to the `main` branch trigger the workflow defined at
 `.github/workflows/build-and-deploy.yml`. The workflow uses Node.js 20,
 installs dependencies, runs tests, builds the storefront SDK, performs the
-postbuild check, and deploys `storefronts/dist` to Cloudflare Pages.
+postbuild check (including a scan for any `import.meta.env` references), and
+deploys `storefronts/dist` to Cloudflare Pages.
 
 To configure deployment secrets go to **Settings → Secrets and variables →
 Actions** in GitHub and add:

--- a/storefronts/scripts/check-sdk.js
+++ b/storefronts/scripts/check-sdk.js
@@ -67,3 +67,26 @@ if (nmiMissing.length) {
 
 log('nmi.js contains required exports.');
 
+const filesToScan = [
+  { path: sdkPath, name: 'smoothr-sdk.js' },
+  { path: checkoutPath, name: 'checkout.js' },
+  { path: stripePath, name: 'gateways/stripe.js' },
+  { path: nmiPath, name: 'gateways/nmi.js' },
+  { path: webflowCheckoutPath, name: 'platforms/webflow/checkout.js' },
+  { path: waitForElementPath, name: 'utils/waitForElement.js' },
+];
+
+const flagged = [];
+
+for (const file of filesToScan) {
+  const text = await readFile(file.path, 'utf8');
+  if (text.includes('import.meta.env')) flagged.push(file.name);
+}
+
+if (flagged.length) {
+  err(`import.meta.env found in: ${flagged.join(', ')}`);
+  process.exit(1);
+}
+
+log('No import.meta.env references detected.');
+


### PR DESCRIPTION
## Summary
- check-storefront bundles for any `import.meta.env`
- document the new check in README

## Testing
- `npm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_687e7556b74c83258e49dc330a8fe353