### PR TITLE
feat: bootstrap storefront SDK

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -1,0 +1,1 @@
+export { init } from './index.js';

--- a/storefronts/features/currency/init.js
+++ b/storefronts/features/currency/init.js
@@ -1,0 +1,1 @@
+export { init } from './index.js';

--- a/storefronts/smoothr-sdk.js
+++ b/storefronts/smoothr-sdk.js
@@ -1,149 +1,70 @@
-// Smoothr SDK bootstrapper
-// Automatically initializes Smoothr modules and features based on DOM attributes.
+import { supabase } from '../supabase/supabaseClient.js';
 
 const scriptEl = document.getElementById('smoothr-sdk');
 const storeId = scriptEl?.dataset?.storeId || null;
 const platform =
   scriptEl?.dataset?.platform || scriptEl?.getAttribute?.('platform') || null;
-
-const debug = new URLSearchParams(location.search).get('smoothr-debug') === 'true';
+const debug = new URLSearchParams(window.location.search).get('smoothr-debug') === 'true';
 
 if (!scriptEl || !storeId) {
   if (debug) {
     console.warn(
       !scriptEl
-        ? '[Smoothr] initialization aborted: #smoothr-sdk script element not found'
-        : '[Smoothr] initialization aborted: data-store-id attribute missing'
+        ? '[Smoothr SDK] initialization aborted: #smoothr-sdk script element not found'
+        : '[Smoothr SDK] initialization aborted: data-store-id attribute missing'
     );
   }
 } else {
+  const config = (window.SMOOTHR_CONFIG = { storeId, platform, debug });
   const Smoothr = (window.Smoothr = window.Smoothr || {});
-  window.smoothr = Smoothr;
-  Smoothr.config = { storeId, platform, debug };
+  window.smoothr = window.smoothr || Smoothr;
+  Smoothr.config = config;
 
-  // Basic event bus for cross-feature communication
-  const events = (() => {
-    const listeners = {};
-    return {
-      on(event, handler) {
-        (listeners[event] = listeners[event] || []).push(handler);
-      },
-      off(event, handler) {
-        const list = listeners[event];
-        if (!list) return;
-        const idx = list.indexOf(handler);
-        if (idx !== -1) list.splice(idx, 1);
-      },
-      emit(event, detail) {
-        (listeners[event] || []).forEach(fn => {
-          try {
-            fn(detail);
-          } catch (err) {
-            console.error('[Smoothr events]', err);
-          }
-        });
-      }
-    };
-  })();
-  Smoothr.events = events;
+  const log = (...args) => debug && console.log('[Smoothr SDK]', ...args);
+  log('Config initialized', config);
 
-  if (debug) {
-    console.groupCollapsed('[Smoothr]');
-    console.log('Store ID:', storeId);
-    console.log('Platform:', platform);
-  }
-
-  // helper for safe dynamic imports
-  async function safeImport(path) {
-    try {
-      return await import(path);
-    } catch (err) {
-      if (debug) console.warn(`Failed to load module ${path}`, err);
-      return null;
-    }
-  }
-
-  // Initialize core modules
-  const auth = await safeImport('./features/auth/index.js');
-  if (auth) {
-    const instance = auth.default ?? auth;
-    Smoothr.auth = instance;
-    if (typeof auth.init === 'function') {
-      await auth.init(Smoothr.config);
-    } else if (typeof instance.init === 'function') {
-      await instance.init(Smoothr.config);
-    }
-  }
-
-  const currency = await safeImport('./features/currency/index.js');
-  if (currency) {
-    const instance = currency.default ?? currency;
-    Smoothr.currency = instance;
-    if (typeof currency.init === 'function') {
-      await currency.init(Smoothr.config);
-    } else if (typeof instance.init === 'function') {
-      await instance.init(Smoothr.config);
-    }
-  }
-
-  // Platform adapter loading
-  let adapter = null;
-  if (platform) {
-    adapter = await safeImport(`./adapters/${platform}.js`);
-    if (!adapter) {
-      // scaffold placeholder adapter
-      adapter = {
-        platformReady: async () => {},
-        domReady: async () => {},
-        observeDOMChanges: () => {}
-      };
-    }
-    await adapter.platformReady?.(Smoothr.config);
-  }
-
-  function runFeatureInit() {
-    const elements = Array.from(document.querySelectorAll('[data-smoothr]'));
-    const featureNames = [...new Set(elements.map(el => el.getAttribute('data-smoothr')))].filter(Boolean);
-    const loaded = [];
-
-    const imports = featureNames.map(async name => {
+  (async () => {
+    if (storeId) {
       try {
-        const mod = await import(`./features/${name}/index.js`);
-        const instance = mod.default ?? mod;
-        Smoothr[name] = instance;
-        loaded.push(name);
-        if (typeof mod.init === 'function') {
-          await mod.init(Smoothr.config);
-        } else if (typeof instance.init === 'function') {
-          await instance.init(Smoothr.config);
-        }
+        log('Fetching store settings');
+        const { data } = await supabase
+          .from('public_store_settings')
+          .select('active_payment_gateway')
+          .eq('store_id', storeId)
+          .maybeSingle();
+        config.settings = { ...(config.settings || {}), ...(data || {}) };
+        log('Store settings loaded', config.settings);
       } catch (err) {
-        if (debug) console.warn(`Feature "${name}" failed to load`, err);
+        debug && console.warn('[Smoothr SDK] Failed to fetch store settings', err);
       }
-    });
-
-    Promise.all(imports).then(() => {
-      if (debug) {
-        console.log('DOM scan:', featureNames);
-        console.log('Loaded features:', loaded);
-        console.groupEnd();
-      }
-    });
-  }
-
-  function onReady(fn) {
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', fn, { once: true });
-    } else {
-      fn();
     }
-  }
 
-  onReady(async () => {
-    await adapter?.domReady?.(Smoothr.config);
-    adapter?.observeDOMChanges?.(Smoothr.config);
-    runFeatureInit();
-  });
+    if (platform) {
+      try {
+        log(`Loading adapter: ${platform}`);
+        const mod = await import(`./adapters/${platform}.js`);
+        const adapter = mod.default ?? mod;
+        const instance = await adapter.initAdapter?.(config);
+        await instance?.domReady?.();
+        log('Adapter initialized');
+      } catch (err) {
+        debug && console.warn('[Smoothr SDK] Failed to load adapter', err);
+      }
+    }
+
+    try {
+      log('Initializing auth feature');
+      await import('./features/auth/init.js').then(m => m.init(config));
+    } catch (err) {
+      debug && console.warn('[Smoothr SDK] Auth init failed', err);
+    }
+
+    try {
+      log('Initializing currency feature');
+      await import('./features/currency/init.js').then(m => m.init(config));
+    } catch (err) {
+      debug && console.warn('[Smoothr SDK] Currency init failed', err);
+    }
+  })();
 }
 
-// TODO: Load third-party SDKs (e.g., Stripe) when required by features.


### PR DESCRIPTION
## Summary
- setup storefront SDK that configures store, loads adapter, and starts auth/currency features
- add init entry points for auth and currency modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893bc68707083259c658f9059b4c6f4