### PR TITLE
Fix NMI vault logic

### DIFF
--- a/shared/checkout/providers/nmi.ts
+++ b/shared/checkout/providers/nmi.ts
@@ -86,13 +86,11 @@ export default async function handleNmi(payload: NmiPayload) {
 
   if (payload.customer_profile_id) {
     params.append('customer_vault_id', payload.customer_profile_id);
-  } else {
+  } else if (payload.payment_token && payload.payment_token.trim()) {
     params.append('customer_vault', 'add_customer');
-    if (payload.payment_token && payload.payment_token.trim()) {
-      params.append('payment_token', payload.payment_token);
-    } else {
-      return { success: false, error: 'Missing payment_token for NMI sale' };
-    }
+    params.append('payment_token', payload.payment_token);
+  } else {
+    return { success: false, error: 'Missing payment_token or vault_id' };
   }
 
   // Add billing if provided, else use shipping

--- a/storefronts/tests/providers/provider-nmi.test.ts
+++ b/storefronts/tests/providers/provider-nmi.test.ts
@@ -71,4 +71,25 @@ describe('handleNmi', () => {
     const res = await handleNmi(basePayload);
     expect(res).toEqual({ success: false, error: 'Missing security key' });
   });
+
+  it('prefers customer_profile_id over token', async () => {
+    const res = await handleNmi({
+      ...basePayload,
+      payment_token: 'tok_x',
+      customer_profile_id: 'vault123'
+    });
+    expect(res.success).toBe(true);
+    const params = new URLSearchParams(fetchMock.mock.calls[0][1].body);
+    expect(params.get('customer_vault_id')).toBe('vault123');
+    expect(params.get('payment_token')).toBeNull();
+    expect(params.get('customer_vault')).toBeNull();
+  });
+
+  it('errors when token and vault id missing', async () => {
+    const res = await handleNmi({
+      ...basePayload,
+      payment_token: undefined as any
+    });
+    expect(res).toEqual({ success: false, error: 'Missing payment_token or vault_id' });
+  });
 });


### PR DESCRIPTION
## Summary
- prefer `customer_profile_id` over token when building the NMI payload
- test that vault id is preferred and missing credentials error out

## Testing
- `npm test` *(fails: connect ENETUNREACH and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f782995708325a2e9902546db3e15