### PR TITLE
Restore Supabase session before SDK init

### DIFF
--- a/storefronts/core/index.js
+++ b/storefronts/core/index.js
@@ -1,5 +1,5 @@
 import * as supabaseClient from '../../shared/supabase/browserClient';
-const { supabase } = supabaseClient;
+const { supabase, ensureSupabaseSessionAuth } = supabaseClient;
 
 // expose for debugging
 if (typeof window !== 'undefined') {
@@ -114,6 +114,26 @@ export default Smoothr;
 
 // Bootstrap SDK: load config and then initialize everything
 (async function initSmoothr() {
+  if (
+    typeof window !== 'undefined' &&
+    window.location?.hash?.includes('access_token')
+  ) {
+    const { data, error } = await supabase.auth.getSessionFromUrl({
+      storeSession: true
+    });
+    if (error) {
+      console.warn('[Smoothr] Error parsing session from URL:', error);
+    }
+  }
+
+  await ensureSupabaseSessionAuth();
+
+  if (supabase.auth?.onAuthStateChange) {
+    supabase.auth.onAuthStateChange((_event, session) => {
+      console.log('[Smoothr] Auth state changed, new session:', session);
+    });
+  }
+
   if (typeof globalThis.setSelectedCurrency !== 'function') {
     globalThis.setSelectedCurrency = () => {};
   }


### PR DESCRIPTION
## Summary
- Ensure browser client exports `ensureSupabaseSessionAuth`
- Restore Supabase session from URL and register auth state change handler before SDK bootstraps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890a9d99e948325b1678db84666dab9