### PR TITLE
Add step-level Supabase logs

### DIFF
--- a/shared/checkout/getStoreIntegration.ts
+++ b/shared/checkout/getStoreIntegration.ts
@@ -3,6 +3,7 @@ import { createServerSupabaseClient } from '../supabase/serverClient';
 export async function getStoreIntegration(storeId: string, integrationId: string) {
   if (!storeId || !integrationId) return null;
   const supabase = createServerSupabaseClient();
+  console.log('[STEP] Fetching store_integrations...');
   const { data, error } = await supabase
     .from('store_integrations')
     .select('api_key, settings')


### PR DESCRIPTION
## Summary
- add `[STEP]` console logs to checkout flow

## Testing
- `npm test` *(fails: vitest not found, checkout tests crash)*

------
https://chatgpt.com/codex/tasks/task_e_687e85c84f288325be0931b57d7cf97b