### PR TITLE
Fix global currency helper test setup

### DIFF
--- a/storefronts/tests/sdk/global-currency-helper.test.js
+++ b/storefronts/tests/sdk/global-currency-helper.test.js
@@ -8,6 +8,7 @@ beforeEach(() => {
     addEventListener: vi.fn(),
     removeEventListener: vi.fn(),
   };
+  global.window.SMOOTHR_CONFIG = { baseCurrency: "USD" };
   global.document = {
     addEventListener: vi.fn(),
     querySelectorAll: vi.fn(() => []),


### PR DESCRIPTION
## Summary
- ensure `window.SMOOTHR_CONFIG` is defined in `global-currency-helper.test.js`

## Testing
- `npm test` *(fails: provider and checkout related tests)*

------
https://chatgpt.com/codex/tasks/task_e_6883798d30b083258af43cb5bdaf3bba