### PR TITLE
refactor: update password reset selectors

### DIFF
--- a/storefronts/tests/sdk/password-reset.test.js
+++ b/storefronts/tests/sdk/password-reset.test.js
@@ -130,9 +130,8 @@ describe("password reset confirmation", () => {
         if (ev === "submit") submitHandler = cb;
       }),
       querySelector: vi.fn((sel) => {
-        if (sel === '[data-smoothr-input="password"]') return passwordInputObj;
-        if (sel === '[data-smoothr-input="password-confirm"]')
-          return confirmInputObj;
+        if (sel === '[data-smoothr="password"]') return passwordInputObj;
+        if (sel === '[data-smoothr="password-confirm"]') return confirmInputObj;
         return null;
       }),
     };

--- a/supabase/authHelpers.js
+++ b/supabase/authHelpers.js
@@ -210,7 +210,7 @@ export function initPasswordResetConfirmation({ redirectTo = '/' } = {}) {
     document
       .querySelectorAll('form[data-smoothr="password-reset-confirm"]')
       .forEach(form => {
-        const passwordInput = form.querySelector('[data-smoothr-input="password"]');
+        const passwordInput = form.querySelector('[data-smoothr="password"]');
         if (passwordInput && passwordInput.addEventListener) {
           passwordInput.addEventListener('input', () => {
             updateStrengthMeter(form, passwordInput.value);
@@ -218,7 +218,7 @@ export function initPasswordResetConfirmation({ redirectTo = '/' } = {}) {
         }
         form.addEventListener && form.addEventListener('submit', async evt => {
           evt.preventDefault();
-          const confirmInput = form.querySelector('[data-smoothr-input="password-confirm"]');
+          const confirmInput = form.querySelector('[data-smoothr="password-confirm"]');
           const password = passwordInput?.value || '';
           const confirm = confirmInput?.value || '';
           if (passwordStrength(password) < 3) {


### PR DESCRIPTION
## Summary
- switch password reset confirmation helpers to use `data-smoothr` attributes
- align password reset confirmation tests with new attribute selectors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ef77129a483259e57805d97a5be67