### PR TITLE
chore: remove smoothr sdk build artifact

### DIFF
--- a/storefronts/smoothr-sdk.js
+++ b/storefronts/smoothr-sdk.js
@@ -1,8 +1,0 @@
-import { supabase } from '../shared/supabase/browserClient.js';
-
-window.smoothr = window.smoothr || {};
-window.smoothr.supabase = supabase;
-
-// Optional helpers for DevTools
-window.smoothr.getSession = () => supabase.auth.getSession();
-window.smoothr.getUser = () => supabase.auth.getUser();


### PR DESCRIPTION
## Summary
- remove old `smoothr-sdk.js` bundle
- confirm SDK exposes supabase client and helper functions
- rebuild storefronts SDK bundle

## Testing
- `npm --prefix storefronts run build`
- `npm --prefix storefronts test`
- `npx --prefix storefronts wrangler pages deploy storefronts/dist --project-name smoothr` *(fails: requires interactive login)*

------
https://chatgpt.com/codex/tasks/task_e_688f0e13d71c832598b855a0f14942d5