### PR TITLE
feat: expose Supabase auth client on storefront

### DIFF
--- a/storefronts/tests/sdk/account-access.test.js
+++ b/storefronts/tests/sdk/account-access.test.js
@@ -9,6 +9,7 @@ vi.mock("@supabase/supabase-js", () => {
     auth: {
       getUser: getUserMock,
       signOut: vi.fn(),
+      onAuthStateChange: vi.fn(),
     },
     from: vi.fn(() => ({
       select: vi.fn(() => ({

--- a/storefronts/tests/sdk/auth-state-change.test.js
+++ b/storefronts/tests/sdk/auth-state-change.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+var onAuthStateChangeHandler;
+var getUserMock;
+var createClientMock;
+var getSessionMock;
+
+vi.mock("@supabase/supabase-js", () => {
+  getUserMock = vi.fn(() => Promise.resolve({ data: { user: null } }));
+  getSessionMock = vi.fn(() => Promise.resolve({ data: { session: {} }, error: null }));
+  const auth = {
+    getUser: getUserMock,
+    signOut: vi.fn(),
+    onAuthStateChange: vi.fn(cb => {
+      onAuthStateChangeHandler = cb;
+      return { data: { subscription: { unsubscribe: vi.fn() } } };
+    }),
+    getSession: getSessionMock
+  };
+  const client = {
+    auth,
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn().mockResolvedValue({ data: null, error: null })
+        }))
+      }))
+    }))
+  };
+  createClientMock = vi.fn(() => client);
+  return { createClient: createClientMock };
+});
+
+import * as auth from "../../core/auth/index.js";
+
+function flushPromises() {
+  return new Promise(setImmediate);
+}
+
+describe("auth state change", () => {
+  beforeEach(() => {
+    global.window = {
+      location: { origin: "", href: "", hostname: "" },
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    };
+    global.document = {
+      addEventListener: vi.fn((evt, cb) => {
+        if (evt === "DOMContentLoaded") cb();
+      }),
+      querySelectorAll: vi.fn(() => []),
+      dispatchEvent: vi.fn()
+    };
+  });
+
+  it("updates user and global auth on session change", async () => {
+    await auth.initAuth();
+    await flushPromises();
+    const user = { id: "42", email: "test@example.com" };
+    onAuthStateChangeHandler("SIGNED_IN", { user });
+    expect(global.window.smoothr.auth.user.value).toEqual(user);
+    expect(global.window.smoothr.auth.client).toBeDefined();
+    await global.window.smoothr.auth.client.auth.getSession();
+    expect(getSessionMock).toHaveBeenCalled();
+  });
+});

