### PR TITLE
refactor: use null check for account access

### DIFF
--- a/storefronts/core/auth/index.js
+++ b/storefronts/core/auth/index.js
@@ -318,8 +318,8 @@ function bindAuthElements(root = document) {
 
     el.addEventListener('click', async evt => {
       evt.preventDefault();
-      const currentUser = window.smoothr?.auth?.user?.value;
-      if (currentUser) {
+      const userRef = window.smoothr?.auth?.user;
+      if (userRef?.value !== null) {
         const url = (await lookupDashboardHomeUrl()) || '/';
         window.location.href = url;
       } else {


### PR DESCRIPTION
## Summary
- explicitly compare account access user ref against null to avoid false positives

## Testing
- `npm --workspace storefronts test`


------
https://chatgpt.com/codex/tasks/task_e_688f68781954832589e25061dd1f71c0