### PR TITLE
Log account access auth state and redirects

### DIFF
--- a/storefronts/core/auth/index.js
+++ b/storefronts/core/auth/index.js
@@ -329,10 +329,14 @@ function bindAuthElements(root = document) {
       evt.preventDefault();
       await ensureSupabaseSessionAuth();
       const userRef = window.smoothr?.auth?.user;
-      if (userRef?.value !== null) {
+      const isLoggedIn = userRef?.value !== null;
+      log('Resolved login state:', isLoggedIn ? 'authenticated' : 'not authenticated');
+      if (isLoggedIn) {
         const url = (await lookupDashboardHomeUrl()) || '/';
+        log('Redirecting to dashboard:', url);
         window.location.href = url;
       } else {
+        log("Dispatching 'smoothr:open-auth' event");
         window.dispatchEvent(
           new CustomEvent('smoothr:open-auth', {
             detail: { targetSelector: '[data-smoothr="auth-wrapper"]' }


### PR DESCRIPTION
## Summary
- log resolved login state when account-access links are clicked
- log dispatch of `smoothr:open-auth` for unauthenticated users
- log dashboard redirect URL when users are signed in

## Testing
- `npm test` *(fails: active_payment_gateway not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6891a9b39ed08325b45b4e7c928f8a7c