### PR TITLE
Stub global currency helper

### DIFF
--- a/storefronts/core/index.js
+++ b/storefronts/core/index.js
@@ -82,6 +82,9 @@ export default Smoothr;
 
 // Bootstrap SDK: load config and then initialize everything
 (async function initSmoothr() {
+  if (typeof globalThis.setSelectedCurrency !== 'function') {
+    globalThis.setSelectedCurrency = () => {};
+  }
   const currentScript =
     document.currentScript ||
     document.querySelector('script[src*="smoothr-sdk"][data-store-id]');


### PR DESCRIPTION
## Summary
- ensure `globalThis.setSelectedCurrency` exists even if initialization fails

## Testing
- `npm test` *(fails: Test Files 13 failed | 28 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688284f3320c832582b68a5a620b26fe