### PR TITLE
Refactor SDK to use static imports for feature modules

### DIFF
--- a/storefronts/core/index.js
+++ b/storefronts/core/index.js
@@ -1,5 +1,24 @@
 import { supabase } from '../../shared/supabase/browserClient';
 
+import * as abandonedCart from './abandoned-cart/index.js';
+import * as affiliates from './affiliates/index.js';
+import * as analytics from './analytics/index.js';
+import * as currency from './currency/index.js';
+import * as dashboard from './dashboard/index.js';
+import * as discounts from './discounts/index.js';
+import * as cart from './cart.js';
+import * as orders from './orders/index.js';
+import * as returns from './returns/index.js';
+import * as reviews from './reviews/index.js';
+import * as subscriptions from './subscriptions/index.js';
+import authModule from './auth/index.js';
+import stripeGateway from '../checkout/gateways/stripe.js';
+import { fetchExchangeRates } from './currency/live-rates.js';
+import { initCartBindings } from './cart/addToCart.js';
+import { renderCart } from './cart/renderCart.js';
+import { setSelectedCurrency as setDomCurrency } from '../platforms/webflow/webflow-dom.js';
+import { setSelectedCurrency as setCmsCurrency } from './currency/cms-currency.js';
+
 // Capture the store ID as soon as the bundle loads
 const script = document.currentScript || document.getElementById('smoothr-sdk');
 const storeId = script?.getAttribute?.('data-store-id') || script?.dataset?.storeId;
@@ -11,95 +30,7 @@ if (!storeId)
     '[Smoothr SDK] No storeId found — auth metadata will be incomplete'
   );
 
-// Dynamically import modules that rely on SMOOTHR_CONFIG
-const moduleDefs = [
-  { name: 'abandonedCart', path: './abandoned-cart/index.js' },
-  { name: 'affiliates', path: './affiliates/index.js' },
-  { name: 'analytics', path: './analytics/index.js' },
-  { name: 'currency', path: './currency/index.js' },
-  { name: 'dashboard', path: './dashboard/index.js' },
-  { name: 'discounts', path: './discounts/index.js' },
-  { name: 'cart', path: './cart.js' },
-  { name: 'orders', path: './orders/index.js' },
-  { name: 'returns', path: './returns/index.js' },
-  { name: 'reviews', path: './reviews/index.js' },
-  { name: 'subscriptions', path: './subscriptions/index.js' },
-  { name: 'authModule', path: './auth/index.js', exports: ['initAuth'] },
-  { name: 'stripeGateway', path: '../checkout/gateways/stripe.js' },
-  {
-    name: 'liveRates',
-    path: './currency/live-rates.js',
-    exports: ['fetchExchangeRates']
-  },
-  {
-    name: 'addToCart',
-    path: './cart/addToCart.js',
-    exports: ['initCartBindings']
-  },
-  {
-    name: 'renderCartModule',
-    path: './cart/renderCart.js',
-    exports: ['renderCart']
-  },
-  {
-    name: 'webflowDom',
-    path: '../platforms/webflow/webflow-dom.js',
-    exports: ['setSelectedCurrency']
-  },
-  {
-    name: 'cmsCurrencyModule',
-    path: './currency/cms-currency.js',
-    exports: ['setSelectedCurrency']
-  }
-];
-
-const modulesLoaded = {};
-
-for (const { name, path, exports: expected } of moduleDefs) {
-  try {
-    const mod = await import(path);
-    modulesLoaded[name] = mod;
-    if (expected) {
-      for (const exp of expected) {
-        if (typeof mod[exp] === 'undefined') {
-          console.warn(
-            `[Smoothr SDK] ${name} missing expected export "${exp}"`
-          );
-        }
-      }
-    }
-  } catch (err) {
-    console.error(`[Smoothr SDK] Failed to load ${name} from ${path}`, err);
-  }
-}
-
-const {
-  abandonedCart,
-  affiliates,
-  analytics,
-  currency,
-  dashboard,
-  discounts,
-  cart,
-  orders,
-  returns,
-  reviews,
-  subscriptions,
-  authModule,
-  stripeGateway,
-  liveRates,
-  addToCart,
-  renderCartModule,
-  webflowDom,
-  cmsCurrencyModule
-} = modulesLoaded;
-
 const auth = authModule?.default || authModule;
