### PR TITLE
Fix auth mock

### DIFF
--- a/storefronts/tests/sdk/global-smoothr-alias.test.js
+++ b/storefronts/tests/sdk/global-smoothr-alias.test.js
@@ -5,6 +5,7 @@ vi.mock("../../core/auth/index.js", () => ({
   initAuth: vi.fn(),
   user: null,
   $$typeof: Symbol.for('react.test.json'),
+  type: 'module'
 }));
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary
- add `type: 'module'` field to auth module mock in tests

## Testing
- `npm test` *(fails: Test Files 12 failed | 29 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68836c5ddc1c83259788c3ecf3d57fc9