### PR TITLE
feat: centralize public config loading

### DIFF
--- a/storefronts/checkout/gateways/stripe.js
+++ b/storefronts/checkout/gateways/stripe.js
@@ -4,7 +4,7 @@ import forceStripeIframeStyle, {
   initStripeStyles
 } from '../utils/stripeIframeStyles.js';
 
-import { supabase } from '../../../shared/supabase/browserClient';
+import { loadPublicConfig } from '../../core/config.ts';
 import { getPublicCredential } from '../getPublicCredential.js';
 import { handleSuccessRedirect } from '../utils/handleSuccessRedirect.js';
 let fieldsMounted = false;
@@ -224,16 +224,7 @@ export function ready() {
 export async function getStoreSettings(storeId) {
   if (!storeId) return null;
   try {
-    const { data, error } = await supabase
-      .from('public_store_settings')
-      .select('*')
-      .eq('store_id', storeId)
-      .maybeSingle();
-    if (error) {
-      warn('Store settings lookup failed:', error.message || error);
-      return null;
-    }
-    return data || null;
+    return await loadPublicConfig(storeId);
   } catch (e) {
     warn('Store settings fetch error:', e?.message || e);
     return null;

--- a/storefronts/checkout/utils/resolveGateway.js
+++ b/storefronts/checkout/utils/resolveGateway.js
@@ -1,5 +1,5 @@
 import resolveGateway from '../../../core/utils/resolveGateway.js';
-import { getStoreSettings } from '../gateways/stripe.js';
+import { loadPublicConfig } from '../../core/config.ts';
 
 export default async function getActivePaymentGateway(log = () => {}, warn = () => {}) {
   const cfg = window.SMOOTHR_CONFIG || {};
@@ -12,7 +12,7 @@ export default async function getActivePaymentGateway(log = () => {}, warn = () 
     throw new Error('Store ID missing');
   }
 
-  const settings = await getStoreSettings(storeId);
+  const settings = await loadPublicConfig(storeId);
   try {
     return resolveGateway(cfg, settings || {});
   } catch (e) {

--- a/storefronts/core/config.ts
+++ b/storefronts/core/config.ts
@@ -1,0 +1,28 @@
+import { createClient } from '@supabase/supabase-js';
+
+const debug = typeof window !== 'undefined' && window.SMOOTHR_CONFIG?.debug;
+const warn = (...args: any[]) => debug && console.warn('[Smoothr Config]', ...args);
+
+export async function loadPublicConfig(storeId: string) {
+  if (!storeId) return null;
+  try {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+    const client = createClient(url, anonKey, {
+      auth: { storageKey: 'smoothr-public', persistSession: false }
+    });
+    const { data, error } = await client
+      .from('public_store_settings')
+      .select('*')
+      .eq('store_id', storeId)
+      .maybeSingle();
+    if (error) {
+      warn('Store settings lookup failed:', error.message || error);
+      return null;
+    }
+    return data || null;
+  } catch (e: any) {
+    warn('Store settings fetch error:', e?.message || e);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add `loadPublicConfig` helper for fetching public store config
- use shared helper in Stripe gateway and checkout gateway resolution

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689095d0d4e483259825177d3709113c