### PR TITLE
Fix NMI sale requires token

### DIFF
--- a/shared/checkout/providers/nmi.ts
+++ b/shared/checkout/providers/nmi.ts
@@ -88,7 +88,11 @@ export default async function handleNmi(payload: NmiPayload) {
     params.append('customer_vault_id', payload.customer_profile_id);
   } else {
     params.append('customer_vault', 'add_customer');
-    params.append('payment_token', payload.payment_token || '');
+    if (payload.payment_token && payload.payment_token.trim()) {
+      params.append('payment_token', payload.payment_token);
+    } else {
+      return { success: false, error: 'Missing payment_token for NMI sale' };
+    }
   }
 
   // Add billing if provided, else use shipping


### PR DESCRIPTION
## Summary
- verify payment_token before sending an NMI sale request

## Testing
- `npm test` *(fails: Blocked fetch during test, connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_687f4b6a0030832599f13a9beb113f6f