### PR TITLE
Remove default border for AuthorizeNet fields

### DIFF
--- a/storefronts/checkout/utils/authorizeNetIframeStyles.js
+++ b/storefronts/checkout/utils/authorizeNetIframeStyles.js
@@ -89,6 +89,10 @@ export function initAuthorizeStyles() {
   const placeholderStyle = document.createElement('style');
   placeholderStyle.textContent = `
 
+    .smoothr-accept-field:not(:focus) {
+      border: none;
+      box-shadow: none;
+    }
     .smoothr-accept-field::placeholder {
       color: ${placeholderColor};
       font-weight: ${placeholderFontWeight};


### PR DESCRIPTION
## Summary
- ensure AuthorizeNet accept fields only show borders while focused

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688575612fd483258d6f5a0923e08a2a