### PR TITLE
Add stripe credential lookup

### DIFF
--- a/storefronts/checkout/gateways/stripe.js
+++ b/storefronts/checkout/gateways/stripe.js
@@ -85,14 +85,15 @@ async function resolveStripeKey() {
   let key;
   if (storeId) {
     try {
-      const cred = await getPublicCredential(storeId, 'stripe');
+      const cred = await getPublicCredential(storeId, 'stripe', 'stripe');
       if (cred) {
-        key = cred.api_key || cred.settings?.public_key || '';
+        key =
+          cred.settings?.publishable_key ||
+          cred.settings?.api_key ||
+          cred.api_key ||
+          '';
         if (key) {
-          log(
-            'Loaded key from Supabase.' +
-              (cred.api_key ? 'store_integrations.api_key' : 'store_integrations.settings.public_key')
-          );
+          log('✅ Stripe key resolved, mounting gateway...');
         }
       }
     } catch (e) {
@@ -100,7 +101,8 @@ async function resolveStripeKey() {
     }
   }
   if (!key) {
-    throw new Error('❌ Stripe key not found — aborting Stripe mount.');
+    warn('❌ Stripe key not found — aborting Stripe mount.');
+    return null;
   }
   cachedKey = key;
   return key;

--- a/storefronts/checkout/getPublicCredential.js
+++ b/storefronts/checkout/getPublicCredential.js
@@ -19,6 +19,21 @@ export async function getPublicCredential(storeId, integrationId, gateway) {
       return data ? { tokenization_key: data.tokenization_key } : null;
     }
 
+    if (integrationId === 'stripe' || gateway === 'stripe') {
+      const match = gateway || integrationId;
+      const { data, error } = await supabase
+        .from('public_store_integration_credentials')
+        .select('api_key, settings')
+        .eq('store_id', storeId)
+        .or(`provider.eq.${match},gateway.eq.${match}`)
+        .maybeSingle();
+      if (error) {
+        console.warn('[Smoothr] Credential lookup failed:', error.message || error);
+        return null;
+      }
+      return data || null;
+    }
+
     let query = supabase
       .from('store_integrations')
       .select('api_key, settings')


### PR DESCRIPTION
## Summary
- add public credential branch for Stripe
- fetch stripe credential in gateway
- gracefully abort mounting when Stripe key missing

## Testing
- `npm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6880b01df40c8325a4ef8ebe9b74585d