### PR TITLE
Refactor auth triggers to use click events

### DIFF
--- a/storefronts/core/auth/index.js
+++ b/storefronts/core/auth/index.js
@@ -32,16 +32,7 @@ function bindAuthElements(root = document) {
     if (el.dataset.smoothrBoundAuth) return;
     safeSetDataset(el, 'smoothrBoundAuth', '1');
 
-    const form = el.closest('[data-smoothr="auth-form"]');
-    if (form && !form.dataset?.smoothrBoundLoginSubmit) {
-      safeSetDataset(form, 'smoothrBoundLoginSubmit', '1');
-      form.addEventListener &&
-        form.addEventListener('submit', evt => {
-          evt.preventDefault();
-          el.dispatchEvent &&
-            el.dispatchEvent(new Event('click', { bubbles: true, cancelable: true }));
-        });
-    }
+    const form = el.closest ? el.closest('[data-smoothr="auth-form"]') : null;
 
     el.addEventListener &&
       el.addEventListener('click', async evt => {
@@ -90,18 +81,11 @@ function bindAuthElements(root = document) {
     if (el.dataset.smoothrBoundAuth) return;
     safeSetDataset(el, 'smoothrBoundAuth', '1');
     const type = el.getAttribute('data-smoothr');
-    const attach = handler => {
-      if (el.tagName === 'FORM') {
-        el.addEventListener && el.addEventListener('submit', handler);
-      } else {
-        el.addEventListener && el.addEventListener('click', handler);
-      }
-    };
-    const form = el.tagName === 'FORM' ? el : el.closest('form');
+    const form = el.closest ? el.closest('[data-smoothr="auth-form"]') : null;
 
     switch (type) {
       case 'login-google': {
-        attach(async evt => {
+        el.addEventListener('click', async evt => {
           evt.preventDefault();
           await signInWithGoogle();
         });
@@ -116,7 +100,7 @@ function bindAuthElements(root = document) {
             });
           }
         }
-        attach(async evt => {
+        el.addEventListener('click', async evt => {
           evt.preventDefault();
           const targetForm = form;
           if (!targetForm) return;
@@ -138,8 +122,7 @@ function bindAuthElements(root = document) {
             showError(targetForm, 'Passwords do not match', confirmInput, el);
             return;
           }
-          const submitBtn = targetForm.querySelector('[type="submit"]');
-          setLoading(submitBtn, true);
+          setLoading(el, true);
           try {
             const { data, error } = await signUp(email, password);
             if (error) {
@@ -159,13 +142,13 @@ function bindAuthElements(root = document) {
           } catch (err) {
             showError(targetForm, err.message || 'Network error', emailInput, el);
           } finally {
-            setLoading(submitBtn, false);
+            setLoading(el, false);
           }
         });
         break;
       }
       case 'password-reset': {
-        attach(async evt => {
+        el.addEventListener('click', async evt => {
           evt.preventDefault();
           const targetForm = form;
           if (!targetForm) return;
@@ -175,8 +158,7 @@ function bindAuthElements(root = document) {
             showError(targetForm, 'Enter a valid email address', emailInput, el);
             return;
           }
-          const submitBtn = targetForm.querySelector('[type="submit"]');
-          setLoading(submitBtn, true);
+          setLoading(el, true);
           try {
             const { error } = await requestPasswordReset(email);
             if (error) {
@@ -197,7 +179,7 @@ function bindAuthElements(root = document) {
               el
             );
           } finally {
-            setLoading(submitBtn, false);
+            setLoading(el, false);
           }
         });
         break;

--- a/storefronts/tests/sdk/login.test.js
+++ b/storefronts/tests/sdk/login.test.js
@@ -34,21 +34,17 @@ function flushPromises() {
 
 describe("login form", () => {
   let clickHandler;
-  let submitHandler;
   let emailValue;
   let passwordValue;
 
   beforeEach(() => {
     clickHandler = undefined;
-    submitHandler = undefined;
     emailValue = "user@example.com";
     passwordValue = "Password1";
 
     const form = {
-      dataset: {},
-      addEventListener: vi.fn((ev, cb) => {
-        if (ev === "submit") submitHandler = cb;
-      }),
+      dataset: { smoothr: "auth-form" },
+      addEventListener: vi.fn(),
       querySelector: vi.fn((sel) => {
         if (sel === '[data-smoothr="email"]')
           return { value: emailValue };
@@ -101,7 +97,7 @@ describe("login form", () => {
     expect(signInMock).not.toHaveBeenCalled();
 
     emailValue = "user@example.com";
-    await submitHandler({ preventDefault: () => {} });
+    await clickHandler({ preventDefault: () => {} });
     await flushPromises();
     expect(signInMock).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- Always register click handlers for auth triggers and scope inputs via `[data-smoothr="auth-form"]`
- Use trigger-based `setLoading` and remove form submit listeners
- Update auth flow tests to simulate trigger clicks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f2552f958832594ef7545d34c566b