### PR TITLE
refactor stripe helper

### DIFF
--- a/storefronts/checkout/gateways/nmi.js
+++ b/storefronts/checkout/gateways/nmi.js
@@ -11,8 +11,13 @@ let isSubmitting = false
 let configPromise
 let resolveConfig
 
-function rgbToHex(rgb) {
-  const [r, g, b] = rgb.match(/\d+/g).map(Number);
+export function rgbToHex(rgb) {
+  if (!rgb || typeof rgb !== 'string') return rgb;
+  if (rgb.trim().startsWith('#')) return rgb;
+  const match = rgb.match(/\d+/g);
+  if (!match || match.length < 3) return rgb;
+  const [r, g, b] = match.map(n => parseInt(n, 10));
+  if ([r, g, b].some(n => Number.isNaN(n))) return rgb;
   return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
 }
 


### PR DESCRIPTION
## Summary
- export rgbToHex
- add getStripeFieldCss helper for Stripe gateway
- deduplicate style logic and load Google font

## Testing
- `npm test` *(fails: ENETUNREACH for external domains)*

------
https://chatgpt.com/codex/tasks/task_e_688112b1782883259b90271e6b724109