### PR TITLE
Retry checkout init when trigger missing

### DIFF
--- a/storefronts/README.md
+++ b/storefronts/README.md
@@ -136,6 +136,11 @@ the SDK listens for the `submit` event so clicks on child elements won't start
 checkout. Avoid adding the attribute to generic containers to prevent unwanted
 triggers.
 
+The `[data-smoothr-pay]` element must exist in the DOM before `initCheckout`
+runs. If the trigger is inserted asynchronously, delay calling `initCheckout`
+or ensure the element is present. When no checkout trigger is found the SDK
+logs a warning and re-attempts initialization after a short delay.
+
 The script posts the cart to `/api/checkout/[provider]` where `[provider]` is the
 active payment gateway. This single endpoint handles all providers. `initCheckout` chooses the gateway by reading
 `window.SMOOTHR_CONFIG.active_payment_gateway`. When the property isn't defined,

--- a/storefronts/checkout/checkout.js
+++ b/storefronts/checkout/checkout.js
@@ -71,7 +71,15 @@ export async function initCheckout(config) {
   // mount fields common to all gateways
   const checkoutEl = await select('[data-smoothr-pay]');
   if (!checkoutEl) {
-    warn('Missing [data-smoothr-pay]');
+    warn(
+      'No checkout trigger found. Add a [data-smoothr-pay] element or delay initCheckout.'
+    );
+    window.__SMOOTHR_CHECKOUT_INITIALIZED__ = false;
+    window.__SMOOTHR_CHECKOUT_BOUND__ = false;
+    if (!window.__SMOOTHR_CHECKOUT_RETRY__) {
+      window.__SMOOTHR_CHECKOUT_RETRY__ = true;
+      setTimeout(() => initCheckout(config), 100);
+    }
     return;
   }
   log('checkout trigger found', checkoutEl);


### PR DESCRIPTION
## Summary
- warn and retry `initCheckout` when no `[data-smoothr-pay]` element is present
- document requirement for checkout trigger in `storefronts/README.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68903fe24af8832581d46dce3a210131