### PR TITLE
Initialize default SMOOTHR config when storeId missing

### DIFF
--- a/storefronts/README.md
+++ b/storefronts/README.md
@@ -40,6 +40,11 @@ When the SDK loads it fetches your store settings from Supabase. Any
 window.SMOOTHR_CONFIG.apiBase; // => 'https://example.com'
 ```
 
+If the SDK loads without a `data-store-id` attribute—such as when running
+tests—it exits early after creating an empty `window.SMOOTHR_CONFIG` object if
+one was not already defined. This ensures modules can run in isolation without
+errors during setup.
+
 ## Core modules
 
 - abandoned-cart

--- a/storefronts/core/index.js
+++ b/storefronts/core/index.js
@@ -106,6 +106,10 @@ export default Smoothr;
   console.log('[Smoothr SDK] Bootstrap triggered', { storeId });
 
   if (!storeId) {
+    // Ensure global config exists for tests and non-SDK modules
+    if (typeof window !== 'undefined' && !window.SMOOTHR_CONFIG) {
+      window.SMOOTHR_CONFIG = {};
+    }
     if (typeof process !== 'undefined' && process.env.NODE_ENV === 'test') {
       return;
     }

--- a/storefronts/tests/sdk/init-config-default.test.js
+++ b/storefronts/tests/sdk/init-config-default.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('../../core/auth/index.js', () => ({ initAuth: vi.fn(), user: null }));
+
+beforeEach(() => {
+  vi.resetModules();
+  global.fetch = vi.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve({ rates: {} }) })
+  );
+  global.window = {
+    location: { origin: '', href: '', hostname: '' },
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  };
+  global.document = {
+    addEventListener: vi.fn(),
+    querySelectorAll: vi.fn(() => []),
+    querySelector: vi.fn(() => null),
+  };
+  Object.defineProperty(global.document, 'currentScript', {
+    value: { dataset: {} },
+    writable: true,
+    configurable: true,
+  });
+  delete global.window.SMOOTHR_CONFIG;
+});
+
+afterEach(() => {
+  Object.defineProperty(global.document, 'currentScript', {
+    value: { dataset: { storeId: '00000000-0000-0000-0000-000000000000' } },
+    writable: true,
+    configurable: true,
+  });
+  delete global.window.SMOOTHR_CONFIG;
+});
+
+describe('initSmoothr with missing storeId', () => {
+  it('creates an empty SMOOTHR_CONFIG object', async () => {
+    await import('../../core/index.js');
+    expect(global.window.SMOOTHR_CONFIG).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `window.SMOOTHR_CONFIG` exists when the SDK boots without a `storeId`
- mention the early exit behaviour in the storefront README
- add regression test for missing `storeId`

## Testing
- `npm test` *(fails: connect ENETUNREACH 104.192.33.49:443)*

------
https://chatgpt.com/codex/tasks/task_e_688246610d54832582734b775853dbbc