### PR TITLE
Fix supabase client options for test env

### DIFF
--- a/shared/supabase/browserClient.ts
+++ b/shared/supabase/browserClient.ts
@@ -1,8 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+const options = process.env.NODE_ENV === 'test'
+  ? { auth: { autoRefreshToken: false, persistSession: false } }
+  : {};
+
+const supabase = createClient(url, key, options);
 
 export { supabase };


### PR DESCRIPTION
## Summary
- ensure browser client disables auth token refresh/persist in tests

## Testing
- `npm test` *(fails: Vitest tests show multiple failures)*

------
https://chatgpt.com/codex/tasks/task_e_6882630d6f2083259b742b5ac80571af