### PR TITLE
refactor: expose auth client only

### DIFF
--- a/storefronts/core/config.js
+++ b/storefronts/core/config.js
@@ -3,7 +3,7 @@ import { createClient } from '@supabase/supabase-js';
 const debug = typeof window !== 'undefined' && window.SMOOTHR_CONFIG?.debug;
 const warn = (...args) => debug && console.warn('[Smoothr Config]', ...args);
 
-export const anonClientOptions = {
+const anonClientOptions = {
   auth: {
     persistSession: false,
     autoRefreshToken: false,
@@ -13,7 +13,7 @@ export const anonClientOptions = {
 
 let anonClient = null;
 
-export function getAnonClient() {
+function getAnonClient() {
   const globalKey = `__supabaseAuthClient${anonClientOptions.auth.storageKey}`;
   if (!anonClient) {
     anonClient = (globalThis)[globalKey] || null;

--- a/storefronts/core/config.ts
+++ b/storefronts/core/config.ts
@@ -3,7 +3,7 @@ import { createClient } from '@supabase/supabase-js';
 const debug = typeof window !== 'undefined' && window.SMOOTHR_CONFIG?.debug;
 const warn = (...args: any[]) => debug && console.warn('[Smoothr Config]', ...args);
 
-export const anonClientOptions = {
+const anonClientOptions = {
   auth: {
     persistSession: false,
     autoRefreshToken: false,
@@ -13,7 +13,7 @@ export const anonClientOptions = {
 
 let anonClient: ReturnType<typeof createClient> | null = null;
 
-export function getAnonClient() {
+function getAnonClient() {
   const globalKey = `__supabaseAuthClient${anonClientOptions.auth.storageKey}`;
   if (!anonClient) {
     anonClient = (globalThis as any)[globalKey] || null;


### PR DESCRIPTION
## Summary
- expose Supabase auth client as `window.supabaseAuth`
- keep anon client private and use `loadPublicConfig` for config loading
- update Smoothr global to reference `supabaseAuth`

## Testing
- `npm --workspace storefronts test`
- `npm run test:supabase`


------
https://chatgpt.com/codex/tasks/task_e_6890b11eb67c832594108fb520023c8d