### PR TITLE
Add test for unsupported payment gateway

### DIFF
--- a/storefronts/tests/providers/provider-handleCheckout-unsupported.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-unsupported.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+let handleCheckout: any;
+
+vi.mock('../../../smoothr/lib/findOrCreateCustomer.ts', () => {
+  return { findOrCreateCustomer: vi.fn(async () => 'cust-1') };
+});
+
+vi.mock('../../../shared/supabase/serverClient', () => {
+  const client = {
+    from: (table: string) => {
+      if (table === 'stores') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(async () => ({ data: [{ id: 'store-1' }], error: null }))
+          }))
+        };
+      }
+      if (table === 'store_settings') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn(async () => ({ data: { settings: { active_payment_gateway: 'bogus' } }, error: null }))
+            }))
+          }))
+        };
+      }
+      if (table === 'customer_payment_profiles') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({ limit: vi.fn(async () => ({ data: [], error: null })) }))
+            }))
+          }))
+        };
+      }
+      return { select: vi.fn(() => ({ eq: vi.fn(() => ({ eq: vi.fn(() => ({ single: vi.fn(async () => ({ data: null, error: null })) })) })) })) };
+    }
+  };
+  return { supabase: client, createServerSupabaseClient: () => client, testMarker: '✅ serverClient loaded' };
+});
+
+async function loadModule() {
+  const mod = await import('../../../shared/checkout/handleCheckout.ts');
+  handleCheckout = mod.handleCheckout;
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  await loadModule();
+});
+
+describe('handleCheckout unsupported provider', () => {
+  it('returns 400 for unknown payment gateway', async () => {
+    const req: Partial<NextApiRequest> = {
+      headers: { origin: 'https://shop.example.com' },
+      method: 'POST',
+      body: {
+        email: 'user@example.com',
+        first_name: 'Jane',
+        last_name: 'Doe',
+        shipping: { name: 'Jane Doe', address: { line1: '1 St', city: 'Town', state: 'TS', postal_code: '00000', country: 'US' } },
+        cart: [{ product_id: 'p1', quantity: 1, price: 100 }],
+        total: 100,
+        currency: 'USD',
+        store_id: 'store-1',
+        same_billing: true
+      }
+    } as any;
+
+    const res: Partial<NextApiResponse> = {
+      status: vi.fn(() => res as any),
+      json: vi.fn(() => res as any),
+      setHeader: vi.fn(),
+      end: vi.fn()
+    };
+
+    await handleCheckout({ req: req as NextApiRequest, res: res as NextApiResponse });
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Unsupported payment gateway' });
+  });
+});


### PR DESCRIPTION
## Summary
- add a test ensuring `handleCheckout` rejects unknown gateways

## Testing
- `npm test` *(fails: global project issues)*
- `npx vitest run tests/providers/provider-handleCheckout-unsupported.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_687f984e83dc8325b6904f8974a6deb6