### PR TITLE
refactor: centralize supabase client

### DIFF
--- a/storefronts/checkout/getPublicCredential.js
+++ b/storefronts/checkout/getPublicCredential.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../shared/supabase/browserClient';
+import { supabase } from '../core/supabaseClient.js';
 
 export async function getPublicCredential(storeId, integrationId, gateway) {
   if (!storeId || !integrationId) return null;

--- a/storefronts/core/auth-only.js
+++ b/storefronts/core/auth-only.js
@@ -1,7 +1,7 @@
 import {
   supabase as authClient,
   ensureSupabaseSessionAuth
-} from '../../shared/supabase/browserClient';
+} from './supabaseClient.js';
 import authModule from './auth/index.js';
 import { loadPublicConfig } from './config.ts';
 import {

--- a/storefronts/core/auth/index.js
+++ b/storefronts/core/auth/index.js
@@ -1,4 +1,4 @@
-import { supabase, ensureSupabaseSessionAuth } from '../../../shared/supabase/browserClient';
+import { supabase, ensureSupabaseSessionAuth } from '../supabaseClient.js';
 import {
   initAuth as initAuthHelper,
   signInWithGoogle,

--- a/storefronts/core/config.js
+++ b/storefronts/core/config.js
@@ -1,37 +1,12 @@
-import { createClient } from '@supabase/supabase-js';
+import supabase from './supabaseClient.js';
 
 const debug = typeof window !== 'undefined' && window.SMOOTHR_CONFIG?.debug;
 const warn = (...args) => debug && console.warn('[Smoothr Config]', ...args);
 
-const anonClientOptions = {
-  auth: {
-    persistSession: false,
-    autoRefreshToken: false,
-    storageKey: 'anon-config-client'
-  }
-};
-
-let anonClient = null;
-
-function getAnonClient() {
-  const globalKey = `__supabaseAuthClient${anonClientOptions.auth.storageKey}`;
-  if (!anonClient) {
-    anonClient = (globalThis)[globalKey] || null;
-    if (!anonClient) {
-      const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-      const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-      anonClient = createClient(url, anonKey, anonClientOptions);
-      globalThis[globalKey] = anonClient;
-    }
-  }
-  return anonClient;
-}
-
 export async function loadPublicConfig(storeId) {
   if (!storeId) return null;
   try {
-    const client = getAnonClient();
-    const { data, error } = await client
+    const { data, error } = await supabase
       .from('public_store_settings')
       .select('*')
       .eq('store_id', storeId)

--- a/storefronts/core/config.ts
+++ b/storefronts/core/config.ts
@@ -1,37 +1,12 @@
-import { createClient } from '@supabase/supabase-js';
+import supabase from './supabaseClient.js';
 
 const debug = typeof window !== 'undefined' && window.SMOOTHR_CONFIG?.debug;
 const warn = (...args: any[]) => debug && console.warn('[Smoothr Config]', ...args);
 
-const anonClientOptions = {
-  auth: {
-    persistSession: false,
-    autoRefreshToken: false,
-    storageKey: 'anon-config-client'
-  }
-};
-
-let anonClient: ReturnType<typeof createClient> | null = null;
-
-function getAnonClient() {
-  const globalKey = `__supabaseAuthClient${anonClientOptions.auth.storageKey}`;
-  if (!anonClient) {
-    anonClient = (globalThis as any)[globalKey] || null;
-    if (!anonClient) {
-      const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-      const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-      anonClient = createClient(url, anonKey, anonClientOptions);
-      (globalThis as any)[globalKey] = anonClient;
-    }
-  }
-  return anonClient;
-}
-
 export async function loadPublicConfig(storeId: string) {
   if (!storeId) return null;
   try {
-    const client = getAnonClient();
-    const { data, error } = await client
+    const { data, error } = await supabase
       .from('public_store_settings')
       .select('*')
       .eq('store_id', storeId)

--- a/storefronts/core/discounts.ts
+++ b/storefronts/core/discounts.ts
@@ -1,4 +1,4 @@
-import { supabase } from '../../shared/supabase/browserClient';
+import { supabase } from './supabaseClient.js';
 
 const debug = typeof window !== 'undefined' && window.SMOOTHR_CONFIG?.debug;
 const log = (...args: any[]) => debug && console.log('[Smoothr Discounts]', ...args);

--- a/storefronts/core/orders/index.js
+++ b/storefronts/core/orders/index.js
@@ -2,7 +2,7 @@
  * Handles order workflows and UI widgets for the storefront.
  */
 
-import { supabase } from '../../../shared/supabase/browserClient';
+import { supabase } from '../supabaseClient.js';
 
 const debug = window.SMOOTHR_CONFIG?.debug;
 const log = (...args) => debug && console.log('[Smoothr Orders]', ...args);

--- a/storefronts/core/supabaseClient.js
+++ b/storefronts/core/supabaseClient.js
@@ -1,0 +1,35 @@
+import { createClient } from '@supabase/supabase-js';
+
+const storageKey = 'smoothr-browser-client';
+const globalKey = `__supabaseAuthClient${storageKey}`;
+
+const supabase =
+  globalThis[globalKey] ||
+  (globalThis[globalKey] = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  ));
+
+async function ensureSupabaseSessionAuth() {
+  try {
+    if (typeof process !== 'undefined' && process.env.NODE_ENV === 'test') return;
+
+    const {
+      data: { session }
+    } = await supabase.auth.getSession();
+
+    const access_token = session?.access_token;
+    const refresh_token = session?.refresh_token;
+
+    if (access_token && refresh_token) {
+      await supabase.auth.setSession({ access_token, refresh_token });
+    } else {
+      console.warn('[Smoothr] Missing access or refresh token — skipping session restore');
+    }
+  } catch {
+    // ignore errors
+  }
+}
+
+export { supabase, ensureSupabaseSessionAuth };
+export default supabase;

--- a/storefronts/tests/platforms/authorizeNet-gateway.test.js
+++ b/storefronts/tests/platforms/authorizeNet-gateway.test.js
@@ -13,8 +13,7 @@ vi.mock('../../checkout/utils/authorizeNetIframeStyles.js', async () => {
   };
 });
 
-vi.mock('../../../shared/supabase/browserClient', () => {
-  
+vi.mock('../../core/supabaseClient.js', () => {
   const maybeSingle = vi.fn(async () => ({
     data: { settings: { client_key: 'client', api_login_id: 'id' } },
     error: null
@@ -23,7 +22,7 @@ vi.mock('../../../shared/supabase/browserClient', () => {
   const eq1 = vi.fn(() => ({ eq: eq2 }));
   const select = vi.fn(() => ({ eq: eq1 }));
   const from = vi.fn(() => ({ select }));
-  return { supabase: { from } };
+  return { supabase: { from }, ensureSupabaseSessionAuth: vi.fn() };
 });
 
 let createPaymentMethod;

--- a/storefronts/tests/sdk/load-config-api-base.test.js
+++ b/storefronts/tests/sdk/load-config-api-base.test.js
@@ -13,7 +13,7 @@ vi.mock('../../core/auth/index.js', () => {
   return { default: authMock, ...authMock };
 });
 
-vi.mock('../../../shared/supabase/browserClient', () => {
+vi.mock('../../core/supabaseClient.js', () => {
   const getSession = vi.fn().mockResolvedValue({
     data: { session: { access_token: 'test-token' } }
   });

--- a/storefronts/tests/sdk/load-config-merge.test.js
+++ b/storefronts/tests/sdk/load-config-merge.test.js
@@ -13,7 +13,7 @@ vi.mock('../../core/auth/index.js', () => {
   return { default: authMock, ...authMock };
 });
 
-vi.mock('../../../shared/supabase/browserClient', () => {
+vi.mock('../../core/supabaseClient.js', () => {
   const getSession = vi.fn().mockResolvedValue({
     data: { session: { access_token: 'test-token' } }
   });

--- a/supabase/authHelpers.js
+++ b/supabase/authHelpers.js
@@ -1,4 +1,4 @@
-import { supabase } from '../shared/supabase/browserClient';
+import { supabase } from '../storefronts/core/supabaseClient.js';
 import { loadPublicConfig } from '../storefronts/core/config.ts';
 
 const globalScope = typeof window !== 'undefined' ? window : globalThis;


### PR DESCRIPTION
## Summary
- centralize Supabase browser client to avoid multiple GoTrue instances
- refactor core and checkout modules to reuse the shared client

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891cc7be8b083258c0b35d843f14510