### PR TITLE
Use storefront stub for findOrCreateCustomer in tests

### DIFF
--- a/storefronts/tests/providers/provider-handleCheckout-authorizeNet.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-authorizeNet.test.ts
@@ -8,9 +8,6 @@ vi.mock('../../../shared/checkout/providers/authorizeNet.ts', () => {
   return { default: vi.fn(async () => ({ success: true, data: { transactionResponse: { transId: 't123' } } })) };
 });
 
-vi.mock('../../../smoothr/lib/findOrCreateCustomer.ts', () => {
-  return { findOrCreateCustomer: vi.fn(async () => 'cust-1') };
-});
 
 vi.mock('../../../shared/supabase/serverClient', () => {
   let storeFromCall = 0;

--- a/storefronts/tests/providers/provider-handleCheckout-nmi-missing-token.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-nmi-missing-token.test.ts
@@ -9,10 +9,6 @@ vi.mock('../../../shared/checkout/providers/nmi.ts', () => {
   return { default: nmiMock };
 });
 
-vi.mock('../../../smoothr/lib/findOrCreateCustomer.ts', () => {
-  return { findOrCreateCustomer: vi.fn(async () => 'cust-1') };
-});
-
 vi.mock('../../../shared/supabase/serverClient', () => {
   const client = {
     from: (table: string) => {

--- a/storefronts/tests/providers/provider-handleCheckout-nmi.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-nmi.test.ts
@@ -16,10 +16,6 @@ vi.mock('../../../shared/checkout/providers/nmi.ts', () => {
   return { default: nmiMock };
 });
 
-vi.mock('../../../smoothr/lib/findOrCreateCustomer.ts', () => {
-  return { findOrCreateCustomer: vi.fn(async () => 'cust-1') };
-});
-
 vi.mock('../../../shared/supabase/serverClient', () => {
   const client = {
     from: (table: string) => {

--- a/storefronts/tests/providers/provider-handleCheckout-settings-error.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-settings-error.test.ts
@@ -9,10 +9,6 @@ vi.mock('../../../shared/checkout/providers/nmi.ts', () => {
   return { default: providerMock };
 });
 
-vi.mock('../../../smoothr/lib/findOrCreateCustomer.ts', () => {
-  return { findOrCreateCustomer: vi.fn(async () => 'cust-1') };
-});
-
 vi.mock('../../../shared/supabase/serverClient', () => {
   const client = {
     from: (table: string) => {

--- a/storefronts/tests/providers/provider-handleCheckout-unsupported.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-unsupported.test.ts
@@ -3,10 +3,6 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 
 let handleCheckout: any;
 
-vi.mock('../../../smoothr/lib/findOrCreateCustomer.ts', () => {
-  return { findOrCreateCustomer: vi.fn(async () => 'cust-1') };
-});
-
 vi.mock('../../../shared/supabase/serverClient', () => {
   const client = {
     from: (table: string) => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,16 @@
 import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
 
 export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: './vitest.setup.ts',
     testTimeout: 10000,
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'smoothr'),
+      '@/lib/findOrCreateCustomer': resolve(__dirname, 'storefronts/lib/findOrCreateCustomer.ts'),
+    },
   },
 });


### PR DESCRIPTION
## Summary
- alias `@/lib/findOrCreateCustomer` to the storefront test stub
- remove old mocks referencing the production module

## Testing
- `npm test` *(fails: checkout payload, stripe mount, provider-handleCheckout* etc.)

------
https://chatgpt.com/codex/tasks/task_e_68836ff7c8a48325a2f65d1f482c1d89