### PR TITLE
Fix Authorize.Net input borders

### DIFF
--- a/storefronts/checkout/utils/authorizeNetIframeStyles.js
+++ b/storefronts/checkout/utils/authorizeNetIframeStyles.js
@@ -86,19 +86,21 @@ export function initAuthorizeStyles() {
     placeholderColor = placeholderCs.color || '#aab7c4';  
     placeholderFontWeight = placeholderCs.fontWeight || 'normal';  
   }  
-  const placeholderStyle = document.createElement('style');  
-  placeholderStyle.textContent = `  
-    .smoothr-accept-field::placeholder {  
-      color: ${placeholderColor};  
-      font-weight: ${placeholderFontWeight};  
-    }  
-    .smoothr-accept-field:focus {  
-      outline: none;  
-      border: none;  
-    }  
-  `;  
-  document.head.appendChild(placeholderStyle);  
-}  
+  const placeholderStyle = document.createElement('style');
+  placeholderStyle.textContent = `
+    .smoothr-accept-field {
+      border: none;
+    }
+    .smoothr-accept-field::placeholder {
+      color: ${placeholderColor};
+      font-weight: ${placeholderFontWeight};
+    }
+    .smoothr-accept-field:focus {
+      outline: none;
+    }
+  `;
+  document.head.appendChild(placeholderStyle);
+}
 
 export function getFonts() {  
   const sourceEl = document.querySelector('[data-smoothr-email]') || document.querySelector('[data-smoothr-card-number]');  
@@ -122,9 +124,8 @@ export function elementStyleFromContainer(el) {
     fontFamily: cs.fontFamily,  
     fontWeight: cs.fontWeight,  
     lineHeight: cs.lineHeight,  
-    backgroundColor: cs.backgroundColor,  
-    border: 'none',  
-    padding: cs.padding,  
+    backgroundColor: cs.backgroundColor,
+    padding: cs.padding,
     margin: '0',  
     width: '100%',  
     height: '100%',  


### PR DESCRIPTION
## Summary
- avoid default browser borders on Authorize.Net inputs to match the focused style inherited from the email field

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68852f03dba083258e501bf40d0565c1