### PR TITLE
Fix Stripe iframe height fallback

### DIFF
--- a/storefronts/checkout/gateways/stripe.js
+++ b/storefronts/checkout/gateways/stripe.js
@@ -14,7 +14,16 @@ function forceStripeIframeStyle(selector) {
       iframe.style.top = '0';
       iframe.style.left = '0';
       iframe.style.width = '100%';
-      iframe.style.height = container.offsetHeight + 'px';
+      let height = container.offsetHeight;
+      if (height < 5) {
+        const scroll = container.scrollHeight;
+        if (scroll > height) height = scroll;
+        if (height < 5) {
+          const stored = parseFloat(container.style.minHeight);
+          if (!Number.isNaN(stored) && stored > 0) height = stored;
+        }
+      }
+      iframe.style.height = height + 'px';
       iframe.style.border = 'none';
       iframe.style.background = 'transparent';
       iframe.style.display = 'block';


### PR DESCRIPTION
## Summary
- improve Stripe iframe helper to handle zero-height containers
- use scrollHeight or placeholder height as fallback when forcing styles

## Testing
- `npm test` *(fails: connect ENETUNREACH when tests attempt to fetch external resources)*

------
https://chatgpt.com/codex/tasks/task_e_688160d16bb0832595efd34c1e631748