### PR TITLE
Add currency base mock to smoothr alias test

### DIFF
--- a/storefronts/tests/sdk/global-smoothr-alias.test.js
+++ b/storefronts/tests/sdk/global-smoothr-alias.test.js
@@ -10,6 +10,11 @@ vi.mock("../../core/auth/index.js", () => ({
   children: []
 }));
 
+vi.mock('../../core/currency/index.js', async () => {
+  const actual = await vi.importActual('../../core/currency/index.js');
+  return { ...actual, baseCurrency: 'USD' };
+});
+
 beforeEach(() => {
   vi.resetModules();
   global.fetch = vi.fn(() =>


### PR DESCRIPTION
## Summary
- expand the smoothr alias test to set a base currency mock for `currency` module

## Testing
- `npm test` *(fails: 8 failed, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_6883827db7bc8325b3cd15303d29dee4