### PR TITLE
Fix Stripe iframe height handling

### DIFF
--- a/storefronts/checkout/utils/forceStripeIframeStyle.js
+++ b/storefronts/checkout/utils/forceStripeIframeStyle.js
@@ -11,17 +11,34 @@ export default function forceStripeIframeStyle(selector) {
       iframe.style.display = 'block';
       iframe.style.opacity = '1';
       if (cs) {
-        iframe.style.height = cs.height || '100%';
+        const rectHeight = container.getBoundingClientRect().height;
+        const h = cs.height;
+        const height =
+          h && h !== 'auto' && h !== '0px'
+            ? h
+            : rectHeight
+            ? `${rectHeight}px`
+            : '100%';
+        iframe.style.height = height;
         if (cs.minHeight && cs.minHeight !== '0px') iframe.style.minHeight = cs.minHeight;
         if (cs.maxHeight && cs.maxHeight !== 'none') iframe.style.maxHeight = cs.maxHeight;
       } else {
-        iframe.style.height = '100%';
+        const rectHeight = container.getBoundingClientRect().height;
+        iframe.style.height = rectHeight ? `${rectHeight}px` : '100%';
       }
       if (container) {
         container.style.width = '100%';
         container.style.minWidth = '100%';
         if (cs) {
-          container.style.height = cs.height;
+          const rectHeight = container.getBoundingClientRect().height;
+          const h = cs.height;
+          const height =
+            h && h !== 'auto' && h !== '0px'
+              ? h
+              : rectHeight
+              ? `${rectHeight}px`
+              : '100%';
+          container.style.height = height;
           if (cs.minHeight && cs.minHeight !== '0px') container.style.minHeight = cs.minHeight;
           if (cs.maxHeight && cs.maxHeight !== 'none') container.style.maxHeight = cs.maxHeight;
         }
@@ -32,7 +49,9 @@ export default function forceStripeIframeStyle(selector) {
           container.style.position = 'relative';
         }
       }
-      console.log(`[Smoothr Stripe] Forced iframe styles for ${selector}`);
+      if (window.SMOOTHR_CONFIG?.debug) {
+        console.log(`[Smoothr Stripe] Forced iframe styles for ${selector}`);
+      }
       clearInterval(interval);
     } else if (++attempts >= 20) {
       clearInterval(interval);


### PR DESCRIPTION
## Summary
- enforce valid iframe and container height in `forceStripeIframeStyle`
- wrap logging behind `SMOOTHR_CONFIG.debug`
- fallback to container bounding box height when needed

## Testing
- `npm test` *(fails: vitest run errors)*

------
https://chatgpt.com/codex/tasks/task_e_68822732e26c83259152b789bc2e98db