### PR TITLE
Fix provider-nmi-mount.test

### DIFF
--- a/storefronts/tests/providers/provider-nmi-mount.test.ts
+++ b/storefronts/tests/providers/provider-nmi-mount.test.ts
@@ -14,7 +14,7 @@ beforeEach(async () => {
   getComputedStyleSpy = vi
     .spyOn(window, 'getComputedStyle')
     .mockReturnValue({
-      fontFamily: 'Arial',
+      fontFamily: 'Arial, sans-serif',
       fontWeight: '400',
       color: '#000',
       fontSize: '16px',


### PR DESCRIPTION
## Summary
- update `getComputedStyle` mock to always return a font family with a comma

## Testing
- `npm test` *(fails: 9 failed, 92 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6883786100ec8325af3e56554acce569