-const { fetchExchangeRates } = liveRates || {};
-const { initCartBindings } = addToCart || {};
-const { renderCart } = renderCartModule || {};
-const { setSelectedCurrency: setDomCurrency } = webflowDom || {};
-const { setSelectedCurrency: setCmsCurrency } = cmsCurrencyModule || {};
 
 // Load config from public_store_settings into window.SMOOTHR_CONFIG
 async function loadConfig(storeId) {
@@ -193,6 +124,7 @@ export default Smoothr;
 
   if (typeof window !== 'undefined') {
     const cfg = window.SMOOTHR_CONFIG;
+    const isFeatureEnabled = name => cfg?.features?.[name] !== false;
 
     // Inject card styles
     if (
@@ -243,6 +175,14 @@ export default Smoothr;
       setSelectedCurrency = setCmsCurrency;
     }
 
+    if (isFeatureEnabled('abandonedCart')) {
+      try {
+        if (typeof abandonedCart.setupAbandonedCartTracker === 'function') {
+          abandonedCart.setupAbandonedCartTracker({ debug: cfg.debug });
+        }
+      } catch {}
+    }
+
     window.Smoothr = Smoothr;
     window.smoothr = window.smoothr || {};
     window.smoothr.auth = auth;
@@ -252,30 +192,32 @@ export default Smoothr;
     window.smoothr.getSession = () => supabase.auth.getSession();
     window.smoothr.getUser = () => supabase.auth.getUser();
 
-    window.renderCart = renderCart;
-    log('🎨 renderCart registered in SDK');
+    if (isFeatureEnabled('cart')) {
+      window.renderCart = renderCart;
+      log('🎨 renderCart registered in SDK');
 
-    window.Smoothr.cart = { ...cart, ...(window.Smoothr.cart || {}) };
-    window.Smoothr.cart.renderCart = renderCart;
-    window.Smoothr.checkout = stripeGateway;
-    window.initCartBindings = initCartBindings;
+      window.Smoothr.cart = { ...cart, ...(window.Smoothr.cart || {}) };
+      window.Smoothr.cart.renderCart = renderCart;
+      window.Smoothr.checkout = stripeGateway;
+      window.initCartBindings = initCartBindings;
 
-    document.addEventListener('DOMContentLoaded', () => {
-      log('✅ DOM ready – calling initCartBindings');
-      if (typeof initCartBindings === 'function') {
-        initCartBindings();
-      } else {
-        console.warn('[Smoothr SDK] initCartBindings is not available');
-      }
-    });
+      document.addEventListener('DOMContentLoaded', () => {
+        log('✅ DOM ready – calling initCartBindings');
+        if (typeof initCartBindings === 'function') {
+          initCartBindings();
+        } else {
+          console.warn('[Smoothr SDK] initCartBindings is not available');
+        }
+      });
+    }
 
-    if (auth?.initAuth) {
+    if (isFeatureEnabled('auth') && auth?.initAuth) {
       auth.initAuth().then(() => {
         if (window.smoothr?.auth?.user?.value && orders?.renderOrders) {
           orders.renderOrders();
         }
       });
-    } else {
+    } else if (!auth?.initAuth) {
       console.warn('[Smoothr SDK] auth.initAuth is not available');
     }
 


### PR DESCRIPTION
## Summary
- replace dynamic module loading with static imports
- conditionally initialize features through `cfg.features`
- gate cart and auth setup on feature enablement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68905318f90483259173e5d8d3bd03d0