### PR TITLE
Expose gateway on window

### DIFF
--- a/storefronts/checkout/checkout.js
+++ b/storefronts/checkout/checkout.js
@@ -59,6 +59,10 @@ export async function initCheckout(config) {
   const gateway = (await loader()).default;
   log(`Using gateway: ${provider}`);
 
+  // Hook our gateway onto the existing global namespace for easy manual calls
+  window.SMOOTHR = window.SMOOTHR || {};
+  window.SMOOTHR.gateway = gateway;
+
   // assign gateway methods to global namespace
   window.Smoothr = window.Smoothr || window.smoothr || {};
   window.smoothr = window.Smoothr;


### PR DESCRIPTION
## Summary
- attach the selected payment gateway to `window.SMOOTHR` so it can be used manually

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run bundle:webflow-checkout` *(fails: cannot find module 'esbuild')*

------
https://chatgpt.com/codex/tasks/task_e_6882102ee7ac8325bcde38d6a1b250ce