### PR TITLE
refactor: replace data-smoothr-input selectors

### DIFF
--- a/storefronts/core/auth/README.md
+++ b/storefronts/core/auth/README.md
@@ -48,14 +48,14 @@ Markup example:
 
 ```html
 <form data-smoothr="login-form">
-  <input type="email" data-smoothr-input="email" />
-  <input type="password" data-smoothr-input="password" />
+  <input type="email" data-smoothr="email" />
+  <input type="password" data-smoothr="password" />
   <div data-smoothr="login">Sign In</div>
 </form>
 <form data-smoothr="signup">
-  <input type="email" data-smoothr-input="email" />
-  <input type="password" data-smoothr-input="password" />
-  <input type="password" data-smoothr-input="password-confirm" />
+  <input type="email" data-smoothr="email" />
+  <input type="password" data-smoothr="password" />
+  <input type="password" data-smoothr="password-confirm" />
   <div data-smoothr-password-strength></div>
   <div data-smoothr-error hidden></div>
   <div data-smoothr-success hidden></div>
@@ -115,8 +115,8 @@ container. The SDK automatically attaches handlers on page load and uses a
 
 ```html
 <form data-smoothr="password-reset-confirm">
-  <input type="password" data-smoothr-input="password" />
-  <input type="password" data-smoothr-input="password-confirm" />
+  <input type="password" data-smoothr="password" />
+  <input type="password" data-smoothr="password-confirm" />
   <button type="submit">Set new password</button>
 </form>
 ```
@@ -179,7 +179,7 @@ NEXT_PUBLIC_SUPABASE_PASSWORD_RESET_REDIRECT_URL=https://your-site.com/reset
 
 ```html
 <form data-smoothr="password-reset">
-  <input type="email" data-smoothr-input="email" />
+  <input type="email" data-smoothr="email" />
   <button type="submit">Send reset link</button>
 </form>
 ```
@@ -188,8 +188,8 @@ NEXT_PUBLIC_SUPABASE_PASSWORD_RESET_REDIRECT_URL=https://your-site.com/reset
 
 ```html
 <form data-smoothr="password-reset-confirm">
-  <input type="password" data-smoothr-input="password" />
-  <input type="password" data-smoothr-input="password-confirm" />
+  <input type="password" data-smoothr="password" />
+  <input type="password" data-smoothr="password-confirm" />
   <button type="submit">Set new password</button>
 </form>
 <script type="module">

