### PR TITLE
Gracefully handle missing payment gateway

### DIFF
--- a/storefronts/checkout/checkout.js
+++ b/storefronts/checkout/checkout.js
@@ -67,6 +67,12 @@ export async function initCheckout(config) {
   log('SMOOTHR_CONFIG', JSON.stringify(window.SMOOTHR_CONFIG));
 
   const provider = await getActivePaymentGateway(log, warn);
+  if (!provider) {
+    warn('No active payment gateway resolved. Aborting initCheckout.');
+    window.__SMOOTHR_CHECKOUT_INITIALIZED__ = false;
+    window.__SMOOTHR_CHECKOUT_BOUND__ = false;
+    return;
+  }
   const gateway = gateways[provider];
   if (!gateway) throw new Error(`Unknown payment gateway: ${provider}`);
   log(`Using gateway: ${provider}`);

--- a/storefronts/checkout/utils/resolveGateway.js
+++ b/storefronts/checkout/utils/resolveGateway.js
@@ -4,15 +4,14 @@ export default function getActivePaymentGateway(log = () => {}, warn = () => {})
   const cfg = window.SMOOTHR_CONFIG || {};
 
   if (!cfg.active_payment_gateway) {
-    const err = new Error('active_payment_gateway not configured');
-    warn(err.message);
-    throw err;
+    warn('active_payment_gateway not configured');
+    return null;
   }
 
   try {
     return resolveGateway(cfg);
   } catch (e) {
     warn('Gateway resolution failed:', e?.message || e);
-    throw e;
+    return null;
   }
 }


### PR DESCRIPTION
## Summary
- Return `null` from `getActivePaymentGateway` with a warning instead of throwing
- Abort checkout initialization when no gateway is resolved

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891b4d1b44083258242969be9eef634