### PR TITLE
feat(checkout): dynamic gateway initializer

### DIFF
--- a/storefronts/features/checkout/init.js
+++ b/storefronts/features/checkout/init.js
@@ -1,0 +1,62 @@
+import { loadScriptOnce } from '../../utils/loadScriptOnce.js';
+
+let initialized = false;
+
+export async function init(config = {}) {
+  if (initialized || (typeof window !== 'undefined' && window.Smoothr?.cart?.checkout)) {
+    return;
+  }
+  initialized = true;
+
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.SMOOTHR_CONFIG = { ...(window.SMOOTHR_CONFIG || {}), ...config };
+
+  const debug = !!window.SMOOTHR_CONFIG?.debug;
+  const gateway = window.SMOOTHR_CONFIG?.settings?.active_payment_gateway;
+  if (!gateway) {
+    return;
+  }
+
+  try {
+    const mod = await import(`./providers/${gateway}/init.js`);
+    const provider = mod.default || mod;
+
+    const scriptSrc =
+      provider.scriptSrc ||
+      provider.sdkSrc ||
+      provider.src ||
+      provider.sdk?.src;
+    const globalCheck =
+      provider.global ||
+      provider.globalVar ||
+      provider.sdk?.global ||
+      provider.globalCheck;
+
+    if (scriptSrc) {
+      await loadScriptOnce(scriptSrc, globalCheck);
+    }
+
+    const checkoutFn =
+      provider.checkout ||
+      (provider.default && provider.default.checkout);
+
+    window.Smoothr = window.Smoothr || {};
+    const cart = (window.Smoothr.cart = window.Smoothr.cart || {});
+    if (typeof checkoutFn === 'function') {
+      cart.checkout = checkoutFn;
+    }
+
+    if (debug) {
+      console.log('[Smoothr] Checkout module loaded');
+      console.log('[Smoothr] Active gateway:', gateway);
+    }
+  } catch (e) {
+    if (debug) {
+      console.warn('[Smoothr] Failed to load provider module', gateway, e);
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add checkout initializer to dynamically load provider SDKs

## Testing
- `npm test` *(fails: ReferenceError: alert is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6893431b6c748325a7f072e90fb0ed8f