--- a/storefronts/core/auth/index.js
+++ b/storefronts/core/auth/index.js
@@ -57,8 +57,8 @@ function bindAuthElements(root = document) {
           evt.preventDefault();
           const targetForm = form;
           if (!targetForm) return;
-          const email = targetForm.querySelector('[data-smoothr-input="email"]');
-          const passwordInput = targetForm.querySelector('[data-smoothr-input="password"]');
+          const email = targetForm.querySelector('[data-smoothr="email"]');
+          const passwordInput = targetForm.querySelector('[data-smoothr="password"]');
           const emailVal = email?.value || '';
           const password = passwordInput?.value || '';
           if (!isValidEmail(emailVal)) {
@@ -104,7 +104,7 @@ function bindAuthElements(root = document) {
       }
       case 'signup': {
         if (form) {
-          const passwordInput = form.querySelector('[data-smoothr-input="password"]');
+          const passwordInput = form.querySelector('[data-smoothr="password"]');
           if (passwordInput && passwordInput.addEventListener) {
             passwordInput.addEventListener('input', () => {
               updateStrengthMeter(form, passwordInput.value);
@@ -115,9 +115,9 @@ function bindAuthElements(root = document) {
           evt.preventDefault();
           const targetForm = form;
           if (!targetForm) return;
-          const emailInput = targetForm.querySelector('[data-smoothr-input="email"]');
-          const passwordInput = targetForm.querySelector('[data-smoothr-input="password"]');
-          const confirmInput = targetForm.querySelector('[data-smoothr-input="password-confirm"]');
+          const emailInput = targetForm.querySelector('[data-smoothr="email"]');
+          const passwordInput = targetForm.querySelector('[data-smoothr="password"]');
+          const confirmInput = targetForm.querySelector('[data-smoothr="password-confirm"]');
           const email = emailInput?.value || '';
           const password = passwordInput?.value || '';
           const confirm = confirmInput?.value || '';
@@ -164,7 +164,7 @@ function bindAuthElements(root = document) {
           evt.preventDefault();
           const targetForm = form;
           if (!targetForm) return;
-          const emailInput = targetForm.querySelector('[data-smoothr-input="email"]');
+          const emailInput = targetForm.querySelector('[data-smoothr="email"]');
           const email = emailInput?.value || '';
           if (!isValidEmail(email)) {
             showError(targetForm, 'Enter a valid email address', emailInput, el);

--- a/storefronts/tests/sdk/dom-mutation.test.js
+++ b/storefronts/tests/sdk/dom-mutation.test.js
@@ -85,8 +85,8 @@ describe("dynamic DOM bindings", () => {
     const passwordInput = { value: "Password1" };
     const form = {
       querySelector: vi.fn((sel) => {
-        if (sel === '[data-smoothr-input="email"]') return emailInput;
-        if (sel === '[data-smoothr-input="password"]') return passwordInput;
+        if (sel === '[data-smoothr="email"]') return emailInput;
+        if (sel === '[data-smoothr="password"]') return passwordInput;
         return null;
       }),
     };
@@ -126,9 +126,9 @@ describe("dynamic DOM bindings", () => {
     const confirmInput = { value: "Password1" };
     const form = {
       querySelector: vi.fn((sel) => {
-        if (sel === '[data-smoothr-input="email"]') return emailInput;
-        if (sel === '[data-smoothr-input="password"]') return passwordInput;
-        if (sel === '[data-smoothr-input="password-confirm"]')
+        if (sel === '[data-smoothr="email"]') return emailInput;
+        if (sel === '[data-smoothr="password"]') return passwordInput;
+        if (sel === '[data-smoothr="password-confirm"]')
           return confirmInput;
         if (sel === '[type="submit"]') return {};
         return null;
@@ -232,7 +232,7 @@ describe("dynamic DOM bindings", () => {
     };
     const form = {
       querySelector: vi.fn((sel) => {
-        if (sel === '[data-smoothr-input="email"]') return emailInput;
+        if (sel === '[data-smoothr="email"]') return emailInput;
         if (sel === "[data-smoothr-success]") return successEl;
         if (sel === "[data-smoothr-error]") return errorEl;
         if (sel === '[type="submit"]') return {};

--- a/storefronts/tests/sdk/login-dataset-immutable.test.js
+++ b/storefronts/tests/sdk/login-dataset-immutable.test.js
@@ -51,9 +51,9 @@ describe("login with immutable dataset", () => {
         if (ev === "submit") submitHandler = cb;
       }),
       querySelector: vi.fn((sel) => {
-        if (sel === '[data-smoothr-input="email"]')
+        if (sel === '[data-smoothr="email"]')
           return { value: emailValue };
-        if (sel === '[data-smoothr-input="password"]')
+        if (sel === '[data-smoothr="password"]')
           return { value: passwordValue };
         return null;
       }),

--- a/storefronts/tests/sdk/login.test.js
+++ b/storefronts/tests/sdk/login.test.js
@@ -50,9 +50,9 @@ describe("login form", () => {
         if (ev === "submit") submitHandler = cb;
       }),
       querySelector: vi.fn((sel) => {
-        if (sel === '[data-smoothr-input="email"]')
+        if (sel === '[data-smoothr="email"]')
           return { value: emailValue };
-        if (sel === '[data-smoothr-input="password"]')
+        if (sel === '[data-smoothr="password"]')
           return { value: passwordValue };
         if (sel === '[data-smoothr="login"]') return btn;
         return null;

--- a/storefronts/tests/sdk/password-reset.test.js
+++ b/storefronts/tests/sdk/password-reset.test.js
@@ -57,7 +57,7 @@ describe("password reset request", () => {
         if (ev === "submit") submitHandler = cb;
       }),
       querySelector: vi.fn((sel) => {
-        if (sel === '[data-smoothr-input="email"]')
+        if (sel === '[data-smoothr="email"]')
           return { value: emailValue };
         return null;
       }),

--- a/storefronts/tests/sdk/signup.test.js
+++ b/storefronts/tests/sdk/signup.test.js
@@ -54,11 +54,11 @@ describe("signup flow", () => {
         if (ev === "submit") submitHandler = cb;
       }),
       querySelector: vi.fn((selector) => {
-        if (selector === '[data-smoothr-input="email"]')
+        if (selector === '[data-smoothr="email"]')
           return { value: emailValue };
-        if (selector === '[data-smoothr-input="password"]')
+        if (selector === '[data-smoothr="password"]')
           return { value: passwordValue };
-        if (selector === '[data-smoothr-input="password-confirm"]')
+        if (selector === '[data-smoothr="password-confirm"]')
           return { value: confirmValue };
         return null;
       }),


### PR DESCRIPTION
## Summary
- use `[data-smoothr]` selectors for email/password fields in auth flows
- update docs and tests to match new attribute names

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ef87bd9f08325b1e8b2504d0e9615