### PR TITLE
fix: ensure session before account access

### DIFF
--- a/storefronts/core/auth/index.js
+++ b/storefronts/core/auth/index.js
@@ -327,6 +327,7 @@ function bindAuthElements(root = document) {
 
     el.addEventListener('click', async evt => {
       evt.preventDefault();
+      await ensureSupabaseSessionAuth();
       const userRef = window.smoothr?.auth?.user;
       if (userRef?.value !== null) {
         const url = (await lookupDashboardHomeUrl()) || '/';


### PR DESCRIPTION
## Summary
- ensure Supabase session is validated before account access redirect

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891a890665083259b7885d75f2f511f