### PR TITLE
Add global test timeout

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,5 +4,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: './vitest.setup.ts',
+    testTimeout: 10000,
   },
 });


### PR DESCRIPTION
## Summary
- add a default 10s timeout for vitest

## Testing
- `npm test` *(fails: 12 failed, 29 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6883608c92a08325ba50d2141cafdc04