### PR TITLE
refactor: rename login form selector to auth form

### DIFF
--- a/storefronts/core/auth/README.md
+++ b/storefronts/core/auth/README.md
@@ -47,7 +47,7 @@ initAuth();
 Markup example:
 
 ```html
-<form data-smoothr="login-form">
+<form data-smoothr="auth-form">
   <input type="email" data-smoothr="email" />
   <input type="password" data-smoothr="password" />
   <div data-smoothr="login">Sign In</div>

--- a/storefronts/core/auth/index.js
+++ b/storefronts/core/auth/index.js
@@ -32,7 +32,7 @@ function bindAuthElements(root = document) {
     if (el.dataset.smoothrBoundAuth) return;
     safeSetDataset(el, 'smoothrBoundAuth', '1');
 
-    const form = el.closest('[data-smoothr="login-form"]');
+    const form = el.closest('[data-smoothr="auth-form"]');
     if (form && !form.dataset?.smoothrBoundLoginSubmit) {
       safeSetDataset(form, 'smoothrBoundLoginSubmit', '1');
       form.addEventListener &&

--- a/storefronts/tests/sdk/login-dataset-immutable.test.js
+++ b/storefronts/tests/sdk/login-dataset-immutable.test.js
@@ -86,7 +86,7 @@ describe("login with immutable dataset", () => {
       }),
       querySelectorAll: vi.fn((sel) => {
         if (sel.includes('[data-smoothr="login"]')) return [btn];
-        if (sel.includes('form[data-smoothr="login-form"]')) return [form];
+        if (sel.includes('form[data-smoothr="auth-form"]')) return [form];
         return [];
       }),
       dispatchEvent: vi.fn(),

--- a/storefronts/tests/sdk/login.test.js
+++ b/storefronts/tests/sdk/login.test.js
@@ -83,7 +83,7 @@ describe("login form", () => {
       }),
       querySelectorAll: vi.fn((sel) => {
         if (sel.includes('[data-smoothr="login"]')) return [btn];
-        if (sel.includes('form[data-smoothr="login-form"]')) return [form];
+        if (sel.includes('form[data-smoothr="auth-form"]')) return [form];
         return [];
       }),
       dispatchEvent: vi.fn(),


### PR DESCRIPTION
## Summary
- use `[data-smoothr="auth-form"]` for login bindings
- update documentation and tests for new selector

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f1a46be0c8325b3c1efbfb7fc523f