### PR TITLE
Update test for event listener object

### DIFF
--- a/storefronts/tests/sdk/checkout-payload.test.js
+++ b/storefronts/tests/sdk/checkout-payload.test.js
@@ -149,7 +149,7 @@ describe('checkout payload', () => {
     await flushPromises();
 
 
-    expect(typeof clickHandler).toBe('function');
+    expect(typeof clickHandler.handleEvent).toBe('function');
     await clickHandler({ preventDefault: vi.fn(), stopPropagation: vi.fn() });
     await flushPromises();
 


### PR DESCRIPTION
## Summary
- adjust checkout payload test to expect a handleEvent property on clickHandler

## Testing
- `npm test` *(fails: "TypeError: Cannot read properties of null (reading 'handleEvent')" and others)*

------
https://chatgpt.com/codex/tasks/task_e_68835c057bb083258f5f43fe71c8e266