### PR TITLE
Remove lineHeight & opacity from Stripe styles

### DIFF
--- a/storefronts/checkout/checkout.js
+++ b/storefronts/checkout/checkout.js
@@ -8,7 +8,7 @@ if (
   const style = document.createElement('style');
   style.id = 'smoothr-card-styles';
   style.textContent =
-    '[data-smoothr-card-number],\n[data-smoothr-card-expiry],\n[data-smoothr-card-cvc]{display:block;position:relative;}\niframe[data-accept-id]{display:block!important;}';
+    '[data-smoothr-card-number],\n[data-smoothr-card-expiry],\n[data-smoothr-card-cvc]{display:flex;position:relative;align-items:center;justify-content:flex-start;padding:0.25rem 0;}\niframe[data-accept-id]{display:block!important;}';
   document.head.appendChild(style);
 }
 

--- a/storefronts/checkout/gateways/stripe.js
+++ b/storefronts/checkout/gateways/stripe.js
@@ -59,7 +59,7 @@ if (
   const style = document.createElement('style');
   style.id = 'smoothr-card-styles';
   style.textContent =
-    '[data-smoothr-card-number],\n[data-smoothr-card-expiry],\n[data-smoothr-card-cvc]{display:flex;position:relative;align-items:center;justify-content:flex-start;}\niframe[data-accept-id]{display:block!important;}';
+    '[data-smoothr-card-number],\n[data-smoothr-card-expiry],\n[data-smoothr-card-cvc]{display:flex;position:relative;align-items:center;justify-content:flex-start;padding:0.25rem 0;}\niframe[data-accept-id]{display:block!important;}';
   document.head.appendChild(style);
 }
 
@@ -214,7 +214,6 @@ export async function mountCardFields() {
           fontStyle: fieldStyle.fontStyle,
           fontWeight: fieldStyle.fontWeight,
           letterSpacing: fieldStyle.letterSpacing,
-          lineHeight: fieldStyle.lineHeight,
           textAlign: fieldStyle.textAlign,
           textShadow: fieldStyle.textShadow,
           '::placeholder': {
@@ -224,9 +223,7 @@ export async function mountCardFields() {
             fontStyle: placeholderStyle.fontStyle,
             fontWeight: placeholderStyle.fontWeight,
             letterSpacing: placeholderStyle.letterSpacing,
-            lineHeight: placeholderStyle.lineHeight,
-            textAlign: placeholderStyle.textAlign,
-            opacity: placeholderStyle.opacity
+            textAlign: placeholderStyle.textAlign
           }
         },
         invalid: {
@@ -283,7 +280,6 @@ export async function mountCardFields() {
           fontStyle: fieldStyle.fontStyle,
           fontWeight: fieldStyle.fontWeight,
           letterSpacing: fieldStyle.letterSpacing,
-          lineHeight: fieldStyle.lineHeight,
           textAlign: fieldStyle.textAlign,
           textShadow: fieldStyle.textShadow,
           '::placeholder': {
@@ -293,9 +289,7 @@ export async function mountCardFields() {
             fontStyle: placeholderStyle.fontStyle,
             fontWeight: placeholderStyle.fontWeight,
             letterSpacing: placeholderStyle.letterSpacing,
-            lineHeight: placeholderStyle.lineHeight,
-            textAlign: placeholderStyle.textAlign,
-            opacity: placeholderStyle.opacity
+            textAlign: placeholderStyle.textAlign
           }
         },
         invalid: {
@@ -351,7 +345,6 @@ export async function mountCardFields() {
           fontStyle: fieldStyle.fontStyle,
           fontWeight: fieldStyle.fontWeight,
           letterSpacing: fieldStyle.letterSpacing,
-          lineHeight: fieldStyle.lineHeight,
           textAlign: fieldStyle.textAlign,
           textShadow: fieldStyle.textShadow,
           '::placeholder': {
@@ -361,9 +354,7 @@ export async function mountCardFields() {
             fontStyle: placeholderStyle.fontStyle,
             fontWeight: placeholderStyle.fontWeight,
             letterSpacing: placeholderStyle.letterSpacing,
-            lineHeight: placeholderStyle.lineHeight,
-            textAlign: placeholderStyle.textAlign,
-            opacity: placeholderStyle.opacity
+            textAlign: placeholderStyle.textAlign
           }
         },
         invalid: {

--- a/storefronts/core/index.js
+++ b/storefronts/core/index.js
@@ -121,7 +121,7 @@ export default Smoothr;
       const style = document.createElement('style');
       style.id = 'smoothr-card-styles';
       style.textContent =
-        '[data-smoothr-card-number],\n[data-smoothr-card-expiry],\n[data-smoothr-card-cvc]{display:block;position:relative;}\niframe[data-accept-id]{display:block!important;}';
+        '[data-smoothr-card-number],\n[data-smoothr-card-expiry],\n[data-smoothr-card-cvc]{display:flex;position:relative;align-items:center;justify-content:flex-start;padding:0.25rem 0;}\niframe[data-accept-id]{display:block!important;}';
       document.head.appendChild(style);
     }
 


### PR DESCRIPTION
## Summary
- strip `lineHeight` and `opacity` from Stripe Element styles
- add padding in injected CSS for card fields

## Testing
- `npm test` *(fails: Test Files 16 failed | 25 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688158375ad883258409513ac386163a