### PR TITLE
chore: add scaffolding for admin modules

### DIFF
--- a/smoothr/admin-modules/README.md
+++ b/smoothr/admin-modules/README.md
@@ -1,3 +1,9 @@
 # admin-modules
 
 Admin dashboard modules for Smoothr.
+
+Each module directory (e.g., `orders`, `subscriptions`) includes:
+
+- `components/` - UI components for the module
+- `pages/` - Page components for the module
+- `hooks/` - Custom React hooks for the module

--- a/smoothr/admin-modules/abandoned-cart/components/README.md
+++ b/smoothr/admin-modules/abandoned-cart/components/README.md
@@ -1,0 +1,1 @@
+UI components for this admin module.

--- a/smoothr/admin-modules/abandoned-cart/hooks/README.md
+++ b/smoothr/admin-modules/abandoned-cart/hooks/README.md
@@ -1,0 +1,1 @@
+Custom React hooks for this admin module.

--- a/smoothr/admin-modules/abandoned-cart/pages/README.md
+++ b/smoothr/admin-modules/abandoned-cart/pages/README.md
@@ -1,0 +1,1 @@
+Page components for this admin module.

--- a/smoothr/admin-modules/affiliates/components/README.md
+++ b/smoothr/admin-modules/affiliates/components/README.md
@@ -1,0 +1,1 @@
+UI components for this admin module.

--- a/smoothr/admin-modules/affiliates/hooks/README.md
+++ b/smoothr/admin-modules/affiliates/hooks/README.md
@@ -1,0 +1,1 @@
+Custom React hooks for this admin module.

--- a/smoothr/admin-modules/affiliates/pages/README.md
+++ b/smoothr/admin-modules/affiliates/pages/README.md
@@ -1,0 +1,1 @@
+Page components for this admin module.

--- a/smoothr/admin-modules/analytics/components/README.md
+++ b/smoothr/admin-modules/analytics/components/README.md
@@ -1,0 +1,1 @@
+UI components for this admin module.

--- a/smoothr/admin-modules/analytics/hooks/README.md
+++ b/smoothr/admin-modules/analytics/hooks/README.md
@@ -1,0 +1,1 @@
+Custom React hooks for this admin module.

--- a/smoothr/admin-modules/analytics/pages/README.md
+++ b/smoothr/admin-modules/analytics/pages/README.md
@@ -1,0 +1,1 @@
+Page components for this admin module.

--- a/smoothr/admin-modules/currency/components/README.md
+++ b/smoothr/admin-modules/currency/components/README.md
@@ -1,0 +1,1 @@
+UI components for this admin module.

--- a/smoothr/admin-modules/currency/hooks/README.md
+++ b/smoothr/admin-modules/currency/hooks/README.md
@@ -1,0 +1,1 @@
+Custom React hooks for this admin module.

--- a/smoothr/admin-modules/currency/pages/README.md
+++ b/smoothr/admin-modules/currency/pages/README.md
@@ -1,0 +1,1 @@
+Page components for this admin module.

--- a/smoothr/admin-modules/dashboard/components/README.md
+++ b/smoothr/admin-modules/dashboard/components/README.md
@@ -1,0 +1,1 @@
+UI components for this admin module.

--- a/smoothr/admin-modules/dashboard/hooks/README.md
+++ b/smoothr/admin-modules/dashboard/hooks/README.md
@@ -1,0 +1,1 @@
+Custom React hooks for this admin module.

--- a/smoothr/admin-modules/dashboard/pages/README.md
+++ b/smoothr/admin-modules/dashboard/pages/README.md
@@ -1,0 +1,1 @@
+Page components for this admin module.

--- a/smoothr/admin-modules/discounts/components/README.md
+++ b/smoothr/admin-modules/discounts/components/README.md
@@ -1,0 +1,1 @@
+UI components for this admin module.

--- a/smoothr/admin-modules/discounts/hooks/README.md
+++ b/smoothr/admin-modules/discounts/hooks/README.md
@@ -1,0 +1,1 @@
+Custom React hooks for this admin module.

--- a/smoothr/admin-modules/discounts/pages/README.md
+++ b/smoothr/admin-modules/discounts/pages/README.md
@@ -1,0 +1,1 @@
+Page components for this admin module.

--- a/smoothr/admin-modules/orders/components/README.md
+++ b/smoothr/admin-modules/orders/components/README.md
@@ -1,0 +1,1 @@
+UI components for this admin module.

--- a/smoothr/admin-modules/orders/hooks/README.md
+++ b/smoothr/admin-modules/orders/hooks/README.md
@@ -1,0 +1,1 @@
+Custom React hooks for this admin module.

--- a/smoothr/admin-modules/orders/pages/README.md
+++ b/smoothr/admin-modules/orders/pages/README.md
@@ -1,0 +1,1 @@
+Page components for this admin module.

--- a/smoothr/admin-modules/returns/components/README.md
+++ b/smoothr/admin-modules/returns/components/README.md
@@ -1,0 +1,1 @@
+UI components for this admin module.

--- a/smoothr/admin-modules/returns/hooks/README.md
+++ b/smoothr/admin-modules/returns/hooks/README.md
@@ -1,0 +1,1 @@
+Custom React hooks for this admin module.

--- a/smoothr/admin-modules/returns/pages/README.md
+++ b/smoothr/admin-modules/returns/pages/README.md
@@ -1,0 +1,1 @@
+Page components for this admin module.

--- a/smoothr/admin-modules/reviews/components/README.md
+++ b/smoothr/admin-modules/reviews/components/README.md
@@ -1,0 +1,1 @@
+UI components for this admin module.

--- a/smoothr/admin-modules/reviews/hooks/README.md
+++ b/smoothr/admin-modules/reviews/hooks/README.md
@@ -1,0 +1,1 @@
+Custom React hooks for this admin module.

--- a/smoothr/admin-modules/reviews/pages/README.md
+++ b/smoothr/admin-modules/reviews/pages/README.md
@@ -1,0 +1,1 @@
+Page components for this admin module.

--- a/smoothr/admin-modules/subscriptions/components/README.md
+++ b/smoothr/admin-modules/subscriptions/components/README.md
@@ -1,0 +1,1 @@
+UI components for this admin module.

--- a/smoothr/admin-modules/subscriptions/hooks/README.md
+++ b/smoothr/admin-modules/subscriptions/hooks/README.md
@@ -1,0 +1,1 @@
+Custom React hooks for this admin module.

--- a/smoothr/admin-modules/subscriptions/pages/README.md
+++ b/smoothr/admin-modules/subscriptions/pages/README.md
@@ -1,0 +1,1 @@
+Page components for this admin module.


### PR DESCRIPTION
## Summary
- add components, pages, and hooks directories to each admin module
- document admin module directory structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689203b971b88325b5e3aaceed1ed3e7