### PR TITLE
Fix chainable supabase mock

### DIFF
--- a/storefronts/tests/providers/provider-handleCheckout-settings-error.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-settings-error.test.ts
@@ -36,7 +36,7 @@ vi.mock('../../../shared/supabase/serverClient', () => {
         return {
           select: vi.fn(() => ({
             eq: vi.fn(() => ({
-              eq: vi.fn(() => ({ single: vi.fn(async () => ({ data: null, error: null })) }))
+              eq: vi.fn(() => ({ limit: vi.fn(async () => ({ data: [], error: null })) }))
             }))
           }))
         };


### PR DESCRIPTION
## Summary
- update Supabase mock for customer profiles so `limit` returns a promise

## Testing
- `npm test` *(fails: ENETUNREACH errors and other vitest failures)*

------
https://chatgpt.com/codex/tasks/task_e_6882449974d883259588001b85cc2789