### PR TITLE
test: mock fetch with text response

### DIFF
--- a/storefronts/tests/sdk/smoothr-config.test.js
+++ b/storefronts/tests/sdk/smoothr-config.test.js
@@ -7,12 +7,13 @@ function flushPromises() {
 
 beforeEach(() => {
   vi.resetModules();
-  global.fetch = vi.fn(() =>
-    Promise.resolve({
+  global.fetch = vi
+    .fn()
+    .mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ rates: { USD: 1, EUR: 0.8 } }),
-    }),
-  );
+      text: () => Promise.resolve("{}"),
+    });
   global.window = {
     location: { origin: "", href: "", hostname: "" },
     addEventListener: vi.fn(),


### PR DESCRIPTION
## Summary
- ensure `smoothr-config` test mocks `fetch` with a `text` method

## Testing
- `npm --workspace storefronts test -- tests/sdk/smoothr-config.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68927205223c8325bfc46e242f0115a8