### PR TITLE
Add RPC mocks for handleCheckout tests

### DIFF
--- a/storefronts/tests/providers/handleCheckout-store-id.test.ts
+++ b/storefronts/tests/providers/handleCheckout-store-id.test.ts
@@ -15,6 +15,7 @@ vi.mock('../../../shared/supabase/serverClient', () => {
       }
       return {};
     },
+    rpc: vi.fn(() => Promise.resolve({ data: 'ST-0001', error: null }))
   };
   return { supabase: client, createServerSupabaseClient: () => client, testMarker: '✅ serverClient loaded' };
 });

--- a/storefronts/tests/providers/provider-handleCheckout-authorizeNet.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-authorizeNet.test.ts
@@ -89,7 +89,8 @@ vi.mock('../../../shared/supabase/serverClient', () => {
           return { insert: vi.fn().mockResolvedValue({ error: null }) };
         }
         return {};
-      }
+      },
+    rpc: vi.fn(() => Promise.resolve({ data: 'ST-0001', error: null }))
   };
   return {
     supabase: client,

--- a/storefronts/tests/providers/provider-handleCheckout-nmi-missing-token.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-nmi-missing-token.test.ts
@@ -59,7 +59,8 @@ vi.mock('../../../shared/supabase/serverClient', () => {
           };
         }
         return {};
-      }
+      },
+    rpc: vi.fn(() => Promise.resolve({ data: 'ST-0001', error: null }))
   };
   return { supabase: client, createServerSupabaseClient: () => client, testMarker: '✅ serverClient loaded' };
 });

--- a/storefronts/tests/providers/provider-handleCheckout-nmi.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-nmi.test.ts
@@ -95,9 +95,10 @@ vi.mock('../../../shared/supabase/serverClient', () => {
         }
         if (table === 'order_items' || table === 'discount_usages') {
           return { insert: vi.fn().mockResolvedValue({ error: null }) };
-        }
-        return {};
       }
+      return {};
+    },
+    rpc: vi.fn(() => Promise.resolve({ data: 'ST-0001', error: null }))
   };
   return { supabase: client, createServerSupabaseClient: () => client, testMarker: '✅ serverClient loaded' };
 });

--- a/storefronts/tests/providers/provider-handleCheckout-settings-error.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-settings-error.test.ts
@@ -59,7 +59,8 @@ vi.mock('../../../shared/supabase/serverClient', () => {
         };
       }
       return { select: vi.fn(() => ({ eq: vi.fn(() => ({ eq: vi.fn(() => ({ single: vi.fn(async () => ({ data: null, error: null })) })) })) })) };
-    }
+    },
+    rpc: vi.fn(() => Promise.resolve({ data: 'ST-0001', error: null }))
   };
   return { supabase: client, createServerSupabaseClient: () => client, testMarker: '✅ serverClient loaded' };
 });

--- a/storefronts/tests/providers/provider-handleCheckout-unsupported.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-unsupported.test.ts
@@ -53,7 +53,8 @@ vi.mock('../../../shared/supabase/serverClient', () => {
         };
       }
       return { select: vi.fn(() => ({ eq: vi.fn(() => ({ eq: vi.fn(() => ({ single: vi.fn(async () => ({ data: null, error: null })) })) })) })) };
-    }
+    },
+    rpc: vi.fn(() => Promise.resolve({ data: 'ST-0001', error: null }))
   };
   return { supabase: client, createServerSupabaseClient: () => client, testMarker: '✅ serverClient loaded' };
 });


### PR DESCRIPTION
## Summary
- update Supabase mocks in provider handleCheckout tests to include `rpc`

## Testing
- `npm test` *(fails: Unhandled Errors and failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68826b34cb7c8325884e395252a19fc1