### PR TITLE
Update checkout provider mocks

### DIFF
--- a/storefronts/tests/providers/provider-handleCheckout-authorizeNet.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-authorizeNet.test.ts
@@ -26,6 +26,18 @@ vi.mock('../../../shared/supabase/serverClient', () => {
               }))
             };
           }
+          if (storeFromCall === 2) {
+            return {
+              select: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  maybeSingle: vi.fn(async () => ({
+                    data: { prefix: 'ST', order_sequence: 1 },
+                    error: null
+                  }))
+                }))
+              }))
+            };
+          }
           return {};
         }
         if (table === 'store_settings') {
@@ -33,6 +45,15 @@ vi.mock('../../../shared/supabase/serverClient', () => {
             select: vi.fn(() => ({
               eq: vi.fn(() => ({
                 maybeSingle: vi.fn(async () => ({ data: { settings: { active_payment_gateway: 'authorizeNet' } }, error: null }))
+              }))
+            }))
+          };
+        }
+        if (table === 'customer_payment_profiles') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                eq: vi.fn(() => ({ limit: vi.fn(async () => ({ data: [], error: null })) }))
               }))
             }))
           };

--- a/storefronts/tests/providers/provider-handleCheckout-nmi-missing-token.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-nmi-missing-token.test.ts
@@ -14,20 +14,46 @@ vi.mock('../../../smoothr/lib/findOrCreateCustomer.ts', () => {
 });
 
 vi.mock('../../../shared/supabase/serverClient', () => {
+  let storeFromCall = 0;
   const client = {
     from: (table: string) => {
         if (table === 'stores') {
-          return {
-            select: vi.fn(() => ({
-              eq: vi.fn(async () => ({ data: [{ id: 'store-1' }], error: null }))
-            }))
-          };
+          storeFromCall++;
+          if (storeFromCall === 1) {
+            return {
+              select: vi.fn(() => ({
+                eq: vi.fn(async () => ({ data: [{ id: 'store-1' }], error: null }))
+              }))
+            };
+          }
+          if (storeFromCall === 2) {
+            return {
+              select: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  maybeSingle: vi.fn(async () => ({
+                    data: { prefix: 'ST', order_sequence: 1 },
+                    error: null
+                  }))
+                }))
+              }))
+            };
+          }
+          return {};
         }
         if (table === 'store_settings') {
           return {
             select: vi.fn(() => ({
               eq: vi.fn(() => ({
                 maybeSingle: vi.fn(async () => ({ data: { settings: { active_payment_gateway: 'nmi' } }, error: null }))
+              }))
+            }))
+          };
+        }
+        if (table === 'customer_payment_profiles') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                eq: vi.fn(() => ({ limit: vi.fn(async () => ({ data: [], error: null })) }))
               }))
             }))
           };

--- a/storefronts/tests/providers/provider-handleCheckout-nmi.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-nmi.test.ts
@@ -54,6 +54,15 @@ vi.mock('../../../shared/supabase/serverClient', () => {
             }))
           };
         }
+        if (table === 'customer_payment_profiles') {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                eq: vi.fn(() => ({ limit: vi.fn(async () => ({ data: [], error: null })) }))
+              }))
+            }))
+          };
+        }
         if (table === 'orders') {
           ordersCall++;
           if (ordersCall === 1) {

--- a/storefronts/tests/providers/provider-handleCheckout-settings-error.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-settings-error.test.ts
@@ -14,14 +14,31 @@ vi.mock('../../../smoothr/lib/findOrCreateCustomer.ts', () => {
 });
 
 vi.mock('../../../shared/supabase/serverClient', () => {
+  let storeFromCall = 0;
   const client = {
     from: (table: string) => {
       if (table === 'stores') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn(async () => ({ data: [{ id: 'store-1' }], error: null }))
-          }))
-        };
+        storeFromCall++;
+        if (storeFromCall === 1) {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(async () => ({ data: [{ id: 'store-1' }], error: null }))
+            }))
+          };
+        }
+        if (storeFromCall === 2) {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                maybeSingle: vi.fn(async () => ({
+                  data: { prefix: 'ST', order_sequence: 1 },
+                  error: null
+                }))
+              }))
+            }))
+          };
+        }
+        return {};
       }
       if (table === 'store_settings') {
         return {

--- a/storefronts/tests/providers/provider-handleCheckout-unsupported.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-unsupported.test.ts
@@ -8,14 +8,31 @@ vi.mock('../../../smoothr/lib/findOrCreateCustomer.ts', () => {
 });
 
 vi.mock('../../../shared/supabase/serverClient', () => {
+  let storeFromCall = 0;
   const client = {
     from: (table: string) => {
       if (table === 'stores') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn(async () => ({ data: [{ id: 'store-1' }], error: null }))
-          }))
-        };
+        storeFromCall++;
+        if (storeFromCall === 1) {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(async () => ({ data: [{ id: 'store-1' }], error: null }))
+            }))
+          };
+        }
+        if (storeFromCall === 2) {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                maybeSingle: vi.fn(async () => ({
+                  data: { prefix: 'ST', order_sequence: 1 },
+                  error: null
+                }))
+              }))
+            }))
+          };
+        }
+        return {};
       }
       if (table === 'store_settings') {
         return {


### PR DESCRIPTION
## Summary
- improve `customer_payment_profiles` mocks in provider checkout tests
- mock second `stores` query for prefix/order sequence

## Testing
- `npm test` *(fails: ENETUNREACH errors)*

------
https://chatgpt.com/codex/tasks/task_e_68825ea7d72883258b210a2e12389e7f