### PR TITLE
refactor: add global SMOOTHR_CONFIG fallback

### DIFF
--- a/supabase/authHelpers.js
+++ b/supabase/authHelpers.js
@@ -1,6 +1,9 @@
 import { supabase } from '../shared/supabase/browserClient';
 
-const debug = typeof window !== 'undefined' && window.SMOOTHR_CONFIG?.debug;
+const globalScope = typeof window !== 'undefined' ? window : globalThis;
+const SMOOTHR_CONFIG = globalScope.SMOOTHR_CONFIG || {};
+
+const debug = SMOOTHR_CONFIG.debug;
 const log = (...args) => debug && console.log('[Smoothr Auth]', ...args);
 const warn = (...args) => debug && console.warn('[Smoothr Auth]', ...args);
 const err = (...args) => debug && console.error('[Smoothr Auth]', ...args);


### PR DESCRIPTION
## Summary
- add globalScope and SMOOTHR_CONFIG helper to avoid direct window access
- reference SMOOTHR_CONFIG for debugging and sign-up store ID

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68902e355fa083259eb6c5f0563117ac