### PR TITLE
test: update resolveGateway import path

### DIFF
--- a/storefronts/tests/sdk/resolveGateway.test.js
+++ b/storefronts/tests/sdk/resolveGateway.test.js
@@ -1,21 +1,28 @@
 // [Codex Fix] Added to test gateway resolution logic
-import { describe, it, expect } from 'vitest';
-import resolveGateway from '../../../core/utils/resolveGateway.js';
+import { describe, it, expect, afterEach } from 'vitest';
+import resolveGateway from '../../checkout/utils/resolveGateway.js';
 
 describe('resolveGateway', () => {
+  afterEach(() => {
+    delete window.SMOOTHR_CONFIG;
+  });
+
   it('prefers config.active_payment_gateway', () => {
-    const provider = resolveGateway({ active_payment_gateway: 'stripe' }, {});
+    window.SMOOTHR_CONFIG = { active_payment_gateway: 'stripe' };
+    const provider = resolveGateway(() => {}, () => {});
     expect(provider).toBe('stripe');
   });
 
   it('uses storeSettings.active_payment_gateway when config missing', () => {
-    const provider = resolveGateway({}, { active_payment_gateway: 'paypal' });
+    window.SMOOTHR_CONFIG = { active_payment_gateway: 'paypal' };
+    const provider = resolveGateway(() => {}, () => {});
     expect(provider).toBe('paypal');
   });
 
   it('throws when only nested settings value exists', () => {
-    expect(() =>
-      resolveGateway({}, { settings: { active_payment_gateway: 'stripe' } })
-    ).toThrow('active_payment_gateway not configured');
+    window.SMOOTHR_CONFIG = { settings: { active_payment_gateway: 'stripe' } };
+    expect(() => resolveGateway(() => {}, () => {})).toThrow(
+      'active_payment_gateway not configured'
+    );
   });
 });


### PR DESCRIPTION
## Summary
- point resolveGateway unit tests to checkout utility version
- configure tests to supply global `SMOOTHR_CONFIG` and clean up after each run

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68919b91b71883258b50e84c36b5c742