### PR TITLE
feat: handle account access auth session

### DIFF
--- a/storefronts/core/auth/index.js
+++ b/storefronts/core/auth/index.js
@@ -178,11 +178,20 @@ function showLoginPopup() {
 
 export async function clickHandler(evt) {
   evt.preventDefault();
-  const { data } = await window.supabaseAuth.auth.getSession();
-  if (!data?.session) {
+  const client = window?.smoothr?.auth?.client || supabase;
+  const {
+    data: { session }
+  } = await client.auth.getSession();
+
+  if (!session) {
+    window.dispatchEvent(
+      new CustomEvent('smoothr:open-auth', {
+        detail: { targetSelector: '[data-smoothr="auth-wrapper"]' }
+      })
+    );
     showLoginPopup();
   } else {
-    const url = await lookupRedirectUrl('login');
+    const url = await lookupDashboardHomeUrl();
     window.location.href = url;
   }
 }


### PR DESCRIPTION
## Summary
- handle session lookup via Smoothr supabase client
- open auth popup when no session is found
- redirect to dashboard home when session exists

## Testing
- `npm test` *(fails: client.auth.getSession is not a function)*


------
https://chatgpt.com/codex/tasks/task_e_689185c2d27c8325876b93ea4fc06a83