### PR TITLE
feat: load public config before checkout

### DIFF
--- a/storefronts/checkout/checkout.js
+++ b/storefronts/checkout/checkout.js
@@ -28,6 +28,7 @@ import authorizeNet from './gateways/authorizeNet.js';
 import paypal from './gateways/paypal.js';
 import nmi from './gateways/nmi.js';
 import segpay from './gateways/segpay.js';
+import { loadPublicConfig } from '../core/config.js';
 
 function forEachPayButton(fn) {
   document.querySelectorAll('[data-smoothr-pay]').forEach(fn);
@@ -49,6 +50,11 @@ export async function initCheckout(config) {
 
   let isSubmitting = false;
   const { log, warn, err, select, q } = checkoutLogger();
+
+  const publicConfig = await loadPublicConfig(window.SMOOTHR_CONFIG?.storeId);
+  if (publicConfig) {
+    window.SMOOTHR_CONFIG = { ...window.SMOOTHR_CONFIG, ...publicConfig };
+  }
 
   log('SDK initialized');
   log('SMOOTHR_CONFIG', JSON.stringify(window.SMOOTHR_CONFIG));


### PR DESCRIPTION
## Summary
- merge remote public store settings into `SMOOTHR_CONFIG` at checkout start

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890c05a71688325ac5e6445ead44e1c