### PR TITLE
Refactor Stripe styles

### DIFF
--- a/shared/utils/color.js
+++ b/shared/utils/color.js
@@ -1,0 +1,10 @@
+export function rgbToHex(rgb) {
+  if (typeof rgb !== 'string') return rgb;
+  if (rgb.startsWith('#')) return rgb;
+  const match = rgb.match(/\d+/g);
+  if (!match || match.length < 3) return rgb;
+  const [r, g, b] = match.map(Number);
+  return `#${r.toString(16).padStart(2, '0')}${g
+    .toString(16)
+    .padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
+}

--- a/shared/utils/fonts.js
+++ b/shared/utils/fonts.js
@@ -1,0 +1,12 @@
+export function loadGoogleFont(fontFamily) {
+  if (
+    !fontFamily ||
+    document.querySelector(`link[href*="fonts.googleapis.com/css2?family=${fontFamily}"]`)
+  )
+    return;
+  const googleFontString = `${fontFamily}:wght@100;200;300;400;500;600;700;800;900&display=swap`;
+  const link = document.createElement('link');
+  link.href = `https://fonts.googleapis.com/css2?family=${googleFontString}`;
+  link.rel = 'stylesheet';
+  document.head.appendChild(link);
+}

--- a/storefronts/checkout/gateways/stripe.js
+++ b/storefronts/checkout/gateways/stripe.js
@@ -1,48 +1,5 @@
-function rgbToHex(rgb) {
-  const [r, g, b] = rgb.match(/\d+/g).map(Number);
-  return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
-}
-
-function forceStripeIframeStyle(selector) {
-  if (typeof document === 'undefined') return;
-  let attempts = 0;
-  const interval = setInterval(() => {
-    const container = document.querySelector(selector);
-    const iframe = container?.querySelector('iframe');
-    if (iframe && container) {
-      iframe.style.position = 'absolute';
-      iframe.style.top = '0';
-      iframe.style.left = '0';
-      iframe.style.width = '100%';
-      let height = container.offsetHeight;
-      if (height < 5) {
-        const scroll = container.scrollHeight;
-        if (scroll > height) height = scroll;
-        if (height < 5) {
-          const stored = parseFloat(container.style.minHeight);
-          if (!Number.isNaN(stored) && stored > 0) height = stored;
-        }
-      }
-      iframe.style.height = height + 'px';
-      iframe.style.border = 'none';
-      iframe.style.background = 'transparent';
-      iframe.style.display = 'block';
-      iframe.style.opacity = '1';
-      container.style.display = 'flex';
-      container.style.alignItems = 'center';
-      container.style.justifyContent = 'flex-start';
-      container.style.width = '100%';
-      container.style.minWidth = '100%';
-      if (window.getComputedStyle(container).position === 'static') {
-        container.style.position = 'relative';
-      }
-      log(`Forced iframe styles for ${selector}`);
-      clearInterval(interval);
-    } else if (++attempts >= 20) {
-      clearInterval(interval);
-    }
-  }, 100);
-}
+import forceStripeIframeStyle from '../../../utils/iframeStyles.js';
+import { buildStripeElementStyle } from '../../core/payments/stripeStyle.js';
 
 import { supabase } from '../../../shared/supabase/browserClient';
 import { getPublicCredential } from '../getPublicCredential.js';
@@ -147,15 +104,6 @@ export async function getElements() {
   return initPromise;
 }
 
