### PR TITLE
feat(auth): add account access binding

### DIFF
--- a/storefronts/core/auth/index.js
+++ b/storefronts/core/auth/index.js
@@ -311,6 +311,27 @@ function bindAuthElements(root = document) {
       }
     }
   });
+
+  document.querySelectorAll('[data-smoothr="account-access"]').forEach(el => {
+    if (el.dataset.smoothrBoundAuth) return;
+    safeSetDataset(el, 'smoothrBoundAuth', '1');
+
+    el.addEventListener('click', async evt => {
+      evt.preventDefault();
+      const currentUser = window.smoothr?.auth?.user?.value;
+      if (currentUser) {
+        const url = (await lookupDashboardHomeUrl()) || '/';
+        window.location.href = url;
+      } else {
+        const target = document.querySelector('[data-smoothr="auth-wrapper"]');
+        (target || document).dispatchEvent(
+          new CustomEvent('smoothr:open-auth', {
+            detail: { targetSelector: '[data-smoothr="auth-wrapper"]' }
+          })
+        );
+      }
+    });
+  });
 }
 
 function bindSignOutButtons() {

--- a/supabase/authHelpers.js
+++ b/supabase/authHelpers.js
@@ -182,7 +182,10 @@ export function initAuth() {
     bindAuthElements();
     bindSignOutButtons();
     if (typeof MutationObserver !== 'undefined') {
-      const observer = new MutationObserver(() => bindAuthElements());
+      const observer = new MutationObserver(() => {
+        bindAuthElements();
+        bindSignOutButtons();
+      });
       observer.observe(document.body, { childList: true, subtree: true });
     }
   });


### PR DESCRIPTION
## Summary
- add account-access click handling to auth bindings
- ensure MutationObserver rebinds sign-out buttons and auth elements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f5742a1008325b47ee71cbfa2e6af