### PR TITLE
Remove unused variables from Stripe gateway

### DIFF
--- a/storefronts/checkout/gateways/stripe.js
+++ b/storefronts/checkout/gateways/stripe.js
@@ -15,7 +15,6 @@ log('[Smoothr Stripe] checkout gateway module loaded');
 log('[Smoothr Stripe] checkout gateway loaded');
 
 let fieldsMounted = false;
-let mountAttempts = 0;
 let stripe;
 let elements;
 let initPromise;
@@ -136,8 +135,6 @@ export async function mountCardFields() {
     coreLog('querySelector', cvcSel);
     const cvcTarget = document.querySelector(cvcSel);
     coreLog('→', cvcTarget);
-
-    const emailInput = document.querySelector('[data-smoothr-email]');
 
     coreLog('Targets found', {
       number: !!numberTarget,


### PR DESCRIPTION
## Summary
- tidy unused variables in Stripe gateway
- `mountAttempts` and `emailInput` constants removed

## Testing
- `npm test` *(fails: ENETUNREACH network errors)*

------
https://chatgpt.com/codex/tasks/task_e_68820ae60c2c8325a1de56763fe13099