### PR TITLE
Dispatch DOMContentLoaded in Webflow adapter test

### DIFF
--- a/storefronts/tests/platforms/webflow/checkout.dom.test.ts
+++ b/storefronts/tests/platforms/webflow/checkout.dom.test.ts
@@ -74,6 +74,7 @@ describe('webflow checkout adapter dom', () => {
     (window as any).intlTelInput = vi.fn();
 
     await import('../../../../client/platforms/webflow/checkoutAdapter.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
 
     for (let i = 0; i < 4; i++) {
       await new Promise(r => setTimeout(r, 0));


### PR DESCRIPTION
## Summary
- trigger DOMContentLoaded in the Webflow checkout adapter test so that geo lookup runs

## Testing
- `npm test` *(fails: Test timed out in 20000ms, 12 failed | 29 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68836b20c96c8325b6ef75c9219b7775