### PR TITLE
refactor: adjust supabase client options

### DIFF
--- a/shared/supabase/browserClient.ts
+++ b/shared/supabase/browserClient.ts
@@ -1,9 +1,21 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
+const storageKey = 'smoothr-browser-client';
+const globalKey = `__supabaseAuthClient${storageKey}`;
+
+const supabase =
+  (globalThis as any)[globalKey] ||
+  ((globalThis as any)[globalKey] = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+        storageKey
+      }
+    }
+  ));
 
 async function ensureSupabaseSessionAuth() {
   try {

--- a/storefronts/core/config.ts
+++ b/storefronts/core/config.ts
@@ -4,15 +4,33 @@ const debug = typeof window !== 'undefined' && window.SMOOTHR_CONFIG?.debug;
 const warn = (...args: any[]) => debug && console.warn('[Smoothr Config]', ...args);
 
 export const anonClientOptions = {
-  auth: { storageKey: 'smoothr-public', persistSession: false }
+  auth: {
+    persistSession: false,
+    autoRefreshToken: false,
+    storageKey: 'anon-config-client'
+  }
 };
+
+let anonClient: ReturnType<typeof createClient> | null = null;
+
+export function getAnonClient() {
+  const globalKey = `__supabaseAuthClient${anonClientOptions.auth.storageKey}`;
+  if (!anonClient) {
+    anonClient = (globalThis as any)[globalKey] || null;
+    if (!anonClient) {
+      const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+      const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+      anonClient = createClient(url, anonKey, anonClientOptions);
+      (globalThis as any)[globalKey] = anonClient;
+    }
+  }
+  return anonClient;
+}
 
 export async function loadPublicConfig(storeId: string) {
   if (!storeId) return null;
   try {
-    const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-    const client = createClient(url, anonKey, anonClientOptions);
+    const client = getAnonClient();
     const { data, error } = await client
       .from('public_store_settings')
       .select('*')

--- a/storefronts/core/index.js
+++ b/storefronts/core/index.js
@@ -1,14 +1,9 @@
 import * as supabaseClient from '../../shared/supabase/browserClient';
 const { supabase } = supabaseClient;
 
-import { createClient as createAnonClient } from '@supabase/supabase-js';
-import { anonClientOptions } from './config.ts';
+import { getAnonClient } from './config.ts';
 
-const anonClient = createAnonClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-  anonClientOptions
-);
+const anonClient = getAnonClient();
 
 import * as abandonedCart from './abandoned-cart/index.js';
 import * as affiliates from './affiliates/index.js';


### PR DESCRIPTION
## Summary
- ensure Supabase public client disables session persistence and token refresh
- share single anon client across modules to avoid duplicates
- make browser Supabase client non-persistent and globally cached

## Testing
- `npm --workspace storefronts test` *(warnings: Multiple GoTrueClient instances detected)*

------
https://chatgpt.com/codex/tasks/task_e_68909e4965e0832581f935a493fa1926