### PR TITLE
Fix NMI mount tests timing

### DIFF
--- a/storefronts/tests/providers/provider-nmi-mount.test.ts
+++ b/storefronts/tests/providers/provider-nmi-mount.test.ts
@@ -78,11 +78,12 @@ afterEach(() => {
 describe('mountNMI', () => {
   async function triggerMount() {
     mountCallback?.();
+    await vi.runAllTimersAsync();
     await scriptPromise;
     await new Promise(r => setTimeout(r));
   }
 
-  it('loads tokenization key and injects script', async () => {
+  it('loads tokenization key and injects script', { timeout: 20000 }, async () => {
     await triggerMount();
     await vi.runAllTimersAsync();
     expect(getCredMock).toHaveBeenCalledWith('store-1', 'nmi', 'nmi');
@@ -90,7 +91,7 @@ describe('mountNMI', () => {
     expect(script.getAttribute('data-tokenization-key')).toBe('tok_key');
   });
 
-  it('reports ready when CollectJS is configured', async () => {
+  it('reports ready when CollectJS is configured', { timeout: 20000 }, async () => {
     await triggerMount();
     await vi.runAllTimersAsync();
     expect(ready()).toBe(true);


### PR DESCRIPTION
## Summary
- keep fake timers active in NMI mount tests
- flush pending timers after triggering mount
- increase per-test timeout to avoid premature timeouts

## Testing
- `npm test` *(fails: Test timed out in 20000ms)*

------
https://chatgpt.com/codex/tasks/task_e_688367cb75b48325a8ae097a016d373e