### PR TITLE
Fix checkout tagName handling

### DIFF
--- a/storefronts/checkout/checkout.js
+++ b/storefronts/checkout/checkout.js
@@ -103,7 +103,7 @@ export async function initCheckout(config) {
     return;
   }
 
-  const isForm = checkoutEl.tagName.toLowerCase() === 'form';
+  const isForm = (checkoutEl.tagName || '').toLowerCase() === 'form';
   const eventName = isForm ? 'submit' : 'click';
 
   payButtons.forEach(btn => {

--- a/storefronts/dist/platforms/webflow/checkout.js
+++ b/storefronts/dist/platforms/webflow/checkout.js
@@ -9505,7 +9505,7 @@ async function initCheckout(config) {
     log4("Skipping shared click binding for NMI");
     return;
   }
-  const isForm = checkoutEl.tagName.toLowerCase() === "form";
+  const isForm = (checkoutEl.tagName || "").toLowerCase() === "form";
   const eventName = isForm ? "submit" : "click";
   payButtons.forEach((btn) => {
     btn.addEventListener(eventName, async (e) => {


### PR DESCRIPTION
## Summary
- guard checkout element tagName lookup so tests don't break

## Testing
- `npm test` *(fails: blocked network requests)*

------
https://chatgpt.com/codex/tasks/task_e_688264b4996c83258da42b7a19f49c95