### PR TITLE
Guard Webflow checkout when gateway missing

### DIFF
--- a/storefronts/platforms/webflow/webflow-ecom-currency.js
+++ b/storefronts/platforms/webflow/webflow-ecom-currency.js
@@ -11,6 +11,12 @@ async function initCheckout() {
   console.log('[Smoothr Checkout] SMOOTHR_CONFIG', window.SMOOTHR_CONFIG);
 
   const gateway = window.SMOOTHR_CONFIG.active_payment_gateway;
+  if (gateway === undefined) {
+    console.warn(
+      '[Smoothr Checkout] No active payment gateway configured'
+    );
+    return;
+  }
   console.log('[Smoothr Checkout] Using gateway:', gateway);
 
   console.log(


### PR DESCRIPTION
## Summary
- return early in Webflow checkout if no active gateway is set

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891b5ed2f488325bb48cc9774b30b91