### PR TITLE
docs: explain Webflow adapter hooks

### DIFF
--- a/storefronts/adapters/webflow.js
+++ b/storefronts/adapters/webflow.js
@@ -1,8 +1,70 @@
 // Placeholder Webflow adapter for Smoothr SDK.
-// Provides no-op lifecycle hooks that can be expanded with platform-specific logic.
+// Each exported hook lets the platform run setup work at different points in the
+// lifecycle. They are intentionally lightweight so implementers can opt in to
+// the pieces they need.
 
-export async function platformReady() {}
-export async function domReady() {}
-export function observeDOMChanges() {}
+/**
+ * Run **before** any Smoothr features touch the DOM. Use this to perform
+ * platform‑specific bootstrapping such as loading third‑party scripts or
+ * waiting for Webflow's own initializer. The default implementation resolves
+ * immediately.
+ *
+ * Example: wait for a hypothetical `window.Webflow.ready()` promise.
+ *
+ * ```js
+ * export async function platformReady() {
+ *   // Await Webflow's global ready signal if it exists.
+ *   await window.Webflow?.ready?.();
+ * }
+ * ```
+ */
+export async function platformReady() {
+  // Example: await Webflow's global ready promise if it exists
+  // await window.Webflow?.ready?.();
+}
+
+/**
+ * Triggered after the DOM is fully parsed. Use this for DOM queries or to set
+ * up observers that depend on elements being present.
+ *
+ * Example: begin observing the cart element for mutations once the document is
+ * ready.
+ *
+ * ```js
+ * export async function domReady() {
+ *   const cart = document.querySelector('#cart');
+ *   if (cart) observeDOMChanges(cart);
+ * }
+ * ```
+ */
+export async function domReady() {
+  // Example: start observing the cart once it's in the DOM
+  // const cart = document.querySelector('#cart');
+  // if (cart) observeDOMChanges(cart);
+}
+
+/**
+ * Attach MutationObservers or other listeners that respond to DOM changes. This
+ * hook is called once during initialization but observers may fire whenever the
+ * DOM updates.
+ *
+ * Example: re-run Smoothr bindings whenever nodes are added under `root`.
+ *
+ * ```js
+ * export function observeDOMChanges(root = document.body) {
+ *   const observer = new MutationObserver(() => {
+ *     // re-bind Smoothr widgets or run custom logic here
+ *   });
+ *   observer.observe(root, { childList: true, subtree: true });
+ * }
+ * ```
+ */
+export function observeDOMChanges(root = document.body) {
+  // Example: watch for elements added under `root`
+  // const observer = new MutationObserver(() => {
+  //   // re-bind Smoothr widgets or run custom logic here
+  // });
+  // observer.observe(root, { childList: true, subtree: true });
+}
 
 export default { platformReady, domReady, observeDOMChanges };


### PR DESCRIPTION
## Summary
- expand Webflow adapter hook docs
- show example platform bootstrap and MutationObserver setup

## Testing
- `npm test` *(fails: ReferenceError: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68924547c8b883259998fff423e12c38