### PR TITLE
feat(auth): add Apple OAuth and rename logout to sign-out

### DIFF
--- a/storefronts/core/auth/README.md
+++ b/storefronts/core/auth/README.md
@@ -1,7 +1,7 @@
 # auth
 
 Authentication utilities powered by Supabase. Attach `[data-smoothr]`
-attributes to trigger login and logout from any storefront.
+attributes to trigger login and sign-out from any storefront.
 
 > **Why use a `div` for the login button?**
 > Webflow blocks password form submissions on `.webflow.io` domains. By never
@@ -10,12 +10,12 @@ attributes to trigger login and logout from any storefront.
 
 ## Redirect lookup
 
-After a successful login or logout the SDK queries the `stores` table in
+After a successful login or sign-out the SDK queries the `stores` table in
 Supabase to find redirect URLs for the current domain. It matches on the
 `store_domain` column, normalizing `window.location.hostname` by stripping
 `www.` and lowercasing.
 
-If a row exists, it uses the `login_redirect_url` or `logout_redirect_url`
+If a row exists, it uses the `login_redirect_url` or `sign-out_redirect_url`
 columns. If nothing is configured or the domain is not found, the user is
 redirected to the site root (`/` or `window.location.origin`).
 
@@ -23,7 +23,7 @@ Required columns in the `stores` table:
 
 - `store_domain` – domain of the storefront
 - `login_redirect_url` – URL to redirect after login
-- `logout_redirect_url` – URL to redirect after logout
+- `sign-out_redirect_url` – URL to redirect after sign-out
 
 
 ## Usage
@@ -62,7 +62,8 @@ Markup example:
   <button type="submit">Create Account</button>
 </form>
 <div data-smoothr="login-google">Sign in with Google</div>
-<div data-smoothr="logout">Logout</div>
+<div data-smoothr="login-apple">Sign in with Apple</div>
+<div data-smoothr="sign-out">Logout</div>
 ```
 
 Error and success containers (`[data-smoothr-error]` and `[data-smoothr-success]`)
@@ -70,7 +71,7 @@ can live anywhere near the element that triggers the action. The SDK walks up
 the DOM from the clicked element to find the closest container before falling
 back to `alert()` and logging a message to the console if none exists.
 
-Both flows dispatch `smoothr:login` and `smoothr:logout` DOM events.
+Both flows dispatch `smoothr:login` and `smoothr:sign-out` DOM events.
 
 ## `[data-smoothr]` attributes
 
@@ -100,10 +101,16 @@ elements added later are also bound.
 <button data-smoothr="login-google">Sign in with Google</button>
 ```
 
-### `[data-smoothr="logout"]`
+### `[data-smoothr="login-apple"]`
 
 ```html
-<a href="#" data-smoothr="logout">Logout</a>
+<button data-smoothr="login-apple">Sign in with Apple</button>
+```
+
+### `[data-smoothr="sign-out"]`
+
+```html
+<a href="#" data-smoothr="sign-out">Logout</a>
 ```
 
 ### `[data-smoothr="password-reset"]`

--- a/storefronts/core/auth/index.js
+++ b/storefronts/core/auth/index.js
@@ -3,6 +3,7 @@ import {
   initAuth,
   initPasswordResetConfirmation,
   signInWithGoogle,
+  signInWithApple,
   signUp,
   requestPasswordReset,
   lookupRedirectUrl,
@@ -76,7 +77,7 @@ function bindAuthElements(root = document) {
   });
 
   const selector =
-    '[data-smoothr="signup"], [data-smoothr="login-google"], [data-smoothr="password-reset"]';
+    '[data-smoothr="signup"], [data-smoothr="login-google"], [data-smoothr="login-apple"], [data-smoothr="password-reset"]';
   root.querySelectorAll(selector).forEach(el => {
     if (el.dataset.smoothrBoundAuth) return;
     safeSetDataset(el, 'smoothrBoundAuth', '1');
@@ -88,6 +89,13 @@ function bindAuthElements(root = document) {
         el.addEventListener('click', async evt => {
           evt.preventDefault();
           await signInWithGoogle();
+        });
+        break;
+      }
+      case 'login-apple': {
+        el.addEventListener('click', async evt => {
+          evt.preventDefault();
+          await signInWithApple();
         });
         break;
       }
@@ -188,8 +196,8 @@ function bindAuthElements(root = document) {
   });
 }
 
