### PR TITLE
chore: default dashboard url to account

### DIFF
--- a/storefronts/core/auth/index.js
+++ b/storefronts/core/auth/index.js
@@ -332,7 +332,7 @@ function bindAuthElements(root = document) {
       const isLoggedIn = userRef?.value !== null;
       log('Resolved login state:', isLoggedIn ? 'authenticated' : 'not authenticated');
       if (isLoggedIn) {
-        const url = (await lookupDashboardHomeUrl()) || '/';
+        const url = (await lookupDashboardHomeUrl()) || '/account';
         log('Redirecting to dashboard:', url);
         window.location.href = url;
       } else {

--- a/supabase/authHelpers.js
+++ b/supabase/authHelpers.js
@@ -147,11 +147,19 @@ export async function lookupDashboardHomeUrl() {
 
   try {
     const config = await loadPublicConfig(SMOOTHR_CONFIG.storeId);
-    cachedDashboardHomeUrl = config?.dashboard_home_url || '/';
+    const url = config?.dashboard_home_url;
+    if (!url) {
+      console.warn(
+        '[Smoothr Auth] Dashboard home URL missing. Falling back to /account'
+      );
+      cachedDashboardHomeUrl = '/account';
+    } else {
+      cachedDashboardHomeUrl = url;
+    }
     return cachedDashboardHomeUrl;
   } catch (error) {
     console.warn('[Smoothr Auth] Dashboard home lookup failed:', error);
-    cachedDashboardHomeUrl = '/';
+    cachedDashboardHomeUrl = '/account';
     return cachedDashboardHomeUrl;
   }
 }


### PR DESCRIPTION
## Summary
- warn when dashboard home URL missing and default to `/account`
- use `/account` fallback when redirecting logged in users

## Testing
- `npm test` *(fails: Module.initCheckout checkout/checkout.js:69:49)*
- `npm run test:supabase`


------
https://chatgpt.com/codex/tasks/task_e_6891ab3a26cc8325b2b9452c62668724