### PR TITLE
feat: support platform attribute in SDK

### DIFF
--- a/storefronts/smoothr-sdk.js
+++ b/storefronts/smoothr-sdk.js
@@ -3,7 +3,8 @@
 
 const scriptEl = document.getElementById('smoothr-sdk');
 const storeId = scriptEl?.dataset?.storeId || null;
-const platform = scriptEl?.dataset?.platform || null;
+const platform =
+  scriptEl?.dataset?.platform || scriptEl?.getAttribute?.('platform') || null;
 
 const debug = new URLSearchParams(location.search).get('smoothr-debug') === 'true';
 

--- a/storefronts/tests/sdk/platform-detection.test.js
+++ b/storefronts/tests/sdk/platform-detection.test.js
@@ -1,0 +1,66 @@
+// [Codex Fix] Updated for ESM/Vitest/Node 20 compatibility
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../../features/auth/index.js", () => {
+  const auth = { init: vi.fn() };
+  return { default: auth, ...auth };
+});
+vi.mock("../../features/currency/index.js", () => {
+  const currency = { init: vi.fn() };
+  return { default: currency, ...currency };
+});
+
+describe("platform detection", () => {
+  let scriptEl;
+
+  beforeEach(() => {
+    vi.resetModules();
+    scriptEl = null;
+
+    global.location = { search: "" };
+    global.window = {
+      location: { search: "" },
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    global.document = {
+      readyState: "complete",
+      addEventListener: vi.fn(),
+      querySelectorAll: vi.fn(() => []),
+      getElementById: vi.fn(() => scriptEl),
+    };
+  });
+
+  it("uses data-platform attribute", async () => {
+    scriptEl = {
+      dataset: { storeId: "1", platform: "webflow" },
+      getAttribute: vi.fn(() => null),
+    };
+    global.document.getElementById.mockReturnValue(scriptEl);
+
+    await import("../../smoothr-sdk.js");
+    expect(global.window.Smoothr.config.platform).toBe("webflow");
+  });
+
+  it("uses platform attribute when data-platform missing", async () => {
+    scriptEl = {
+      dataset: { storeId: "1" },
+      getAttribute: vi.fn((name) => (name === "platform" ? "magento" : null)),
+    };
+    global.document.getElementById.mockReturnValue(scriptEl);
+
+    await import("../../smoothr-sdk.js");
+    expect(global.window.Smoothr.config.platform).toBe("magento");
+  });
+
+  it("prefers data-platform over platform attribute", async () => {
+    scriptEl = {
+      dataset: { storeId: "1", platform: "webflow" },
+      getAttribute: vi.fn((name) => (name === "platform" ? "magento" : null)),
+    };
+    global.document.getElementById.mockReturnValue(scriptEl);
+
+    await import("../../smoothr-sdk.js");
+    expect(global.window.Smoothr.config.platform).toBe("webflow");
+  });
+});


### PR DESCRIPTION
## Summary
- detect platform from either `data-platform` or `platform` attributes on the SDK script tag
- add tests for platform attribute detection and priority over `data-platform`

## Testing
- `npm --workspace storefronts test`
- `npm run test:supabase`


------
https://chatgpt.com/codex/tasks/task_e_689240c23ae883258bf320ae63b00aab