### PR TITLE
feat: guard auth and currency init

### DIFF
--- a/storefronts/features/auth/index.js
+++ b/storefronts/features/auth/index.js
@@ -378,7 +378,11 @@ const auth = {
 };
 
 export async function init(config = {}) {
-  if (initialized) return window.Smoothr?.auth;
+  updateGlobalAuth();
+  if (initialized) {
+    log('Auth module already initialized');
+    return window.Smoothr?.auth;
+  }
 
   if (typeof window !== 'undefined') {
     window.SMOOTHR_CONFIG = { ...(window.SMOOTHR_CONFIG || {}), ...config };

--- a/storefronts/features/currency/index.js
+++ b/storefronts/features/currency/index.js
@@ -111,7 +111,11 @@ function updateGlobalCurrency() {
 }
 
 export async function init(config = {}) {
-  if (initialized) return window.Smoothr?.currency;
+  updateGlobalCurrency();
+  if (initialized) {
+    if (debug) console.log('[Smoothr] Currency module already initialized');
+    return window.Smoothr?.currency;
+  }
 
   if (typeof window !== 'undefined') {
     window.SMOOTHR_CONFIG = { ...(window.SMOOTHR_CONFIG || {}), ...config };


### PR DESCRIPTION
## Summary
- prevent duplicate initialization for auth and currency modules
- expose helpers on every init call and log if already initialized

## Testing
- `npm test` *(fails: 21 failed, 93 passed)*
- `npm run test:supabase`


------
https://chatgpt.com/codex/tasks/task_e_68925091621c83259517f9ee95c6cfc7