### PR TITLE
Fix NMI cart item type

### DIFF
--- a/shared/checkout/providers/nmi.ts
+++ b/shared/checkout/providers/nmi.ts
@@ -35,7 +35,7 @@ interface NmiPayload {
     };
   };
   cart: Array<{
-    product_id: string;
+    product_id?: string;
     name: string;
     quantity: number;
     price: number;
@@ -106,7 +106,8 @@ export default async function handleNmi(payload: NmiPayload) {
 
   // Add cart items as products (NMI supports multiple product lines)
   payload.cart.forEach((item, index) => {
-    params.append(`product[${index}][sku]`, item.product_id);
+    // Fallback to empty string so "undefined" isn't sent when product_id is missing
+    params.append(`product[${index}][sku]`, item.product_id || '');
     params.append(`product[${index}][description]`, item.name);
     params.append(`product[${index}][qty]`, item.quantity.toString());
     params.append(`product[${index}][price]`, (item.price / 100).toFixed(2));


### PR DESCRIPTION
## Summary
- make `product_id` optional in `NmiPayload`
- avoid sending `undefined` SKU by falling back to an empty string

## Testing
- `npm test` *(fails: Test timed out / network errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f6785f6d483259a436fe11b9f24e2