### PR TITLE
Fix document.currentScript stub in config tests

### DIFF
--- a/storefronts/tests/sdk/load-config-api-base.test.js
+++ b/storefronts/tests/sdk/load-config-api-base.test.js
@@ -24,6 +24,11 @@ beforeEach(() => {
     querySelectorAll: vi.fn(() => []),
     querySelector: vi.fn(() => null)
   };
+  Object.defineProperty(global.document, 'currentScript', {
+    value: { dataset: { storeId: '00000000-0000-0000-0000-000000000000' } },
+    writable: true,
+    configurable: true
+  });
   global.localStorage = {
     getItem: vi.fn(),
     setItem: vi.fn(),

--- a/storefronts/tests/sdk/load-config-merge.test.js
+++ b/storefronts/tests/sdk/load-config-merge.test.js
@@ -25,6 +25,11 @@ beforeEach(() => {
     querySelectorAll: vi.fn(() => []),
     querySelector: vi.fn(() => null)
   };
+  Object.defineProperty(global.document, 'currentScript', {
+    value: { dataset: { storeId: '00000000-0000-0000-0000-000000000000' } },
+    writable: true,
+    configurable: true
+  });
   global.localStorage = {
     getItem: vi.fn(),
     setItem: vi.fn(),

--- a/storefronts/tests/sdk/smoothr-config.test.js
+++ b/storefronts/tests/sdk/smoothr-config.test.js
@@ -25,6 +25,11 @@ beforeEach(() => {
     querySelectorAll: vi.fn(() => []),
     querySelector: vi.fn(() => null),
   };
+  Object.defineProperty(global.document, 'currentScript', {
+    value: { dataset: { storeId: '00000000-0000-0000-0000-000000000000' } },
+    writable: true,
+    configurable: true,
+  });
   global.localStorage = {
     getItem: vi.fn(),
     setItem: vi.fn(),


### PR DESCRIPTION
## Summary
- stub `document.currentScript` when replacing `document` in config tests

## Testing
- `npm test --silent` *(fails: 9 failed, 94 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688269a0eacc832587c45304535ccc51