### PR TITLE
Expand auth mock in global smoothr alias test

### DIFF
--- a/storefronts/tests/sdk/global-smoothr-alias.test.js
+++ b/storefronts/tests/sdk/global-smoothr-alias.test.js
@@ -5,7 +5,8 @@ vi.mock("../../core/auth/index.js", () => ({
   initAuth: vi.fn(),
   user: null,
   $$typeof: Symbol.for('react.test.json'),
-  type: 'module'
+  type: 'module',
+  props: {}
 }));
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary
- extend the mocked `core/auth` module in `global-smoothr-alias.test.js`

## Testing
- `npm test` *(fails: 9 failed, 92 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6883779f61488325a1b98993f27501c1