### PR TITLE
Fix Stripe credential query

### DIFF
--- a/storefronts/checkout/getPublicCredential.js
+++ b/storefronts/checkout/getPublicCredential.js
@@ -23,7 +23,7 @@ export async function getPublicCredential(storeId, integrationId, gateway) {
       const match = gateway || integrationId;
       const { data, error } = await supabase
         .from('public_store_integration_credentials')
-        .select('api_key, settings')
+        .select('settings')
         .eq('store_id', storeId)
         .or(`provider.eq.${match},gateway.eq.${match}`)
         .maybeSingle();


### PR DESCRIPTION
## Summary
- fix public credential lookup for Stripe

## Testing
- `npm test` *(fails: vitest unable to reach network resources)*

------
https://chatgpt.com/codex/tasks/task_e_6880ba68bcfc83259eba801d4ffb2aaf