### PR TITLE
Adjust checkout status expectations

### DIFF
--- a/storefronts/tests/providers/provider-handleCheckout-settings-error.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-settings-error.test.ts
@@ -80,7 +80,7 @@ describe('handleCheckout supabase error', () => {
 
     await handleCheckout({ req: req as NextApiRequest, res: res as NextApiResponse });
 
-    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.status).toHaveBeenCalledWith(500);
     expect(res.json).toHaveBeenCalledWith({ error: 'Failed to load store settings', detail: 'fail' });
     expect(providerMock).not.toHaveBeenCalled();
   });

--- a/storefronts/tests/providers/provider-handleCheckout-unsupported.test.ts
+++ b/storefronts/tests/providers/provider-handleCheckout-unsupported.test.ts
@@ -74,7 +74,7 @@ describe('handleCheckout unsupported provider', () => {
 
     await handleCheckout({ req: req as NextApiRequest, res: res as NextApiResponse });
 
-    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.status).toHaveBeenCalledWith(400);
     expect(res.json).toHaveBeenCalledWith({ error: 'Unsupported payment gateway' });
   });
 });


### PR DESCRIPTION
## Summary
- update expectation of `provider-handleCheckout-settings-error` test to check for status 500
- update expectation of `provider-handleCheckout-unsupported` test to check for status 400

## Testing
- `npm test` *(fails: 8 failed, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_68838726ac98832584ba6d3ee2d31243