### PR TITLE
feat: conditionally init checkout

### DIFF
--- a/storefronts/platforms/webflow/checkout.js
+++ b/storefronts/platforms/webflow/checkout.js
@@ -42,12 +42,12 @@ window.SMOOTHR_CONFIG.platform = 'webflow-ecom';
 const waitForStoreId = () => {
   const config = window.SMOOTHR_CONFIG;
   if (config?.storeId) {
-    if (config.active_payment_gateway) {
+    if (window.SMOOTHR_CONFIG?.active_payment_gateway) {
       console.log('[Smoothr] initCheckout ready — mounting');
       initCheckout();
     } else {
       console.warn(
-        '[Smoothr] No active payment gateway configured, skipping initCheckout'
+        '[Smoothr Checkout] Skipping initCheckout — no active gateway'
       );
     }
   } else {

--- a/storefronts/platforms/webflow/webflow-ecom-currency.js
+++ b/storefronts/platforms/webflow/webflow-ecom-currency.js
@@ -44,5 +44,11 @@ async function initCheckout() {
 }
 
 // Run init on load
-document.addEventListener('DOMContentLoaded', initCheckout);
+document.addEventListener('DOMContentLoaded', () => {
+  if (window.SMOOTHR_CONFIG?.active_payment_gateway) {
+    initCheckout();
+  } else {
+    console.warn('[Smoothr Checkout] Skipping initCheckout — no active gateway');
+  }
+});
 


### PR DESCRIPTION
## Summary
- gate `initCheckout` for Webflow currency loader if no gateway is configured
- guard Webflow checkout auto-start with payment gateway presence

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891cf4d5ad483259327da039120562e