### PR TITLE
Update checkout upsert key

### DIFF
--- a/shared/checkout/handleCheckout.ts
+++ b/shared/checkout/handleCheckout.ts
@@ -768,7 +768,8 @@ export async function handleCheckout({ req, res }: { req: NextApiRequest; res: N
     console.log('[STEP] Upserting order record...');
     const { data, error } = await supabase
       .from('orders')
-      .upsert(orderPayload, { onConflict: 'order_number' })
+      // Ensure upsert uses the composite unique constraint on (store_id, order_number)
+      .upsert(orderPayload, { onConflict: 'store_id,order_number' })
       .select('id')
       .single();
     if (error) {


### PR DESCRIPTION
## Summary
- use composite `(store_id,order_number)` constraint when upserting orders

## Testing
- `npm test` *(fails: vitest not found due to env limits)*

------
https://chatgpt.com/codex/tasks/task_e_687f3e259034832591ce553542dc5f38