### PR TITLE
Prefer config stripe key

### DIFF
--- a/storefronts/checkout/gateways/stripe.js
+++ b/storefronts/checkout/gateways/stripe.js
@@ -63,6 +63,12 @@ export async function waitForInteractable(el, timeout = 1500) {
 
 async function resolveStripeKey() {
   if (cachedKey) return cachedKey;
+  const directKey = window.SMOOTHR_CONFIG?.stripeKey;
+  if (directKey) {
+    cachedKey = directKey;
+    return directKey;
+  }
+
   const storeId = window.SMOOTHR_CONFIG?.storeId;
   let key;
   if (storeId) {


### PR DESCRIPTION
## Summary
- return `SMOOTHR_CONFIG.stripeKey` in `resolveStripeKey` before making network calls

## Testing
- `npm test` *(fails: ENETUNREACH for external network calls)*

------
https://chatgpt.com/codex/tasks/task_e_68826a6ee8108325885b439174f0cdf5