--- a/storefronts/tests/sdk/dom-mutation.test.js
+++ b/storefronts/tests/sdk/dom-mutation.test.js
@@ -23,6 +23,7 @@ vi.mock("@supabase/supabase-js", () => {
       signInWithOAuth: signInWithOAuthMock,
       signUp: signUpMock,
       resetPasswordForEmail: resetPasswordMock,
+      onAuthStateChange: vi.fn(),
     },
     from: vi.fn(() => ({
       select: vi.fn(() => ({

--- a/storefronts/tests/sdk/global-auth.test.js
+++ b/storefronts/tests/sdk/global-auth.test.js
@@ -9,7 +9,7 @@ vi.mock("@supabase/supabase-js", () => {
   getUserMock = vi.fn();
   signOutMock = vi.fn(() => Promise.resolve({ error: null }));
   createClientMock = vi.fn(() => ({
-    auth: { getUser: getUserMock, signOut: signOutMock },
+    auth: { getUser: getUserMock, signOut: signOutMock, onAuthStateChange: vi.fn() },
     from: vi.fn(() => ({
       select: vi.fn(() => ({
         eq: vi.fn(() => ({

--- a/storefronts/tests/sdk/google-login.test.js
+++ b/storefronts/tests/sdk/google-login.test.js
@@ -13,6 +13,7 @@ vi.mock("@supabase/supabase-js", () => {
       getUser: getUserMock,
       signOut: vi.fn(),
       signInWithOAuth: signInWithOAuthMock,
+      onAuthStateChange: vi.fn(),
     },
     from: vi.fn(() => ({
       select: vi.fn(() => ({

--- a/storefronts/tests/sdk/login-dataset-immutable.test.js
+++ b/storefronts/tests/sdk/login-dataset-immutable.test.js
@@ -13,6 +13,7 @@ vi.mock("@supabase/supabase-js", () => {
       getUser: getUserMock,
       signInWithPassword: signInMock,
       signOut: vi.fn(),
+      onAuthStateChange: vi.fn(),
     },
     from: vi.fn(() => ({
       select: vi.fn(() => ({

--- a/storefronts/tests/sdk/login.test.js
+++ b/storefronts/tests/sdk/login.test.js
@@ -4,15 +4,19 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 var signInMock;
 var getUserMock;
 var createClientMock;
+var getSessionMock;
 
 vi.mock("@supabase/supabase-js", () => {
   signInMock = vi.fn();
   getUserMock = vi.fn(() => Promise.resolve({ data: { user: null } }));
+  getSessionMock = vi.fn(() => Promise.resolve({ data: { session: {} }, error: null }));
   createClientMock = vi.fn(() => ({
     auth: {
       getUser: getUserMock,
       signInWithPassword: signInMock,
       signOut: vi.fn(),
+      onAuthStateChange: vi.fn(),
+      getSession: getSessionMock,
     },
     from: vi.fn(() => ({
       select: vi.fn(() => ({
@@ -108,5 +112,7 @@ describe("login form", () => {
     await clickHandler({ preventDefault: () => {} });
     await flushPromises();
     expect(global.window.smoothr.auth.user.value).toEqual(user);
+    await global.window.smoothr.auth.client.auth.getSession();
+    expect(getSessionMock).toHaveBeenCalled();
   });
 });

--- a/storefronts/tests/sdk/password-reset.test.js
+++ b/storefronts/tests/sdk/password-reset.test.js
@@ -21,6 +21,7 @@ vi.mock("@supabase/supabase-js", () => {
       resetPasswordForEmail: resetPasswordMock,
       updateUser: updateUserMock,
       setSession: setSessionMock,
+      onAuthStateChange: vi.fn(),
     },
     from: vi.fn(() => ({
       select: vi.fn(() => ({

--- a/storefronts/tests/sdk/signup.test.js
+++ b/storefronts/tests/sdk/signup.test.js
@@ -4,16 +4,20 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 var signUpMock;
 var getUserMock;
 var createClientMock;
+var getSessionMock;
 
 vi.mock("@supabase/supabase-js", () => {
   signUpMock = vi.fn();
   getUserMock = vi.fn(() => Promise.resolve({ data: { user: null } }));
+  getSessionMock = vi.fn(() => Promise.resolve({ data: { session: {} }, error: null }));
   createClientMock = vi.fn(() => ({
     auth: {
       getUser: getUserMock,
       signUp: signUpMock,
       signOut: vi.fn(),
       signInWithOAuth: vi.fn(),
+      onAuthStateChange: vi.fn(),
+      getSession: getSessionMock,
     },
     from: vi.fn(() => ({
       select: vi.fn(() => ({
@@ -140,5 +144,7 @@ describe("signup flow", () => {
     await clickHandler({ preventDefault: () => {} });
     await flushPromises();
     expect(global.window.smoothr.auth.user.value).toEqual(user);
+    await global.window.smoothr.auth.client.auth.getSession();
+    expect(getSessionMock).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- expose Supabase client via `window.smoothr.auth.client`
- refresh global auth state on Supabase session changes
- cover auth listener and session retrieval in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890251d87748325adce7dca5f010e1b