### PR TITLE
Fix stripe remount logic

### DIFF
--- a/storefronts/checkout/gateways/stripe.js
+++ b/storefronts/checkout/gateways/stripe.js
@@ -242,6 +242,7 @@ export async function mountCardFields() {
         if (iframe && width < 10) {
           warn('iframe dead → remounting now...');
           cardNumberElement?.unmount?.();
+          cardNumberElement?.destroy?.();
           cardNumberElement = elements.create('cardNumber', { style, placeholder: placeholderText });
           cardNumberElement.mount('[data-smoothr-card-number]');
           forceStripeIframeStyle('[data-smoothr-card-number]');
@@ -308,6 +309,7 @@ export async function mountCardFields() {
         if (iframe && width < 10) {
           warn('iframe dead → remounting now...');
           el?.unmount?.();
+          el?.destroy?.();
           const remount = elements.create('cardExpiry', { style, placeholder: placeholderText });
           remount.mount('[data-smoothr-card-expiry]');
           forceStripeIframeStyle('[data-smoothr-card-expiry]');
@@ -373,6 +375,7 @@ export async function mountCardFields() {
         if (iframe && width < 10) {
           warn('iframe dead → remounting now...');
           el?.unmount?.();
+          el?.destroy?.();
           const remount = elements.create('cardCvc', { style, placeholder: placeholderText });
           remount.mount('[data-smoothr-card-cvc]');
           forceStripeIframeStyle('[data-smoothr-card-cvc]');


### PR DESCRIPTION
## Summary
- fully destroy Stripe Elements when remounting

## Testing
- `npm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68815c24a4bc83259f4dd03bf8e14116