### PR TITLE
Respect basicStripeStyle flag for card styles

### DIFF
--- a/storefronts/checkout/checkout.js
+++ b/storefronts/checkout/checkout.js
@@ -1,6 +1,8 @@
 // checkout.js
 
 if (
+  typeof window !== 'undefined' &&
+  !window.SMOOTHR_CONFIG?.basicStripeStyle &&
   typeof document !== 'undefined' &&
   typeof document.createElement === 'function' &&
   !document.querySelector('#smoothr-card-styles')

--- a/storefronts/core/index.js
+++ b/storefronts/core/index.js
@@ -116,6 +116,7 @@ export default Smoothr;
     if (
       typeof document !== 'undefined' &&
       typeof document.createElement === 'function' &&
+      !window.SMOOTHR_CONFIG?.basicStripeStyle &&
       !document.querySelector('#smoothr-card-styles')
     ) {
       const style = document.createElement('style');

--- a/storefronts/tests/sdk/style-injection.test.js
+++ b/storefronts/tests/sdk/style-injection.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+let appendSpy;
+
+beforeEach(() => {
+  vi.resetModules();
+  appendSpy = vi.fn();
+  global.document = {
+    createElement: vi.fn(() => ({})),
+    querySelector: vi.fn(() => null),
+    head: { appendChild: appendSpy }
+  };
+  global.window = { SMOOTHR_CONFIG: { basicStripeStyle: true } };
+});
+
+describe('card style injection', () => {
+  it('skips style element when basicStripeStyle is true', async () => {
+    await import('../../checkout/checkout.js');
+    expect(appendSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- skip injecting card style blocks when `basicStripeStyle` is enabled
- test that style block isn't injected when the flag is true

## Testing
- `npm test` *(fails: ENETUNREACH errors)*

------
https://chatgpt.com/codex/tasks/task_e_6882175380748325975bec4f14b8c705