### PR TITLE
Fix NMI checkout missing token expectation

### DIFF
--- a/storefronts/tests/providers/provider-handleCheckout-nmi-missing-token.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-nmi-missing-token.test.ts
@@ -102,7 +102,9 @@ describe('handleCheckout nmi missing token', () => {
     await handleCheckout({ req: req as NextApiRequest, res: res as NextApiResponse });
 
     expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ error: 'payment_token is required' });
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'payment_token or customer_profile_id is required'
+    });
     expect(nmiMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- adjust expected error message when `payment_token` or `customer_profile_id` is missing in the NMI checkout test

## Testing
- `npm --workspace storefronts test -- tests/providers/provider-handleCheckout-nmi-missing-token.test.ts`
- `npm test` *(fails: provider tests require network access and browser APIs)*

------
https://chatgpt.com/codex/tasks/task_e_68826dfb4bc0832594a6b04c282317f4