### PR TITLE
Make API CORS origin configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,11 @@ window with the `DEDUPE_WINDOW_MS` environment variable. It defaults to 30
 seconds. Setting a lower value or `0` disables server-side duplicate
 suppression.
 
+### CORS_ORIGIN
+
+API routes use this variable for CORS headers. Set it to the allowed
+origin URL. When unset, `*` is used.
+
 ## Checkout flow
 
 All gateways now delegate post-success behavior to `handleSuccessRedirect()` in utils.

--- a/smoothr/pages/api/checkout/[provider].ts
+++ b/smoothr/pages/api/checkout/[provider].ts
@@ -4,16 +4,17 @@ import '../../../../shared/init';
 import { handleCheckout } from 'shared/checkout/handleCheckout';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const origin = process.env.CORS_ORIGIN || '*';
   if (req.method === 'OPTIONS') {
     return res
       .status(200)
-      .setHeader('Access-Control-Allow-Origin', 'https://smoothr-cms.webflow.io')
+      .setHeader('Access-Control-Allow-Origin', origin)
       .setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
       .setHeader('Access-Control-Allow-Headers', 'Content-Type')
       .end();
   }
 
-  res.setHeader('Access-Control-Allow-Origin', 'https://smoothr-cms.webflow.io');
+  res.setHeader('Access-Control-Allow-Origin', origin);
 
   console.log('[API] 🔥 [provider] API route hit');
   if (req.method !== 'POST' && req.method !== 'OPTIONS') {

--- a/smoothr/pages/api/create-order.ts
+++ b/smoothr/pages/api/create-order.ts
@@ -8,16 +8,17 @@ export default async function handler(
   res: NextApiResponse,
 ) {
   const supabase = createServerSupabaseClient();
+  const origin = process.env.CORS_ORIGIN || '*';
   if (req.method === 'OPTIONS') {
     return res
       .status(200)
-      .setHeader('Access-Control-Allow-Origin', 'https://smoothr-cms.webflow.io')
+      .setHeader('Access-Control-Allow-Origin', origin)
       .setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
       .setHeader('Access-Control-Allow-Headers', 'Content-Type')
       .end();
   }
 
-  res.setHeader('Access-Control-Allow-Origin', 'https://smoothr-cms.webflow.io');
+  res.setHeader('Access-Control-Allow-Origin', origin);
   if (req.method !== 'POST') {
     res.status(405).json({ error: 'Method not allowed' });
     return;

--- a/smoothr/pages/api/get-payment-key.js
+++ b/smoothr/pages/api/get-payment-key.js
@@ -2,8 +2,8 @@
 import { createClient } from '@supabase/supabase-js';
 
 export default async function handler(req, res) {
-  // Set CORS headers
-  res.setHeader('Access-Control-Allow-Origin', 'https://smoothr-cms.webflow.io');
+  const origin = process.env.CORS_ORIGIN || '*';
+  res.setHeader('Access-Control-Allow-Origin', origin);
   res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
 


### PR DESCRIPTION
## Summary
- allow customizing Access-Control-Allow-Origin header in checkout API routes
- document `CORS_ORIGIN` environment variable

## Testing
- `npm test` *(fails: ENETUNREACH errors)*

------
https://chatgpt.com/codex/tasks/task_e_6880a5e75cec832598f724a0d7405ed2