### PR TITLE
feat: isolate public supabase session

### DIFF
--- a/storefronts/core/config.ts
+++ b/storefronts/core/config.ts
@@ -3,14 +3,16 @@ import { createClient } from '@supabase/supabase-js';
 const debug = typeof window !== 'undefined' && window.SMOOTHR_CONFIG?.debug;
 const warn = (...args: any[]) => debug && console.warn('[Smoothr Config]', ...args);
 
+export const anonClientOptions = {
+  auth: { storageKey: 'smoothr-public', persistSession: false }
+};
+
 export async function loadPublicConfig(storeId: string) {
   if (!storeId) return null;
   try {
     const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
     const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-    const client = createClient(url, anonKey, {
-      auth: { storageKey: 'smoothr-public', persistSession: false }
-    });
+    const client = createClient(url, anonKey, anonClientOptions);
     const { data, error } = await client
       .from('public_store_settings')
       .select('*')

--- a/storefronts/core/index.js
+++ b/storefronts/core/index.js
@@ -2,10 +2,12 @@ import * as supabaseClient from '../../shared/supabase/browserClient';
 const { supabase } = supabaseClient;
 
 import { createClient as createAnonClient } from '@supabase/supabase-js';
+import { anonClientOptions } from './config.ts';
 
 const anonClient = createAnonClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  anonClientOptions
 );
 
 import * as abandonedCart from './abandoned-cart/index.js';


### PR DESCRIPTION
## Summary
- avoid session persistence & storage collisions for anonymous Supabase clients
- share anon client options in `loadPublicConfig`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68909922b574832593adc4b213f31d50