### PR TITLE
build: bundle auth-only and checkout entries

### DIFF
--- a/storefronts/vite.config.js
+++ b/storefronts/vite.config.js
@@ -31,14 +31,17 @@ export default defineConfig(({ mode }) => {
       target: 'esnext', // ✅ Enables top-level await
       rollupOptions: {
         external: [],
-        input: path.resolve(__dirname, 'core/index.js'),
-        treeshake: false,
+        input: {
+          sdk: path.resolve(__dirname, 'core/index.js'),
+          'auth-only': path.resolve(__dirname, 'core/auth-only.js'),
+          checkout: path.resolve(__dirname, 'core/checkout.js')
+        },
+        treeshake: true,
         preserveEntrySignatures: 'exports-only',
         output: {
           dir: path.resolve(__dirname, 'dist'),
-          entryFileNames: 'smoothr-sdk.js',
-          format: 'es',
-          inlineDynamicImports: true
+          entryFileNames: 'smoothr-[name].js',
+          format: 'es'
         }
       },
       outDir: 'dist',


### PR DESCRIPTION
## Summary
- build standalone bundles for sdk, auth-only, and checkout
- enable rollup tree-shaking and custom output filenames

## Testing
- `npm run build`
- `npm test` *(fails: expected "spy" to be called with arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6891c10a79d08325bc0d08a31b393a62