### PR TITLE
Fix currency mock in global smoothr tests

### DIFF
--- a/storefronts/tests/sdk/global-smoothr-alias.test.js
+++ b/storefronts/tests/sdk/global-smoothr-alias.test.js
@@ -12,7 +12,14 @@ vi.mock("../../core/auth/index.js", () => ({
 
 vi.mock('../../core/currency/index.js', async () => {
   const actual = await vi.importActual('../../core/currency/index.js');
-  return { ...actual, baseCurrency: 'USD' };
+  return {
+    ...actual,
+    baseCurrency: 'USD',
+    $$typeof: Symbol.for('react.test.json'),
+    type: 'module',
+    props: {},
+    children: []
+  };
 });
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary
- extend the currency module mock in `global-smoothr-alias.test.js` to keep mock meta

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'payment_intent_id'))*

------
https://chatgpt.com/codex/tasks/task_e_6883882096748325ab9f8272d23a1b45