### PR TITLE
chore: bundle Supabase deps in Vite optimizeDeps

### DIFF
--- a/storefronts/vite.config.js
+++ b/storefronts/vite.config.js
@@ -25,6 +25,17 @@ const inputFiles = getAllJs(path.resolve(__dirname, 'core'));
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
   return {
+    optimizeDeps: {
+      include: [
+        '@supabase/supabase-js',
+        '@supabase/gotrue-js',
+        '@supabase/postgrest-js',
+        '@supabase/storage-js',
+        '@supabase/realtime-js',
+        '@supabase/functions-js',
+        'isows'
+      ]
+    },
     define: {
       // Map Cloudflare’s NEXT_PUBLIC_* secrets into process.env
       'process.env.NEXT_PUBLIC_SUPABASE_URL': JSON.stringify(env.NEXT_PUBLIC_SUPABASE_URL),
@@ -44,6 +55,7 @@ export default defineConfig(({ mode }) => {
     build: {
       target: 'esnext', // ✅ Enables top-level await
       rollupOptions: {
+        external: [],
         input: inputFiles,
         treeshake: false,
         preserveEntrySignatures: 'exports-only',


### PR DESCRIPTION
## Summary
- include Supabase and related packages in Vite `optimizeDeps.include`
- ensure Rollup bundles all dependencies by clearing `rollupOptions.external`

## Testing
- `npm run build`
- `find dist -maxdepth 1 -type d`
- `npm test`
- `npx wrangler pages deploy dist` *(fails: npm error canceled)*
- `curl -I https://sdk.smoothr.io/smoothr-sdk.js`

------
https://chatgpt.com/codex/tasks/task_e_68904ae881cc8325b15b777c455b40c4