### PR TITLE
Add querySelector to document mock

### DIFF
--- a/storefronts/vitest.setup.js
+++ b/storefronts/vitest.setup.js
@@ -18,6 +18,7 @@ if (typeof globalThis.window.removeEventListener === "undefined") {
 if (typeof globalThis.document === "undefined") {
   globalThis.document = {
     addEventListener: vi.fn(),
+    querySelector: vi.fn(() => null),
     querySelectorAll: vi.fn(() => []),
     body: {},
     dispatchEvent: vi.fn(),


### PR DESCRIPTION
## Summary
- return `null` by default from the document mock `querySelector` stub

## Testing
- `npm test` *(fails: ENETUNREACH and other unhandled errors)*

------
https://chatgpt.com/codex/tasks/task_e_688242350f9c8325bec38bcced562906