### PR TITLE
Mount card fields on checkout init

### DIFF
--- a/storefronts/checkout/checkout.js
+++ b/storefronts/checkout/checkout.js
@@ -81,24 +81,18 @@ export async function initCheckout(config) {
   if (!emailField) emailField = await select('[data-smoothr-email]');
   const totalEl = await select('[data-smoothr-total]');
 
-  // attempt to mount card fields (for non-NMI gateways too)
-  let attempts = 0;
-  while (attempts < 2 && !gateway.isMounted()) {
-    try {
-      await new Promise((resolve, reject) => {
-        window.requestAnimationFrame(() => {
-          gateway.mountCardFields().then(resolve).catch(reject);
-        });
+  // attempt to mount card fields once on init
+  window.requestAnimationFrame(() => {
+    console.log('[Smoothr Stripe] scheduling mountCardFields on load');
+    gateway
+      .mountCardFields()
+      .then(() => {
+        console.log('[Smoothr Stripe] mountCardFields complete');
+      })
+      .catch(err => {
+        console.warn('[Smoothr Stripe] mountCardFields failed:', err);
       });
-    } catch (e) {
-      warn('Mount failed:', e.message);
-    }
-    attempts++;
-  }
-  if (!gateway.isMounted()) {
-    warn('Gateway mount failed');
-    return;
-  }
+  });
   bindCardInputs();
 
   // NMI handles its own click flow

--- a/storefronts/checkout/gateways/stripe.js
+++ b/storefronts/checkout/gateways/stripe.js
@@ -9,6 +9,8 @@ const debug = window.SMOOTHR_CONFIG?.debug;
 const log = (...args) => debug && console.log('[Smoothr Stripe]', ...args);
 const warn = (...args) => debug && console.warn('[Smoothr Stripe]', ...args);
 
+log('[Smoothr Stripe] checkout gateway module loaded');
+
 log('[Smoothr Stripe] checkout gateway loaded');
 
 let fieldsMounted = false;


### PR DESCRIPTION
## Summary
- log Stripe gateway module load
- mount card fields in requestAnimationFrame when checkout starts

## Testing
- `npm test` *(fails: vitest could not finish due to network errors)*

------
https://chatgpt.com/codex/tasks/task_e_688205b1642c8325a048ce05e0a89668