### PR TITLE
test: update auth and currency tests for init APIs

### DIFF
--- a/storefronts/tests/adapters/checkout.test.js
+++ b/storefronts/tests/adapters/checkout.test.js
@@ -97,7 +97,6 @@ beforeEach(() => {
   };
 
   global.window.Smoothr = Smoothr;
-  global.window.smoothr = Smoothr;
   submitCheckout = async () => {
     const provider =
       global.window.SMOOTHR_CONFIG?.active_payment_gateway || 'stripe';

--- a/storefronts/tests/adapters/renderCart.test.js
+++ b/storefronts/tests/adapters/renderCart.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import * as currency from '../../features/currency/index.js';
 
 let container;
 let template;
@@ -6,7 +7,7 @@ let totalEl;
 let removeItemMock;
 let Smoothr;
 
-beforeEach(() => {
+beforeEach(async () => {
   vi.resetModules();
   document.body.innerHTML = '';
 
@@ -84,6 +85,12 @@ beforeEach(() => {
   };
 
   window.Smoothr = Smoothr;
+  window.SMOOTHR_CONFIG = { baseCurrency: 'USD' };
+  global.fetch = vi.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve({ rates: {} }) })
+  );
+  global.localStorage = { getItem: vi.fn(), setItem: vi.fn(), removeItem: vi.fn() };
+  await currency.init({ baseCurrency: 'USD' });
 });
 
 async function loadRenderCart() {
@@ -114,9 +121,9 @@ describe('renderCart', () => {
     const clone = container.querySelector('.cart-rendered');
     expect(clone.querySelector('[data-smoothr-name]').textContent).toBe('Item Two');
     expect(clone.querySelector('[data-smoothr-quantity]').textContent).toBe('1');
-    expect(clone.querySelector('[data-smoothr-price]').textContent).toBe('0.5');
-    expect(clone.querySelector('[data-smoothr-subtotal]').textContent).toBe('0.5');
-    expect(totalEl.textContent).toBe('2.5');
+    expect(clone.querySelector('[data-smoothr-price]').textContent).toBe('$0.50');
+    expect(clone.querySelector('[data-smoothr-subtotal]').textContent).toBe('$0.50');
+    expect(totalEl.textContent).toBe('$2.50');
   });
 
   it('remove buttons trigger cart.removeItem', async () => {

--- a/storefronts/tests/adapters/webflow-dom.test.js
+++ b/storefronts/tests/adapters/webflow-dom.test.js
@@ -3,7 +3,7 @@ import {
   setSelectedCurrency,
   initCurrencyDom,
 } from "../../adapters/webflow/currencyDomAdapter.js";
-import { setBaseCurrency, updateRates } from "../../features/currency/index.js";
+import * as currency from "../../features/currency/index.js";
 
 class CustomEvt {
   constructor(type, init) {
@@ -17,9 +17,9 @@ describe("webflow adapter price replacement", () => {
   let els;
   let store;
 
-  beforeEach(() => {
-    setBaseCurrency("USD");
-    updateRates({ USD: 1, EUR: 0.5 });
+  beforeEach(async () => {
+    await currency.init({ baseCurrency: "USD" });
+    currency.updateRates({ USD: 1, EUR: 0.5 });
 
     store = null;
     global.localStorage = {
@@ -28,6 +28,9 @@ describe("webflow adapter price replacement", () => {
         store = v;
       }),
     };
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({ rates: {} }) })
+    );
 
     events = {};
     els = [

--- a/storefronts/tests/sdk/account-access.test.js
+++ b/storefronts/tests/sdk/account-access.test.js
@@ -25,7 +25,7 @@ vi.mock("@supabase/supabase-js", () => {
 import * as authHelpers from "../../../supabase/authHelpers.js";
 vi.spyOn(authHelpers, "lookupDashboardHomeUrl").mockResolvedValue("/dashboard");
 
-import * as auth from "../../features/auth/index.js";
+let auth;
 
 function flushPromises() {
   return new Promise(setImmediate);
@@ -35,7 +35,8 @@ describe("account access trigger", () => {
   let btn;
   let clickHandler;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
     clickHandler = undefined;
     btn = {
       tagName: "DIV",
@@ -68,15 +69,16 @@ describe("account access trigger", () => {
       querySelector: vi.fn(() => null),
       dispatchEvent: vi.fn(),
     };
+    auth = await import("../../features/auth/index.js");
   });
 
   it("redirects logged-in users to dashboard home", async () => {
     const user = { id: "1", email: "test@example.com" };
     getUserMock.mockResolvedValueOnce({ data: { user } });
 
-    await auth.initAuth();
+    await auth.init();
     await flushPromises();
-    expect(global.window.smoothr.auth.user.value).toEqual(user);
+    expect(global.window.Smoothr.auth.user.value).toEqual(user);
 
     await clickHandler({ target: btn, preventDefault: () => {} });
     await flushPromises();
@@ -87,7 +89,7 @@ describe("account access trigger", () => {
   it("dispatches open-auth event for anonymous users", async () => {
     getUserMock.mockResolvedValueOnce({ data: { user: null } });
 
-    await auth.initAuth();
+    await auth.init();
     await flushPromises();
 
     await clickHandler({ target: btn, preventDefault: () => {} });

--- a/storefronts/tests/sdk/auth-state-change.test.js
+++ b/storefronts/tests/sdk/auth-state-change.test.js
@@ -54,13 +54,13 @@ describe("auth state change", () => {
   });
 
   it("updates user and global auth on session change", async () => {
-    await auth.initAuth();
+    await auth.init();
     await flushPromises();
     const user = { id: "42", email: "test@example.com" };
     onAuthStateChangeHandler("SIGNED_IN", { user });
-    expect(global.window.smoothr.auth.user.value).toEqual(user);
-    expect(global.window.smoothr.auth.client).toBeDefined();
-    await global.window.smoothr.auth.client.auth.getSession();
+    expect(global.window.Smoothr.auth.user.value).toEqual(user);
+    expect(global.window.Smoothr.auth.client).toBeDefined();
+    await global.window.Smoothr.auth.client.auth.getSession();
     expect(getSessionMock).toHaveBeenCalled();
   });
 });

--- a/storefronts/tests/sdk/checkout-payload.test.js
+++ b/storefronts/tests/sdk/checkout-payload.test.js
@@ -130,7 +130,6 @@ beforeEach(() => {
       }
     }
   };
-  global.window.smoothr = global.window.Smoothr;
   global.alert = global.window.alert = vi.fn();
 });
 

--- a/storefronts/tests/sdk/currency.test.js
+++ b/storefronts/tests/sdk/currency.test.js
@@ -1,14 +1,15 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import {
-  formatPrice,
-  convertPrice,
-  setBaseCurrency,
-  updateRates
-} from '../../features/currency/index.js';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import * as currency from '../../features/currency/index.js';
+
+const { formatPrice, convertPrice, setBaseCurrency, updateRates, init } = currency;
 
 describe('currency utilities', () => {
-  beforeEach(() => {
-    setBaseCurrency('USD');
+  beforeEach(async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({ rates: {} }) })
+    );
+    global.localStorage = { getItem: vi.fn(), setItem: vi.fn(), removeItem: vi.fn() };
+    await init({ baseCurrency: 'USD' });
     updateRates({ USD: 1, EUR: 0.9, GBP: 0.8 });
   });
 

--- a/storefronts/tests/sdk/dom-mutation.test.js
+++ b/storefronts/tests/sdk/dom-mutation.test.js
@@ -1,6 +1,6 @@
 // [Codex Fix] Updated for ESM/Vitest/Node 20 compatibility
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import * as auth from "../../features/auth/index.js";
+let auth;
 
 var signInMock;
 var signUpMock;
@@ -36,7 +36,6 @@ vi.mock("@supabase/supabase-js", () => {
   return { createClient: createClientMock };
 });
 
-vi.spyOn(auth, "lookupRedirectUrl").mockResolvedValue("/redirect");
 
 function flushPromises() {
   return new Promise(setImmediate);
@@ -55,7 +54,8 @@ describe("dynamic DOM bindings", () => {
   let win;
   let docClickHandler;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
     elements = [];
     forms = [];
     mutationCallback = undefined;
@@ -103,6 +103,8 @@ describe("dynamic DOM bindings", () => {
     };
     global.document = doc;
     global.window = win;
+    auth = await import("../../features/auth/index.js");
+    vi.spyOn(auth, "lookupRedirectUrl").mockResolvedValue("/redirect");
   });
 
   it("attaches listeners to added login elements and updates auth state", async () => {
@@ -129,7 +131,7 @@ describe("dynamic DOM bindings", () => {
       }),
     };
 
-    auth.initAuth();
+    await auth.init();
     await flushPromises();
     expect(btn.addEventListener).not.toHaveBeenCalled();
 
@@ -143,7 +145,7 @@ describe("dynamic DOM bindings", () => {
     await clickHandler({ preventDefault: () => {} });
     await flushPromises();
 
-    expect(global.window.smoothr.auth.user.value).toEqual(user);
+    expect(global.window.Smoothr.auth.user.value).toEqual(user);
     expect(global.document.dispatchEvent).toHaveBeenCalled();
     const evt = global.document.dispatchEvent.mock.calls.at(-1)[0];
     expect(evt.type).toBe("smoothr:login");
@@ -176,7 +178,7 @@ describe("dynamic DOM bindings", () => {
       }),
     };
 
-    auth.initAuth();
+    await auth.init();
     await flushPromises();
     forms.push(form);
     elements.push(btn);
@@ -188,7 +190,7 @@ describe("dynamic DOM bindings", () => {
     await clickHandler({ preventDefault: () => {} });
     await flushPromises();
 
-    expect(global.window.smoothr.auth.user.value).toEqual(user);
+    expect(global.window.Smoothr.auth.user.value).toEqual(user);
     expect(global.document.dispatchEvent).toHaveBeenCalled();
     const evt = global.document.dispatchEvent.mock.calls.at(-1)[0];
     expect(evt.type).toBe("smoothr:login");
@@ -216,7 +218,7 @@ describe("dynamic DOM bindings", () => {
       }),
     };
 
-    auth.initAuth();
+    await auth.init();
     await flushPromises();
     elements.push(btn);
     mutationCallback();
@@ -234,7 +236,7 @@ describe("dynamic DOM bindings", () => {
 
     const user = { id: "3", email: "google@example.com" };
     getUserMock.mockResolvedValue({ data: { user } });
-    auth.initAuth();
+    await auth.init();
     await flushPromises();
 
     expect(global.document.dispatchEvent).toHaveBeenCalled();
@@ -264,7 +266,7 @@ describe("dynamic DOM bindings", () => {
       }),
     };
 
-    auth.initAuth();
+    await auth.init();
     await flushPromises();
     elements.push(btn);
     mutationCallback();
@@ -282,7 +284,7 @@ describe("dynamic DOM bindings", () => {
 
     const user = { id: "4", email: "apple@example.com" };
     getUserMock.mockResolvedValue({ data: { user } });
-    auth.initAuth();
+    await auth.init();
     await flushPromises();
 
     expect(global.document.dispatchEvent).toHaveBeenCalled();
@@ -333,7 +335,7 @@ describe("dynamic DOM bindings", () => {
       }),
     };
 
-    auth.initAuth();
+    await auth.init();
     await flushPromises();
     forms.push(form);
     elements.push(btn);
@@ -374,7 +376,7 @@ describe("dynamic DOM bindings", () => {
       closest: vi.fn(() => btn),
     };
 
-    auth.initAuth();
+    await auth.init();
     await flushPromises();
     elements.push(btn);
     mutationCallback();

--- a/storefronts/tests/sdk/global-auth.test.js
+++ b/storefronts/tests/sdk/global-auth.test.js
@@ -21,7 +21,7 @@ vi.mock("@supabase/supabase-js", () => {
   return { createClient: createClientMock };
 });
 
-import { auth } from "../../adapters/core/sdk-auth-entry.js";
+import { auth, init } from "../../adapters/core/sdk-auth-entry.js";
 
 function flushPromises() {
   return new Promise(setImmediate);
@@ -58,17 +58,17 @@ describe("global auth", () => {
     };
   });
 
-  it("sets and clears window.smoothr.auth.user", async () => {
+  it("sets and clears window.Smoothr.auth.user", async () => {
     const user = { id: "1", email: "test@example.com" };
     getUserMock.mockResolvedValueOnce({ data: { user } });
 
-    auth.initAuth();
+    await init();
     await flushPromises();
-    expect(global.window.smoothr.auth.user.value).toEqual(user);
+    expect(global.window.Smoothr.auth.user.value).toEqual(user);
 
     getUserMock.mockResolvedValueOnce({ data: { user: null } });
     await signOutHandler({ preventDefault: () => {} });
     await flushPromises();
-    expect(global.window.smoothr.auth.user.value).toBeNull();
+    expect(global.window.Smoothr.auth.user.value).toBeNull();
   });
 });

--- a/storefronts/tests/sdk/google-login.test.js
+++ b/storefronts/tests/sdk/google-login.test.js
@@ -26,7 +26,7 @@ vi.mock("@supabase/supabase-js", () => {
   return { createClient: createClientMock };
 });
 
-import { initAuth } from "../../features/auth/index.js";
+let init;
 
 function flushPromises() {
   return new Promise(setImmediate);
@@ -37,7 +37,8 @@ describe("OAuth login buttons", () => {
   let appleClickHandler;
   let store;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
     googleClickHandler = undefined;
     appleClickHandler = undefined;
     store = null;
@@ -84,10 +85,11 @@ describe("OAuth login buttons", () => {
         return result;
       }),
     };
+    ({ init } = await import("../../features/auth/index.js"));
   });
 
   it("triggers Supabase OAuth sign-in for Google", async () => {
-    initAuth();
+    await init();
     await flushPromises();
 
     await googleClickHandler({ preventDefault: () => {} });
@@ -101,7 +103,7 @@ describe("OAuth login buttons", () => {
   });
 
   it("triggers Supabase OAuth sign-in for Apple", async () => {
-    initAuth();
+    await init();
     await flushPromises();
 
     await appleClickHandler({ preventDefault: () => {} });

--- a/storefronts/tests/sdk/init-idempotency.test.js
+++ b/storefronts/tests/sdk/init-idempotency.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+var getUserMock;
+var createClientMock;
+var getSessionMock;
+
+vi.mock("@supabase/supabase-js", () => {
+  getUserMock = vi.fn(() => Promise.resolve({ data: { user: null } }));
+  getSessionMock = vi.fn(() => Promise.resolve({ data: { session: {} }, error: null }));
+  createClientMock = vi.fn(() => ({
+    auth: {
+      getUser: getUserMock,
+      signOut: vi.fn(),
+      onAuthStateChange: vi.fn(),
+      getSession: getSessionMock
+    },
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn().mockResolvedValue({ data: null, error: null })
+        }))
+      }))
+    }))
+  }));
+  return { createClient: createClientMock };
+});
+
+import * as auth from "../../features/auth/index.js";
+import * as currency from "../../features/currency/index.js";
+
+describe("module init idempotency", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({ rates: {} }) })
+    );
+    global.localStorage = { getItem: vi.fn(), setItem: vi.fn(), removeItem: vi.fn() };
+    global.window = {
+      location: { origin: "", href: "", hostname: "" },
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    };
+    global.document = {
+      addEventListener: vi.fn((evt, cb) => {
+        if (evt === "DOMContentLoaded") cb();
+      }),
+      querySelectorAll: vi.fn(() => []),
+      dispatchEvent: vi.fn()
+    };
+  });
+
+  it("auth.init can be called twice", async () => {
+    await auth.init();
+    const first = window.Smoothr.auth;
+    await auth.init();
+    expect(window.Smoothr.auth).toBe(first);
+    expect(getUserMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("currency.init can be called twice", async () => {
+    await currency.init({ baseCurrency: "USD" });
+    const first = window.Smoothr.currency.getCurrency();
+    await currency.init({ baseCurrency: "USD" });
+    expect(window.Smoothr.currency.getCurrency()).toBe(first);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/storefronts/tests/sdk/login-dataset-immutable.test.js
+++ b/storefronts/tests/sdk/login-dataset-immutable.test.js
@@ -26,8 +26,7 @@ vi.mock("@supabase/supabase-js", () => {
   return { createClient: createClientMock };
 });
 
-import * as auth from "../../features/auth/index.js";
-vi.spyOn(auth, "lookupRedirectUrl").mockResolvedValue("/redirect");
+let auth;
 
 function flushPromises() {
   return new Promise(setImmediate);
@@ -39,7 +38,8 @@ describe("login with immutable dataset", () => {
   let passwordValue;
   let loginTrigger;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
     clickHandler = undefined;
     emailValue = "user@example.com";
     passwordValue = "Password1";
@@ -85,11 +85,13 @@ describe("login with immutable dataset", () => {
       }),
       dispatchEvent: vi.fn(),
     };
+    auth = await import("../../features/auth/index.js");
+    vi.spyOn(auth, "lookupRedirectUrl").mockResolvedValue("/redirect");
   });
 
   it("logs in even when dataset is immutable", async () => {
     signInMock.mockResolvedValue({ data: { user: { id: "1" } }, error: null });
-    auth.initAuth();
+    await auth.init();
     await flushPromises();
 
     expect(loginTrigger.dataset.smoothrBoundAuth).toBeUndefined();

--- a/storefronts/tests/sdk/password-reset.test.js
+++ b/storefronts/tests/sdk/password-reset.test.js
@@ -34,9 +34,7 @@ vi.mock("@supabase/supabase-js", () => {
   return { createClient: createClientMock };
 });
 
-import * as auth from "../../features/auth/index.js";
-
-vi.spyOn(auth, "lookupRedirectUrl").mockResolvedValue("/redirect");
+let auth;
 
 function flushPromises() {
   return new Promise(setImmediate);
@@ -46,7 +44,8 @@ describe("password reset request", () => {
   let clickHandler;
   let emailValue;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
     emailValue = "user@example.com";
     clickHandler = undefined;
     let btn;
@@ -85,11 +84,13 @@ describe("password reset request", () => {
       }),
     };
     global.alert = global.window.alert = vi.fn();
+    auth = await import("../../features/auth/index.js");
+    vi.spyOn(auth, "lookupRedirectUrl").mockResolvedValue("/redirect");
   });
 
   it("sends reset email", async () => {
     resetPasswordMock.mockResolvedValue({ data: {}, error: null });
-    auth.initAuth();
+    await auth.init();
     await flushPromises();
     await clickHandler({ preventDefault: () => {} });
     await flushPromises();
@@ -104,7 +105,7 @@ describe("password reset request", () => {
       data: null,
       error: new Error("bad"),
     });
-    auth.initAuth();
+    await auth.init();
     await flushPromises();
     await clickHandler({ preventDefault: () => {} });
     await flushPromises();
@@ -119,7 +120,8 @@ describe("password reset confirmation", () => {
   let passwordInputObj;
   let confirmInputObj;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
     updateUserMock.mockClear();
     setSessionMock.mockClear();
     passwordValue = "newpass123";
@@ -165,6 +167,8 @@ describe("password reset confirmation", () => {
       }),
     };
     global.alert = global.window.alert = vi.fn();
+    auth = await import("../../features/auth/index.js");
+    vi.spyOn(auth, "lookupRedirectUrl").mockResolvedValue("/redirect");
   });
 
   it("updates password and redirects", async () => {
@@ -214,7 +218,7 @@ describe("password reset confirmation", () => {
     expect(updateUserMock).not.toHaveBeenCalled();
   });
 
-  it("sets window.smoothr.auth.user after update", async () => {
+  it("sets window.Smoothr.auth.user after update", async () => {
     const user = { id: "1", email: "test@example.com" };
     updateUserMock.mockResolvedValue({ data: { user }, error: null });
     setSessionMock.mockResolvedValue({ data: {}, error: null });
@@ -222,6 +226,6 @@ describe("password reset confirmation", () => {
     await flushPromises();
     await clickHandler({ preventDefault: () => {} });
     await flushPromises();
-    expect(global.window.smoothr.auth.user.value).toEqual(user);
+    expect(global.window.Smoothr.auth.user.value).toEqual(user);
   });
 });

--- a/storefronts/tests/sdk/stripe-mount.test.js
+++ b/storefronts/tests/sdk/stripe-mount.test.js
@@ -64,7 +64,6 @@ beforeEach(() => {
     },
     Smoothr: { cart: { getCart: () => ({ items: [] }), getTotal: () => 0 } }
   };
-  global.window.smoothr = global.window.Smoothr;
 });
 
 describe('stripe element mounting', () => {


### PR DESCRIPTION
## Summary
- adjust SDK tests to use `auth.init` and `window.Smoothr`
- initialize currency module in tests and update DOM price expectations
- add idempotency test for repeated auth/currency initialization

## Testing
- `npm test` *(fails: lookupDashboardHomeUrl not called, dispatchEvent not called, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68925415aa2883258a93a29a14bbe4c5