-function bindLogoutButtons() {
-  document.querySelectorAll('[data-smoothr="logout"]').forEach(btn => {
+function bindSignOutButtons() {
+  document.querySelectorAll('[data-smoothr="sign-out"]').forEach(btn => {
     btn.addEventListener('click', async evt => {
       evt.preventDefault();
       const { error } = await supabase.auth.signOut();
@@ -209,19 +217,20 @@ function bindLogoutButtons() {
           log('%c🔒 Smoothr Auth: Not logged in', 'color: #f87171; font-weight: bold;');
         }
       }
-      document.dispatchEvent(new CustomEvent('smoothr:logout'));
-      const url = await lookupRedirectUrl('logout');
+      document.dispatchEvent(new CustomEvent('smoothr:sign-out'));
+      const url = await lookupRedirectUrl('sign-out');
       window.location.href = url;
     });
   });
 }
 
-registerDOMBindings(bindAuthElements, bindLogoutButtons);
+registerDOMBindings(bindAuthElements, bindSignOutButtons);
 
 export {
   initAuth,
   initPasswordResetConfirmation,
   signInWithGoogle,
+  signInWithApple,
   signUp,
   requestPasswordReset,
   lookupRedirectUrl,

--- a/storefronts/tests/sdk/dom-mutation.test.js
+++ b/storefronts/tests/sdk/dom-mutation.test.js
@@ -43,7 +43,7 @@ function flushPromises() {
 
 const LOGIN_SELECTOR = '[data-smoothr="login"]';
 const OTHER_SELECTOR =
-  '[data-smoothr="signup"], [data-smoothr="login-google"], [data-smoothr="password-reset"]';
+  '[data-smoothr="signup"], [data-smoothr="login-google"], [data-smoothr="login-apple"], [data-smoothr="password-reset"]';
 
 describe("dynamic DOM bindings", () => {
   let mutationCallback;
@@ -72,7 +72,7 @@ describe("dynamic DOM bindings", () => {
         if (selector === OTHER_SELECTOR) {
           return elements.filter(el => el.dataset?.smoothr !== "login");
         }
-        if (selector === '[data-smoothr="logout"]') return [];
+        if (selector === '[data-smoothr="sign-out"]') return [];
         return [];
       }),
       dispatchEvent: vi.fn(),

--- a/storefronts/tests/sdk/global-auth.test.js
+++ b/storefronts/tests/sdk/global-auth.test.js
@@ -28,10 +28,10 @@ function flushPromises() {
 }
 
 describe("global auth", () => {
-  let logoutHandler;
+  let signOutHandler;
 
   beforeEach(() => {
-    logoutHandler = undefined;
+    signOutHandler = undefined;
     global.window = {
       location: { origin: "", href: "", hostname: "" },
       addEventListener: vi.fn(),
@@ -41,10 +41,10 @@ describe("global auth", () => {
       addEventListener: vi.fn((evt, cb) => cb()),
       dispatchEvent: vi.fn(),
       querySelectorAll: vi.fn((selector) => {
-        if (selector === '[data-smoothr="logout"]') {
+        if (selector === '[data-smoothr="sign-out"]') {
           const btn = {
             addEventListener: vi.fn((event, cb) => {
-              if (event === "click") logoutHandler = cb;
+              if (event === "click") signOutHandler = cb;
             }),
           };
           return [btn];
@@ -63,7 +63,7 @@ describe("global auth", () => {
     expect(global.window.smoothr.auth.user).toEqual(user);
 
     getUserMock.mockResolvedValueOnce({ data: { user: null } });
-    await logoutHandler({ preventDefault: () => {} });
+    await signOutHandler({ preventDefault: () => {} });
     await flushPromises();
     expect(global.window.smoothr.auth.user).toBeNull();
   });

--- a/supabase/authHelpers.js
+++ b/supabase/authHelpers.js
@@ -164,7 +164,7 @@ export function initAuth() {
   });
   document.addEventListener('DOMContentLoaded', () => {
     bindAuthElements();
-    bindLogoutButtons();
+    bindSignOutButtons();
     if (typeof MutationObserver !== 'undefined') {
       const observer = new MutationObserver(() => bindAuthElements());
       observer.observe(document.body, { childList: true, subtree: true });
@@ -180,6 +180,17 @@ export async function signInWithGoogle() {
   }
   await supabase.auth.signInWithOAuth({
     provider: 'google',
+    options: { redirectTo: getOAuthRedirectUrl() }
+  });
+}
+
+export async function signInWithApple() {
+  await lookupRedirectUrl('login');
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('smoothr_oauth', '1');
+  }
+  await supabase.auth.signInWithOAuth({
+    provider: 'apple',
     options: { redirectTo: getOAuthRedirectUrl() }
   });
 }
@@ -258,9 +269,9 @@ export function initPasswordResetConfirmation({ redirectTo = '/' } = {}) {
 // Placeholder functions to avoid reference errors. These will be provided by
 // storefront modules at runtime.
 export let bindAuthElements = () => {};
-export let bindLogoutButtons = () => {};
+export let bindSignOutButtons = () => {};
 
-export function registerDOMBindings(bindAuth, bindLogout) {
+export function registerDOMBindings(bindAuth, bindSignOut) {
   bindAuthElements = bindAuth;
-  bindLogoutButtons = bindLogout;
+  bindSignOutButtons = bindSignOut;
 }


### PR DESCRIPTION
## Summary
- support Apple OAuth login via new `data-smoothr="login-apple"` switch case
- rename logout bindings to sign-out, updating selectors, events, and redirect keys
- document sign-out flow and new login attributes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f270a39148325bda8f540103555c8