### PR TITLE
refactor: simplify storefronts build config

### DIFF
--- a/storefronts/vite.config.js
+++ b/storefronts/vite.config.js
@@ -1,40 +1,15 @@
 import { defineConfig, loadEnv } from 'vite';
 import path from 'path';
-import fs from 'fs';
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-function getAllJs(dir) {
-  const entries = fs.readdirSync(dir, { withFileTypes: true });
-  const files = [];
-  for (const entry of entries) {
-    const full = path.resolve(dir, entry.name);
-    if (entry.isDirectory()) {
-      files.push(...getAllJs(full));
-    } else if (entry.isFile() && full.endsWith('.js')) {
-      files.push(full);
-    }
-  }
-  return files;
-}
-
-const inputFiles = getAllJs(path.resolve(__dirname, 'core'));
-
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
   return {
     optimizeDeps: {
-      include: [
-        '@supabase/supabase-js',
-        '@supabase/gotrue-js',
-        '@supabase/postgrest-js',
-        '@supabase/storage-js',
-        '@supabase/realtime-js',
-        '@supabase/functions-js',
-        'isows'
-      ]
+      include: ['@supabase/supabase-js']
     },
     define: {
       // Map Cloudflare’s NEXT_PUBLIC_* secrets into process.env
@@ -56,15 +31,14 @@ export default defineConfig(({ mode }) => {
       target: 'esnext', // ✅ Enables top-level await
       rollupOptions: {
         external: [],
-        input: inputFiles,
+        input: path.resolve(__dirname, 'core/index.js'),
         treeshake: false,
         preserveEntrySignatures: 'exports-only',
         output: {
-          preserveModules: true,
-          preserveModulesRoot: path.resolve(__dirname, 'core'),
-          entryFileNames: (chunk) =>
-            chunk.name === 'index' ? 'smoothr-sdk.js' : '[name].js',
-          chunkFileNames: '[name].js'
+          dir: path.resolve(__dirname, 'dist'),
+          entryFileNames: 'smoothr-sdk.js',
+          format: 'es',
+          inlineDynamicImports: true
         }
       },
       outDir: 'dist',


### PR DESCRIPTION
## Summary
- streamline `storefronts/vite.config.js` to bundle only the SDK entrypoint
- produce single ESM output `dist/smoothr-sdk.js`
- limit dev bundling to `@supabase/supabase-js`

## Testing
- `npm --workspace storefronts run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689051f9c8008325a34c133e3914f245