### PR TITLE
Fix Webflow adapter init timing

### DIFF
--- a/client/platforms/webflow/checkoutAdapter.js
+++ b/client/platforms/webflow/checkoutAdapter.js
@@ -21,7 +21,9 @@ loadCSS('https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.8/css/intlTe
 loadScript('https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js', () => {
   loadScript('https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.8/js/intlTelInput.min.js', () => {
     loadScript('https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.8/js/utils.js', () => {
-      document.addEventListener('DOMContentLoaded', initializePickers);
+      const runInit = () => initializePickers();
+      if (document.readyState !== 'loading') runInit();
+      else document.addEventListener('DOMContentLoaded', runInit);
     });
   });
 });


### PR DESCRIPTION
## Summary
- update checkout adapter to run initialization after script load and DOM

## Testing
- `npm test` *(fails: connect ENETUNREACH during tests)*

------
https://chatgpt.com/codex/tasks/task_e_68826cad923883259c92ad225869de7b