### PR TITLE
Fix stripe iframe height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Simplified test commands so running `npm test` from the repository root executes all package tests.
 - Documented Supabase testing instructions including the `OPENEXCHANGERATES_TOKEN` requirement.
 - Fixed Stripe iframe width issues using the `forceStripeIframeStyle` helper.
+- Improved `forceStripeIframeStyle` to also enforce height and respect placeholder `min-height`/`max-height`.
 - Added logging for Authorize.Net Accept.js responses and a timeout warning if dispatchData does not fire.
 - Sanitized Authorize.Net card fields before tokenization.
 - Added client-side formatting for Webflow card number, expiry and CVC inputs.

--- a/storefronts/checkout/utils/forceStripeIframeStyle.js
+++ b/storefronts/checkout/utils/forceStripeIframeStyle.js
@@ -5,13 +5,26 @@ export default function forceStripeIframeStyle(selector) {
     const container = document.querySelector(selector);
     const iframe = container?.querySelector('iframe');
     if (iframe) {
+      const cs = container ? window.getComputedStyle(container) : null;
       iframe.style.width = '100%';
       iframe.style.minWidth = '100%';
       iframe.style.display = 'block';
       iframe.style.opacity = '1';
+      if (cs) {
+        iframe.style.height = cs.height || '100%';
+        if (cs.minHeight && cs.minHeight !== '0px') iframe.style.minHeight = cs.minHeight;
+        if (cs.maxHeight && cs.maxHeight !== 'none') iframe.style.maxHeight = cs.maxHeight;
+      } else {
+        iframe.style.height = '100%';
+      }
       if (container) {
         container.style.width = '100%';
         container.style.minWidth = '100%';
+        if (cs) {
+          container.style.height = cs.height;
+          if (cs.minHeight && cs.minHeight !== '0px') container.style.minHeight = cs.minHeight;
+          if (cs.maxHeight && cs.maxHeight !== 'none') container.style.maxHeight = cs.maxHeight;
+        }
         if (
           typeof window !== 'undefined' &&
           window.getComputedStyle(container).position === 'static'

--- a/storefronts/platforms/README.md
+++ b/storefronts/platforms/README.md
@@ -109,7 +109,7 @@ If any required billing fields are missing the browser console logs:
 
 ## forceStripeIframeStyle helper
 
-The checkout adapter exposes `forceStripeIframeStyle()`, which runs automatically right after `.mount()` on each Stripe card field. It fixes the notorious “1px iframe bug” that can appear in flexbox layouts by forcing the Stripe Elements iframe to remain at `100%` width.
+The checkout adapter exposes `forceStripeIframeStyle()`, which runs automatically right after `.mount()` on each Stripe card field. It fixes the notorious “1px iframe bug” that can appear in flexbox layouts by forcing the Stripe Elements iframe to remain at `100%` width and height. The helper also mirrors any `height`, `min-height` and `max-height` values from your Webflow placeholder divs onto the iframe.
 Stripe Elements automatically inherit font and color styles from their container, so extra CSS is rarely needed.
 
 


### PR DESCRIPTION
## Summary
- ensure forceStripeIframeStyle also mirrors height settings
- document the helper's height support
- note the fix in the changelog

## Testing
- `npm test` *(fails: vitest tests fail due to blocked network fetches)*

------
https://chatgpt.com/codex/tasks/task_e_688222a51718832583acb9c4d284dc85