### PR TITLE
refactor: centralize cors handling

### DIFF
--- a/smoothr/pages/api/checkout/[provider].ts
+++ b/smoothr/pages/api/checkout/[provider].ts
@@ -2,19 +2,16 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import '../../../../shared/init';
 import { handleCheckout } from 'shared/checkout/handleCheckout';
+import { applyCors } from '../../../utils/cors';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const origin = process.env.CORS_ORIGIN || '*';
   if (req.method === 'OPTIONS') {
-    return res
-      .status(200)
-      .setHeader('Access-Control-Allow-Origin', origin)
-      .setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
-      .setHeader('Access-Control-Allow-Headers', 'Content-Type')
-      .end();
+    applyCors(res, origin);
+    return res.status(200).end();
   }
 
-  res.setHeader('Access-Control-Allow-Origin', origin);
+  applyCors(res, origin);
 
   console.log('[API] 🔥 [provider] API route hit');
   if (req.method !== 'POST' && req.method !== 'OPTIONS') {

--- a/smoothr/pages/api/create-checkout-session.ts
+++ b/smoothr/pages/api/create-checkout-session.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import Stripe from 'stripe';
 import { createServerSupabaseClient } from 'shared/supabase/serverClient';
 import { getStoreIntegration } from 'shared/checkout/getStoreIntegration';
+import { applyCors } from '../../utils/cors';
 
 const debug = process.env.SMOOTHR_DEBUG === 'true';
 const log = (...args: any[]) => debug && console.log('[create-checkout]', ...args);
@@ -23,16 +24,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const origin = req.headers.origin || '*';
   try {
     if (req.method === 'OPTIONS') {
-      res.setHeader('Access-Control-Allow-Origin', origin);
-      res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
-      res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+      applyCors(res, origin);
       res.status(200).end();
       return;
     }
 
-    res.setHeader('Access-Control-Allow-Origin', origin);
-    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    applyCors(res, origin);
 
     if (req.method !== 'POST') {
       res.status(405).json({ error: 'Method not allowed' });

--- a/smoothr/pages/api/createOrder.ts
+++ b/smoothr/pages/api/createOrder.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import 'shared/init';
 import { createServerSupabaseClient } from 'shared/supabase/serverClient';
 import { createOrder } from 'shared/checkout/createOrder';
+import { applyCors } from '../../utils/cors';
 
 export default async function handler(
   req: NextApiRequest,
@@ -10,15 +11,11 @@ export default async function handler(
   const supabase = createServerSupabaseClient();
   const origin = process.env.CORS_ORIGIN || '*';
   if (req.method === 'OPTIONS') {
-    return res
-      .status(200)
-      .setHeader('Access-Control-Allow-Origin', origin)
-      .setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
-      .setHeader('Access-Control-Allow-Headers', 'Content-Type')
-      .end();
+    applyCors(res, origin);
+    return res.status(200).end();
   }
 
-  res.setHeader('Access-Control-Allow-Origin', origin);
+  applyCors(res, origin);
   if (req.method !== 'POST') {
     res.status(405).json({ error: 'Method not allowed' });
     return;

--- a/smoothr/pages/api/get-payment-key.js
+++ b/smoothr/pages/api/get-payment-key.js
@@ -1,17 +1,15 @@
 // pages/api/get-payment-key.js
 import { createClient } from '@supabase/supabase-js';
+import { applyCors } from '../../utils/cors';
 
 export default async function handler(req, res) {
   const origin = process.env.CORS_ORIGIN || '*';
-  res.setHeader('Access-Control-Allow-Origin', origin);
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-
-  // Handle preflight OPTIONS request
   if (req.method === 'OPTIONS') {
+    applyCors(res, origin);
     return res.status(200).json({});
   }
 
+  applyCors(res, origin);
   const { storeId, provider } = req.query;
 
   if (!storeId || !provider) {


### PR DESCRIPTION
## Summary
- use `applyCors` utility across API routes
- handle `OPTIONS` requests consistently

## Testing
- `npm --workspace smoothr run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68920202855083258b87550966d95f1e