### PR TITLE
feat: expose supabase client

### DIFF
--- a/storefronts/core/index.js
+++ b/storefronts/core/index.js
@@ -162,6 +162,12 @@ export default Smoothr;
 
     window.Smoothr = Smoothr;
     window.smoothr = window.smoothr || Smoothr;
+    window.smoothr.supabase = supabase;
+
+    // Optional helpers for DevTools
+    window.smoothr.getSession = () => supabase.auth.getSession();
+    window.smoothr.getUser = () => supabase.auth.getUser();
+
     window.renderCart = renderCart;
     log('🎨 renderCart registered in SDK');
 

--- a/storefronts/smoothr-sdk.js
+++ b/storefronts/smoothr-sdk.js
@@ -1,0 +1,8 @@
+import { supabase } from '../shared/supabase/browserClient.js';
+
+window.smoothr = window.smoothr || {};
+window.smoothr.supabase = supabase;
+
+// Optional helpers for DevTools
+window.smoothr.getSession = () => supabase.auth.getSession();
+window.smoothr.getUser = () => supabase.auth.getUser();


### PR DESCRIPTION
## Summary
- attach supabase browser client to global `smoothr` namespace for devtools helpers
- expose supabase client and helper functions through SDK initialization

## Testing
- `npm test`
- `npm --prefix storefronts run build`
- `npx --prefix storefronts wrangler pages deploy storefronts/dist --project-name smoothr` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_688f0175007c832585e276a9009e0f24