### PR TITLE
Fix NMI vault fallback

### DIFF
--- a/shared/checkout/providers/nmi.ts
+++ b/shared/checkout/providers/nmi.ts
@@ -86,11 +86,16 @@ export default async function handleNmi(payload: NmiPayload) {
 
   if (payload.customer_profile_id) {
     params.append('customer_vault_id', payload.customer_profile_id);
-  } else if (payload.payment_token && payload.payment_token.trim()) {
+  } else if (payload.payment_token) {
     params.append('customer_vault', 'add_customer');
     params.append('payment_token', payload.payment_token);
   } else {
-    return { success: false, error: 'Missing payment_token or vault_id' };
+    return {
+      success: false,
+      error: 'Missing payment_token or customer_profile_id for NMI sale',
+      transaction_id: null,
+      customer_vault_id: null
+    };
   }
 
   // Add billing if provided, else use shipping

--- a/storefronts/tests/providers/provider-nmi.test.ts
+++ b/storefronts/tests/providers/provider-nmi.test.ts
@@ -90,6 +90,11 @@ describe('handleNmi', () => {
       ...basePayload,
       payment_token: undefined as any
     });
-    expect(res).toEqual({ success: false, error: 'Missing payment_token or vault_id' });
+    expect(res).toEqual({
+      success: false,
+      error: 'Missing payment_token or customer_profile_id for NMI sale',
+      transaction_id: null,
+      customer_vault_id: null
+    });
   });
 });


### PR DESCRIPTION
## Summary
- send payment token when no vault profile was requested
- update failing NMI test expectations

## Testing
- `npm test` *(fails: vitest could not run due to missing environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_687f7f70b078832589bae6ed48d023c0