### PR TITLE
Switch NMI gateway to auth

### DIFF
--- a/shared/checkout/providers/nmi.ts
+++ b/shared/checkout/providers/nmi.ts
@@ -61,7 +61,7 @@ export default async function handleNmi(payload: NmiPayload) {
   // Prepare NMI params with full details
   const params = new URLSearchParams({
     security_key: securityKey,
-    type: 'sale',
+    type: 'auth',
     amount: (payload.amount / 100).toFixed(2),
     firstname: payload.first_name,
     lastname: payload.last_name,
@@ -92,7 +92,7 @@ export default async function handleNmi(payload: NmiPayload) {
   } else {
     return {
       success: false,
-      error: 'Missing payment_token or customer_profile_id for NMI sale',
+      error: 'Missing payment_token or customer_profile_id for NMI auth',
       transaction_id: null,
       customer_vault_id: null
     };

--- a/storefronts/tests/providers/provider-nmi.test.ts
+++ b/storefronts/tests/providers/provider-nmi.test.ts
@@ -92,7 +92,7 @@ describe('handleNmi', () => {
     });
     expect(res).toEqual({
       success: false,
-      error: 'Missing payment_token or customer_profile_id for NMI sale',
+      error: 'Missing payment_token or customer_profile_id for NMI auth',
       transaction_id: null,
       customer_vault_id: null
     });


### PR DESCRIPTION
## Summary
- change NMI transaction type from `sale` to `auth`
- update failing error message in provider and tests

## Testing
- `npm test` *(fails: vitest errors and blocked network requests)*

------
https://chatgpt.com/codex/tasks/task_e_687f83aea00c8325b29c308f4b7a1ba7