-function loadGoogleFont(fontFamily) {
-  if (!fontFamily || document.querySelector(`link[href*="fonts.googleapis.com/css2?family=${fontFamily}"]`)) return;
-  const googleFontString = `${fontFamily}:wght@100;200;300;400;500;600;700;800;900&display=swap`;
-  const link = document.createElement('link');
-  link.href = `https://fonts.googleapis.com/css2?family=${googleFontString}`;
-  link.rel = 'stylesheet';
-  document.head.appendChild(link);
-  log('Loaded Google font:', googleFontString);
-}
 
 export async function mountCardFields() {
   if (mountPromise) return mountPromise;
@@ -199,48 +147,11 @@ export async function mountCardFields() {
       await waitForInteractable(numberTarget);
       const placeholderEl = numberTarget.querySelector('[data-smoothr-card-placeholder]');
       const placeholderText = placeholderEl ? placeholderEl.textContent.trim() : 'Card Number';
-      const fieldStyle = window.getComputedStyle(numberTarget);
-      let placeholderStyle;
-      if (placeholderEl) {
-        placeholderStyle = window.getComputedStyle(placeholderEl);
-      } else if (emailInput) {
-        placeholderStyle = window.getComputedStyle(emailInput, '::placeholder');
-      } else {
-        placeholderStyle = fieldStyle;
-      }
-      const placeholderColorHex = rgbToHex(placeholderStyle.color);
-      const fontFamilyClean = (placeholderStyle.fontFamily || fieldStyle.fontFamily)
-        .split(',')[0]
-        .trim()
-        .replace(/"/g, '');
-      loadGoogleFont(fontFamilyClean);
-      const style = {
-        base: {
-          backgroundColor: 'transparent',
-          color: fieldStyle.color,
-          fontFamily: fieldStyle.fontFamily,
-          fontSize: fieldStyle.fontSize,
-          fontStyle: fieldStyle.fontStyle,
-          fontWeight: fieldStyle.fontWeight,
-          letterSpacing: fieldStyle.letterSpacing,
-          lineHeight: fieldStyle.lineHeight,
-          textAlign: fieldStyle.textAlign,
-          textShadow: fieldStyle.textShadow,
-          '::placeholder': {
-            color: placeholderColorHex,
-            fontFamily: placeholderStyle.fontFamily,
-            fontSize: placeholderStyle.fontSize,
-            fontStyle: placeholderStyle.fontStyle,
-            fontWeight: placeholderStyle.fontWeight,
-            letterSpacing: placeholderStyle.letterSpacing,
-            lineHeight: placeholderStyle.lineHeight,
-            textAlign: placeholderStyle.textAlign
-          }
-        },
-        invalid: {
-          color: '#fa755a'
-        }
-      };
+      const style = buildStripeElementStyle(
+        numberTarget,
+        '[data-smoothr-card-placeholder]',
+        'Card Number'
+      );
       log('cardNumber style', style);
       const el = elements.create('cardNumber', { style, placeholder: placeholderText });
       el.mount('[data-smoothr-card-number]');
@@ -275,48 +186,11 @@ export async function mountCardFields() {
       await waitForInteractable(expiryTarget);
       const placeholderEl = expiryTarget.querySelector('[data-smoothr-expiry-placeholder]');
       const placeholderText = placeholderEl ? placeholderEl.textContent.trim() : 'MM/YY';
-      const fieldStyle = window.getComputedStyle(expiryTarget);
-      let placeholderStyle;
-      if (placeholderEl) {
-        placeholderStyle = window.getComputedStyle(placeholderEl);
-      } else if (emailInput) {
-        placeholderStyle = window.getComputedStyle(emailInput, '::placeholder');
-      } else {
-        placeholderStyle = fieldStyle;
-      }
-      const placeholderColorHex = rgbToHex(placeholderStyle.color);
-      const fontFamilyClean = (placeholderStyle.fontFamily || fieldStyle.fontFamily)
-        .split(',')[0]
-        .trim()
-        .replace(/"/g, '');
-      loadGoogleFont(fontFamilyClean);
-      const style = {
-        base: {
-          backgroundColor: 'transparent',
-          color: fieldStyle.color,
-          fontFamily: fieldStyle.fontFamily,
-          fontSize: fieldStyle.fontSize,
-          fontStyle: fieldStyle.fontStyle,
-          fontWeight: fieldStyle.fontWeight,
-          letterSpacing: fieldStyle.letterSpacing,
-          lineHeight: fieldStyle.lineHeight,
-          textAlign: fieldStyle.textAlign,
-          textShadow: fieldStyle.textShadow,
-          '::placeholder': {
-            color: placeholderColorHex,
-            fontFamily: placeholderStyle.fontFamily,
-            fontSize: placeholderStyle.fontSize,
-            fontStyle: placeholderStyle.fontStyle,
-            fontWeight: placeholderStyle.fontWeight,
-            letterSpacing: placeholderStyle.letterSpacing,
-            lineHeight: placeholderStyle.lineHeight,
-            textAlign: placeholderStyle.textAlign
-          }
-        },
-        invalid: {
-          color: '#fa755a'
-        }
-      };
+      const style = buildStripeElementStyle(
+        expiryTarget,
+        '[data-smoothr-expiry-placeholder]',
+        'MM/YY'
+      );
       log('cardExpiry style', style);
       const el = elements.create('cardExpiry', { style, placeholder: placeholderText });
       el.mount('[data-smoothr-card-expiry]');
@@ -350,48 +224,11 @@ export async function mountCardFields() {
       await waitForInteractable(cvcTarget);
       const placeholderEl = cvcTarget.querySelector('[data-smoothr-cvv-placeholder]');
       const placeholderText = placeholderEl ? placeholderEl.textContent.trim() : 'CVC';
-      const fieldStyle = window.getComputedStyle(cvcTarget);
-      let placeholderStyle;
-      if (placeholderEl) {
-        placeholderStyle = window.getComputedStyle(placeholderEl);
-      } else if (emailInput) {
-        placeholderStyle = window.getComputedStyle(emailInput, '::placeholder');
-      } else {
-        placeholderStyle = fieldStyle;
-      }
-      const placeholderColorHex = rgbToHex(placeholderStyle.color);
-      const fontFamilyClean = (placeholderStyle.fontFamily || fieldStyle.fontFamily)
-        .split(',')[0]
-        .trim()
-        .replace(/"/g, '');
-      loadGoogleFont(fontFamilyClean);
-      const style = {
-        base: {
-          backgroundColor: 'transparent',
-          color: fieldStyle.color,
-          fontFamily: fieldStyle.fontFamily,
-          fontSize: fieldStyle.fontSize,
-          fontStyle: fieldStyle.fontStyle,
-          fontWeight: fieldStyle.fontWeight,
-          letterSpacing: fieldStyle.letterSpacing,
-          lineHeight: fieldStyle.lineHeight,
-          textAlign: fieldStyle.textAlign,
-          textShadow: fieldStyle.textShadow,
-          '::placeholder': {
-            color: placeholderColorHex,
-            fontFamily: placeholderStyle.fontFamily,
-            fontSize: placeholderStyle.fontSize,
-            fontStyle: placeholderStyle.fontStyle,
-            fontWeight: placeholderStyle.fontWeight,
-            letterSpacing: placeholderStyle.letterSpacing,
-            lineHeight: placeholderStyle.lineHeight,
-            textAlign: placeholderStyle.textAlign
-          }
-        },
-        invalid: {
-          color: '#fa755a'
-        }
-      };
+      const style = buildStripeElementStyle(
+        cvcTarget,
+        '[data-smoothr-cvv-placeholder]',
+        'CVC'
+      );
       log('cardCvc style', style);
       const el = elements.create('cardCvc', { style, placeholder: placeholderText });
       el.mount('[data-smoothr-card-cvc]');

--- a/storefronts/core/payments/stripeStyle.js
+++ b/storefronts/core/payments/stripeStyle.js
@@ -1,0 +1,54 @@
+import { rgbToHex } from '../../../shared/utils/color.js';
+import { loadGoogleFont } from '../../../shared/utils/fonts.js';
+
+export function buildStripeElementStyle(targetEl, placeholderSelector, defaultPlaceholder) {
+  const placeholderEl = targetEl.querySelector(placeholderSelector);
+  const fieldStyle = window.getComputedStyle(targetEl);
+  let placeholderStyle;
+  if (placeholderEl) {
+    placeholderStyle = window.getComputedStyle(placeholderEl);
+  } else {
+    const emailInput = document.querySelector('[data-smoothr-email]');
+    if (emailInput) {
+      placeholderStyle = window.getComputedStyle(emailInput, '::placeholder');
+    } else {
+      placeholderStyle = fieldStyle;
+    }
+  }
+  const placeholderColorHex = rgbToHex(placeholderStyle.color);
+  const fontFamilyClean = (placeholderStyle.fontFamily || fieldStyle.fontFamily)
+    .split(',')[0]
+    .trim()
+    .replace(/"/g, '');
+  loadGoogleFont(fontFamilyClean);
+  const style = {
+    base: {
+      backgroundColor: 'transparent',
+      color: fieldStyle.color,
+      fontFamily: fieldStyle.fontFamily,
+      fontSize: fieldStyle.fontSize,
+      fontStyle: fieldStyle.fontStyle,
+      fontWeight: fieldStyle.fontWeight,
+      letterSpacing: fieldStyle.letterSpacing,
+      lineHeight: fieldStyle.lineHeight,
+      textAlign: fieldStyle.textAlign,
+      textShadow: fieldStyle.textShadow,
+      '::placeholder': {
+        color: placeholderColorHex,
+        fontFamily: placeholderStyle.fontFamily,
+        fontSize: placeholderStyle.fontSize,
+        fontStyle: placeholderStyle.fontStyle,
+        fontWeight: placeholderStyle.fontWeight,
+        letterSpacing: placeholderStyle.letterSpacing,
+        lineHeight: placeholderStyle.lineHeight,
+        textAlign: placeholderStyle.textAlign
+      }
+    },
+    invalid: {
+      color: '#fa755a'
+    }
+  };
+  const debug = window.SMOOTHR_CONFIG?.debug;
+  if (debug) console.log('[Smoothr Stripe] style built for', placeholderSelector);
+  return style;
+}

--- a/storefronts/tests/sdk/stripe-mount.test.js
+++ b/storefronts/tests/sdk/stripe-mount.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 let styleSpy = vi.fn();
 let getCredMock;
-vi.mock('../../checkout/gateways/forceStripeIframeStyle.js', () => ({
+vi.mock('../../../utils/iframeStyles.js', () => ({
   default: (...args) => styleSpy(...args)
 }));
 vi.mock('../../checkout/getPublicCredential.js', () => ({

--- a/utils/iframeStyles.js
+++ b/utils/iframeStyles.js
@@ -1,0 +1,39 @@
+export default function forceStripeIframeStyle(selector, attempts = 20, interval = 100) {
+  if (typeof document === 'undefined') return;
+  let count = 0;
+  const timer = setInterval(() => {
+    const container = document.querySelector(selector);
+    const iframe = container?.querySelector('iframe');
+    if (iframe && container) {
+      iframe.style.position = 'absolute';
+      iframe.style.top = '0';
+      iframe.style.left = '0';
+      iframe.style.width = '100%';
+      let height = container.offsetHeight;
+      if (height < 5) {
+        const scroll = container.scrollHeight;
+        if (scroll > height) height = scroll;
+        if (height < 5) {
+          const stored = parseFloat(container.style.minHeight);
+          if (!Number.isNaN(stored) && stored > 0) height = stored;
+        }
+      }
+      iframe.style.height = height + 'px';
+      iframe.style.border = 'none';
+      iframe.style.background = 'transparent';
+      iframe.style.display = 'block';
+      iframe.style.opacity = '1';
+      container.style.display = 'flex';
+      container.style.alignItems = 'center';
+      container.style.justifyContent = 'flex-start';
+      container.style.width = '100%';
+      container.style.minWidth = '100%';
+      if (window.getComputedStyle(container).position === 'static') {
+        container.style.position = 'relative';
+      }
+      clearInterval(timer);
+    } else if (++count >= attempts) {
+      clearInterval(timer);
+    }
+  }, interval);
+}


### PR DESCRIPTION
## Summary
- extract a reusable `buildStripeElementStyle()` helper
- move color, font and iframe utilities to shared modules
- update Stripe gateway to use new helper
- adjust Stripe iframe style tests

## Testing
- `npm run bundle:webflow-checkout`
- `npm test` *(fails: Missing data-store-id / network errors)*

------
https://chatgpt.com/codex/tasks/task_e_6881f92bb9c48325aea137ca83a9598e