### PR TITLE
Fix handleCheckout profile lookup order

### DIFF
--- a/shared/checkout/handleCheckout.ts
+++ b/shared/checkout/handleCheckout.ts
@@ -201,24 +201,6 @@ export async function handleCheckout({ req, res }: { req: NextApiRequest; res: N
   }
 
   let customer_profile_id: string | null = null;
-  console.log('[STEP] Fetching customer_payment_profiles...');
-  const { data: profileRows, error: profileErr } = await supabase
-    .from('customer_payment_profiles')
-    .select('profile_id')
-    .eq('customer_id', customerId)
-    .eq('gateway', provider)
-    .limit(1);
-  
-  customer_profile_id = profileRows?.[0]?.profile_id || null;
-  
-
-  if (profileErr) {
-    console.error('[Supabase ERROR] Profile lookup failed:', profileErr.message);
-    return res
-      .status(500)
-      .json({ error: 'Profile lookup failed', detail: profileErr.message });
-  }
-  customer_profile_id = profileData?.profile_id || null;
 
 
   const { name, address } = shipping;
@@ -356,6 +338,24 @@ export async function handleCheckout({ req, res }: { req: NextApiRequest; res: N
 
   const provider = (storeSettings?.active_payment_gateway || '') as string;
   log('Selected provider:', provider);
+
+  // Fetch customer payment profile using the selected provider
+  console.log('[STEP] Fetching customer_payment_profiles...');
+  const { data: profileRows, error: profileErr } = await supabase
+    .from('customer_payment_profiles')
+    .select('profile_id')
+    .eq('customer_id', customerId)
+    .eq('gateway', provider)
+    .limit(1);
+
+  if (profileErr) {
+    console.error('[Supabase ERROR] Profile lookup failed:', profileErr.message);
+    return res
+      .status(500)
+      .json({ error: 'Profile lookup failed', detail: profileErr.message });
+  }
+
+  customer_profile_id = profileRows?.[0]?.profile_id || null;
 
   const providers: Record<string, any> = {
     stripe: stripeProvider,


### PR DESCRIPTION
## Summary
- fetch customer payment profile after provider lookup
- ensure correct provider is used

## Testing
- `npm test` *(fails: vitest not found; network errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f369c936883259006792d2b13580f