### PR TITLE
feat: log loaded config details

### DIFF
--- a/storefronts/core/auth-only.js
+++ b/storefronts/core/auth-only.js
@@ -52,6 +52,12 @@ const auth = authModule?.default || authModule;
     } else {
       record = (await loadPublicConfig(storeId)) ?? {};
     }
+    console.debug('[Smoothr Config] Loaded config:', record);
+    if (record.active_payment_gateway == null) {
+      console.debug(
+        '[Smoothr Config] active_payment_gateway is null or undefined (empty settings or RLS issue)'
+      );
+    }
     for (const [key, value] of Object.entries(record)) {
       const camelKey = key.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
       window.SMOOTHR_CONFIG[camelKey] = value;


### PR DESCRIPTION
## Summary
- log loaded config record for troubleshooting
- flag when active payment gateway is missing

## Testing
- `npm --workspace storefronts test`
- `npm run test:supabase`


------
https://chatgpt.com/codex/tasks/task_e_6891d0c42738832586acbeddd1f3fd17