### PR TITLE
refactor: relocate auth-only entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,17 @@ that required exports exist and that no compiled file still contains
 The storefront SDK publishes lightweight bundles that can be loaded directly:
 
 ```html
-<!-- Auth-only bundle -->
-<script type="module" src="https://sdk.smoothr.io/core/auth-only.js"></script>
+<!-- SDK auth entry bundle -->
+<script
+  type="module"
+  src="https://sdk.smoothr.io/features/auth/sdk-auth-entry.js"
+></script>
 
 <!-- Checkout bundle -->
 <script type="module" src="https://sdk.smoothr.io/core/checkout.js"></script>
 ```
 
-`auth-only.js` initializes authentication and currency helpers without any
+`sdk-auth-entry.js` initializes authentication and currency helpers without any
 checkout logic. `checkout.js` provides the checkout flow and can be paired with
 platform adapters like `./platforms/webflow/checkout.js`.
 

--- a/storefronts/README.md
+++ b/storefronts/README.md
@@ -245,10 +245,13 @@ shared checkout module. `initCheckout` runs automatically once the DOM is ready,
 so no polling logic is required.
 
 For pages that only need authentication and user management, include the
-lightweight `core/auth-only.js` bundle:
+lightweight `features/auth/sdk-auth-entry.js` bundle:
 
 ```html
-<script type="module" src="https://sdk.smoothr.io/core/auth-only.js?v=dev-final"></script>
+<script
+  type="module"
+  src="https://sdk.smoothr.io/features/auth/sdk-auth-entry.js?v=dev-final"
+></script>
 ```
 
 ## Development

--- a/storefronts/adapters/core/sdk-auth-entry.js
+++ b/storefronts/adapters/core/sdk-auth-entry.js
@@ -1,0 +1,2 @@
+export * from '../../features/auth/sdk-auth-entry.js';
+export { default } from '../../features/auth/sdk-auth-entry.js';

--- a/storefronts/core/index.js
+++ b/storefronts/core/index.js
@@ -1,7 +1,7 @@
-export * from './auth-only.js';
+export * from '../features/auth/sdk-auth-entry.js';
 export * from './checkout.js';
 
-import authOnly from './auth-only.js';
+import authOnly from '../features/auth/sdk-auth-entry.js';
 import * as checkout from './checkout.js';
 
 const Smoothr = { ...authOnly, ...checkout };

--- a/storefronts/features/auth/sdk-auth-entry.js
+++ b/storefronts/features/auth/sdk-auth-entry.js
@@ -1,14 +1,14 @@
 import {
   supabase as authClient,
   ensureSupabaseSessionAuth
-} from './supabaseClient.js';
-import authModule from './auth/index.js';
-import { loadPublicConfig } from './config.ts';
+} from '../../core/supabaseClient.js';
+import authModule from '../../core/auth/index.js';
+import { loadPublicConfig } from '../../core/config.ts';
 import {
   lookupRedirectUrl,
   lookupDashboardHomeUrl
-} from '../../supabase/authHelpers.js';
-import * as currency from './currency/index.js';
+} from '../../../supabase/authHelpers.js';
+import * as currency from '../../core/currency/index.js';
 
 const supabase = authClient;
 if (typeof window !== 'undefined') {

--- a/storefronts/platforms/core/auth-only.js
+++ b/storefronts/platforms/core/auth-only.js
@@ -1,2 +1,0 @@
-export * from '../../core/auth-only.js';
-export { default } from '../../core/auth-only.js';

--- a/storefronts/tests/sdk/global-auth.test.js
+++ b/storefronts/tests/sdk/global-auth.test.js
@@ -21,7 +21,7 @@ vi.mock("@supabase/supabase-js", () => {
   return { createClient: createClientMock };
 });
 
-import { auth } from "../../platforms/core/auth-only.js";
+import { auth } from "../../adapters/core/sdk-auth-entry.js";
 
 function flushPromises() {
   return new Promise(setImmediate);

--- a/storefronts/vite.config.js
+++ b/storefronts/vite.config.js
@@ -33,7 +33,10 @@ export default defineConfig(({ mode }) => {
         external: [],
         input: {
           sdk: path.resolve(__dirname, 'core/index.js'),
-          'auth-only': path.resolve(__dirname, 'core/auth-only.js'),
+            'sdk-auth-entry': path.resolve(
+              __dirname,
+              'features/auth/sdk-auth-entry.js'
+            ),
           checkout: path.resolve(__dirname, 'core/checkout.js')
         },
         treeshake: true,


### PR DESCRIPTION
## Summary
- move core auth-only module to `features/auth/sdk-auth-entry.js`
- add adapter entry and update imports/exports and docs
- adjust build config and tests for new entry path

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891d3a60eec83259385a5d19fc4956f