### PR TITLE
Update tests for Smoothr

### DIFF
--- a/storefronts/tests/providers/provider-handleCheckout-authorizeNet.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-authorizeNet.test.ts
@@ -115,7 +115,7 @@ describe('handleCheckout authorizeNet', () => {
     };
 
     await handleCheckout({ req: req as NextApiRequest, res: res as NextApiResponse });
-    expect(orderPayload.payment_intent_id).toBe('t123');
+    expect(orderPayload.payment_id).toBe('t123');
     expect(orderPayload.status).toBe('paid');
   });
 });

--- a/storefronts/tests/providers/provider-handleCheckout-nmi-missing-token.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-nmi-missing-token.test.ts
@@ -75,7 +75,7 @@ describe('handleCheckout nmi missing token', () => {
     await handleCheckout({ req: req as NextApiRequest, res: res as NextApiResponse });
 
     expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ error: 'payment_token is required' });
+    expect(res.json).toHaveBeenCalledWith({ error: 'payment_token or customer_profile_id is required' });
     expect(nmiMock).not.toHaveBeenCalled();
   });
 });

--- a/storefronts/tests/providers/provider-handleCheckout-nmi.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-nmi.test.ts
@@ -134,7 +134,7 @@ describe('handleCheckout nmi', () => {
     expect(nmiMock).toHaveBeenCalledWith(
       expect.objectContaining({ payment_token: 'tok_123', amount: 100 })
     );
-    expect(orderPayload.payment_intent_id).toBe('t123');
+    expect(orderPayload.payment_id).toBe('t123');
     expect(orderPayload.status).toBe('paid');
     expect(typeof orderPayload.paid_at).toBe('string');
   });

--- a/storefronts/tests/sdk/global-currency-helper.test.js
+++ b/storefronts/tests/sdk/global-currency-helper.test.js
@@ -11,6 +11,7 @@ beforeEach(() => {
   global.document = {
     addEventListener: vi.fn(),
     querySelectorAll: vi.fn(() => []),
+    currentScript: { dataset: { storeId: '00000000-0000-0000-0000-000000000000' } },
   };
   global.localStorage = {
     getItem: vi.fn(),

--- a/storefronts/tests/sdk/global-smoothr-alias.test.js
+++ b/storefronts/tests/sdk/global-smoothr-alias.test.js
@@ -13,6 +13,12 @@ beforeEach(() => {
     addEventListener: vi.fn(),
     removeEventListener: vi.fn(),
   };
+  global.document = {
+    addEventListener: vi.fn(),
+    querySelectorAll: vi.fn(() => []),
+    querySelector: vi.fn(() => null),
+    currentScript: { dataset: { storeId: '00000000-0000-0000-0000-000000000000' } },
+  };
 });
 
 describe("global smoothr alias", () => {

--- a/storefronts/tests/sdk/load-config-api-base.test.js
+++ b/storefronts/tests/sdk/load-config-api-base.test.js
@@ -22,7 +22,8 @@ beforeEach(() => {
   global.document = {
     addEventListener: vi.fn(),
     querySelectorAll: vi.fn(() => []),
-    querySelector: vi.fn(() => null)
+    querySelector: vi.fn(() => null),
+    currentScript: { dataset: { storeId: '00000000-0000-0000-0000-000000000000' } }
   };
   global.localStorage = {
     getItem: vi.fn(),

--- a/storefronts/tests/sdk/load-config-merge.test.js
+++ b/storefronts/tests/sdk/load-config-merge.test.js
@@ -23,7 +23,8 @@ beforeEach(() => {
   global.document = {
     addEventListener: vi.fn(),
     querySelectorAll: vi.fn(() => []),
-    querySelector: vi.fn(() => null)
+    querySelector: vi.fn(() => null),
+    currentScript: { dataset: { storeId: '00000000-0000-0000-0000-000000000000' } }
   };
   global.localStorage = {
     getItem: vi.fn(),

--- a/storefronts/tests/sdk/smoothr-config.test.js
+++ b/storefronts/tests/sdk/smoothr-config.test.js
@@ -24,6 +24,7 @@ beforeEach(() => {
     addEventListener: vi.fn(),
     querySelectorAll: vi.fn(() => []),
     querySelector: vi.fn(() => null),
+    currentScript: { dataset: { storeId: '00000000-0000-0000-0000-000000000000' } },
   };
   global.localStorage = {
     getItem: vi.fn(),


### PR DESCRIPTION
## Summary
- align NMI missing-token expectation with production error message
- expect `payment_id` for checkout tests
- ensure a mock `<script>` with `data-store-id` exists to initialize Smoothr

## Testing
- `npx -y vitest --update` *(fails: cannot find package '@supabase/supabase-js')*
- `npm test` *(fails: cannot find package '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_e_68827388f1788325856c3b737259044f