### PR TITLE
Fix Stripe credential lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ the `publishable_key` and `secret_key` under the `settings` column:
 }
 ```
 
-The checkout SDK reads `settings.publishable_key` from the
+The checkout SDK reads `publishable_key` from the
 `public_store_integration_credentials` view when fetching configuration for a
 store. Activate the gateway by setting
 `public_store_settings.active_payment_gateway` to `stripe` (or override it on

--- a/storefronts/checkout/gateways/stripe.js
+++ b/storefronts/checkout/gateways/stripe.js
@@ -87,11 +87,7 @@ async function resolveStripeKey() {
     try {
       const cred = await getPublicCredential(storeId, 'stripe', 'stripe');
       if (cred) {
-        key =
-          cred.settings?.publishable_key ||
-          cred.settings?.api_key ||
-          cred.api_key ||
-          '';
+        key = cred.publishable_key || '';
         if (key) {
           log('✅ Stripe key resolved, mounting gateway...');
         }

--- a/storefronts/checkout/getPublicCredential.js
+++ b/storefronts/checkout/getPublicCredential.js
@@ -20,18 +20,22 @@ export async function getPublicCredential(storeId, integrationId, gateway) {
     }
 
     if (integrationId === 'stripe' || gateway === 'stripe') {
-      const match = gateway || integrationId;
       const { data, error } = await supabase
         .from('public_store_integration_credentials')
-        .select('settings')
+        .select('publishable_key')
         .eq('store_id', storeId)
-        .or(`provider.eq.${match},gateway.eq.${match}`)
+        .eq('provider', 'stripe')
         .maybeSingle();
       if (error) {
         console.warn('[Smoothr] Credential lookup failed:', error.message || error);
         return null;
       }
-      return data || null;
+      if (data?.publishable_key) {
+        console.log('[Smoothr] Loaded Stripe key from Supabase.');
+        return { publishable_key: data.publishable_key };
+      }
+      console.warn('[Smoothr] Stripe publishable key not found');
+      return null;
     }
 
     let query = supabase

--- a/storefronts/tests/sdk/stripe-mount.test.js
+++ b/storefronts/tests/sdk/stripe-mount.test.js
@@ -18,7 +18,7 @@ beforeEach(() => {
   vi.resetModules();
   styleSpy = vi.fn();
   domReadyCb = null;
-  getCredMock = vi.fn(async () => ({ settings: { publishable_key: 'pk_test' } }));
+  getCredMock = vi.fn(async () => ({ publishable_key: 'pk_test' }));
 
   cardNumberEl = { mount: vi.fn() };
   cardExpiryEl = { mount: vi.fn() };
@@ -69,7 +69,7 @@ describe('stripe element mounting', () => {
     await vi.runAllTimersAsync();
     vi.useRealTimers();
 
-    expect(getCredMock).toHaveBeenCalledWith('store-1', 'stripe');
+    expect(getCredMock).toHaveBeenCalledWith('store-1', 'stripe', 'stripe');
 
     expect(elementsCreate).toHaveBeenCalledWith(
       'cardNumber',


### PR DESCRIPTION
## Summary
- streamline Stripe credential lookup on the storefront
- update stripe gateway to use new credential field
- update test mocks and docs

## Testing
- `npm test` *(fails: connect ENETUNREACH for external fetch)*

------
https://chatgpt.com/codex/tasks/task_e_6880fa28ece08325ad56cb52b496539d