### PR TITLE
refactor(auth): use reactive user ref

### DIFF
--- a/storefronts/checkout/checkout.js
+++ b/storefronts/checkout/checkout.js
@@ -144,7 +144,7 @@ export async function initCheckout(config) {
         (window.Smoothr.cart.getTotal?.() || parseFloat(totalEl.textContent.replace(/[^0-9.]/g, '')) || 0) * 100
       );
       const currency = window.SMOOTHR_CONFIG.baseCurrency;
-      const customer_id = window.smoothr.auth.user?.id || null;
+      const customer_id = window.smoothr.auth.user?.value?.id || null;
       const store_id = window.SMOOTHR_CONFIG.storeId;
       const platform = window.SMOOTHR_CONFIG.platform;
 

--- a/storefronts/checkout/gateways/paypal.js
+++ b/storefronts/checkout/gateways/paypal.js
@@ -112,7 +112,7 @@ export async function mountCardFields() {
         cart,
         total,
         currency,
-        customer_id: window.smoothr?.auth?.user?.id || null,
+        customer_id: window.smoothr?.auth?.user?.value?.id || null,
         platform: window.SMOOTHR_CONFIG?.platform
       };
 

--- a/storefronts/core/auth/README.md
+++ b/storefronts/core/auth/README.md
@@ -182,12 +182,12 @@ and the final redirect is determined by the store settings described earlier.
 ## Accessing the current user
 
 `initAuth()` retrieves the existing session and exposes it on
-`window.smoothr.auth.user`. The value is `null` if no user is logged in.
+`window.smoothr.auth.user.value`. The value is `null` if no user is logged in.
 After `initAuth()` resolves (or after automatic initialization when loading
 the SDK) you can check whether someone is logged in by reading:
 
 ```javascript
-window.smoothr?.auth?.user !== null
+window.smoothr?.auth?.user?.value !== null
 ```
 
 This property is `undefined` before initialization, so ensure `initAuth()` has

--- a/storefronts/core/index.js
+++ b/storefronts/core/index.js
@@ -184,7 +184,7 @@ export default Smoothr;
     });
 
     Promise.resolve(auth.initAuth()).then(() => {
-      if (window.smoothr?.auth?.user) {
+      if (window.smoothr?.auth?.user?.value) {
         orders.renderOrders();
       }
     });

--- a/storefronts/core/orders/index.js
+++ b/storefronts/core/orders/index.js
@@ -57,7 +57,7 @@ export async function renderOrders(container) {
     if (el !== template) el.remove();
   });
 
-  const user = window.smoothr?.auth?.user;
+  const user = window.smoothr?.auth?.user?.value;
   const orders = await fetchOrderHistory(user?.id);
 
   if (!orders.length) {

--- a/storefronts/tests/sdk/dom-mutation.test.js
+++ b/storefronts/tests/sdk/dom-mutation.test.js
@@ -129,7 +129,7 @@ describe("dynamic DOM bindings", () => {
     await clickHandler({ preventDefault: () => {} });
     await flushPromises();
 
-    expect(global.window.smoothr.auth.user).toEqual(user);
+    expect(global.window.smoothr.auth.user.value).toEqual(user);
     expect(global.document.dispatchEvent).toHaveBeenCalled();
     const evt = global.document.dispatchEvent.mock.calls.at(-1)[0];
     expect(evt.type).toBe("smoothr:login");
@@ -174,7 +174,7 @@ describe("dynamic DOM bindings", () => {
     await clickHandler({ preventDefault: () => {} });
     await flushPromises();
 
-    expect(global.window.smoothr.auth.user).toEqual(user);
+    expect(global.window.smoothr.auth.user.value).toEqual(user);
     expect(global.document.dispatchEvent).toHaveBeenCalled();
     const evt = global.document.dispatchEvent.mock.calls.at(-1)[0];
     expect(evt.type).toBe("smoothr:login");

--- a/storefronts/tests/sdk/global-auth.test.js
+++ b/storefronts/tests/sdk/global-auth.test.js
@@ -62,11 +62,11 @@ describe("global auth", () => {
 
     initAuth();
     await flushPromises();
-    expect(global.window.smoothr.auth.user).toEqual(user);
+    expect(global.window.smoothr.auth.user.value).toEqual(user);
 
     getUserMock.mockResolvedValueOnce({ data: { user: null } });
     await signOutHandler({ preventDefault: () => {} });
     await flushPromises();
-    expect(global.window.smoothr.auth.user).toBeNull();
+    expect(global.window.smoothr.auth.user.value).toBeNull();
   });
 });

--- a/storefronts/tests/sdk/login.test.js
+++ b/storefronts/tests/sdk/login.test.js
@@ -107,6 +107,6 @@ describe("login form", () => {
     await flushPromises();
     await clickHandler({ preventDefault: () => {} });
     await flushPromises();
-    expect(global.window.smoothr.auth.user).toEqual(user);
+    expect(global.window.smoothr.auth.user.value).toEqual(user);
   });
 });

--- a/storefronts/tests/sdk/password-reset.test.js
+++ b/storefronts/tests/sdk/password-reset.test.js
@@ -221,6 +221,6 @@ describe("password reset confirmation", () => {
     await flushPromises();
     await clickHandler({ preventDefault: () => {} });
     await flushPromises();
-    expect(global.window.smoothr.auth.user).toEqual(user);
+    expect(global.window.smoothr.auth.user.value).toEqual(user);
   });
 });

--- a/storefronts/tests/sdk/signup.test.js
+++ b/storefronts/tests/sdk/signup.test.js
@@ -138,6 +138,6 @@ describe("signup flow", () => {
     await flushPromises();
     await clickHandler({ preventDefault: () => {} });
     await flushPromises();
-    expect(global.window.smoothr.auth.user).toEqual(user);
+    expect(global.window.smoothr.auth.user.value).toEqual(user);
   });
 });


### PR DESCRIPTION
## Summary
- expose auth helpers (login, signup, resetPassword, signOut) and track the session user with a reactive ref
- keep global Smoothr.auth reference stable and export default auth object
- update modules and docs to reference `user.value`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f3efaf3dc8325b41a8402f7af0823