### PR TITLE
Include store ID in auth requests

### DIFF
--- a/storefronts/core/auth/index.js
+++ b/storefronts/core/auth/index.js
@@ -17,7 +17,11 @@ import {
   findMessageContainer
 } from '../../../supabase/authHelpers.js';
 
-const debug = window.SMOOTHR_CONFIG?.debug;
+// Ensure SMOOTHR_CONFIG is accessible in both browser and non-browser environments
+const globalScope = typeof window !== 'undefined' ? window : globalThis;
+const SMOOTHR_CONFIG = globalScope.SMOOTHR_CONFIG || {};
+
+const debug = SMOOTHR_CONFIG?.debug;
 const log = (...args) => debug && console.log('[Smoothr Auth]', ...args);
 
 // minimal reactive ref implementation
@@ -30,7 +34,8 @@ const user = ref(null);
 async function login(email, password) {
   const { data, error } = await supabase.auth.signInWithPassword({
     email,
-    password
+    password,
+    options: { data: { store_id: SMOOTHR_CONFIG.storeId } }
   });
   if (!error) {
     user.value = data.user || null;
@@ -43,7 +48,11 @@ async function login(email, password) {
 }
 
 async function signup(email, password) {
-  const { data, error } = await supabase.auth.signUp({ email, password });
+  const { data, error } = await supabase.auth.signUp({
+    email,
+    password,
+    options: { data: { store_id: SMOOTHR_CONFIG.storeId } }
+  });
   if (!error) {
     user.value = data.user || null;
     if (typeof window !== 'undefined') {

--- a/storefronts/tests/sdk/signup.test.js
+++ b/storefronts/tests/sdk/signup.test.js
@@ -97,6 +97,7 @@ describe("signup flow", () => {
     expect(signUpMock).toHaveBeenCalledWith({
       email: "test@example.com",
       password: "Password1",
+      options: { data: { store_id: globalThis.SMOOTHR_CONFIG.storeId } },
     });
     expect(global.document.dispatchEvent).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- Ensure `SMOOTHR_CONFIG` is pulled from `window`/`globalThis` so auth flows work in both browser and server contexts
- Include `store_id` metadata when logging in or signing up
- Adjust signup tests for new Supabase options payload

## Testing
- `npm --workspace storefronts test`
- `npm run test:supabase`


------
https://chatgpt.com/codex/tasks/task_e_68901f60abec8325a3d48ff5cac4efe3