### PR TITLE
feat: centralize global config access

### DIFF
--- a/storefronts/features/abandoned-cart/index.js
+++ b/storefronts/features/abandoned-cart/index.js
@@ -6,10 +6,12 @@
  * can be used by future recovery flows (emails, webhooks, etc.).
  */
 
+import { getConfig } from '../config/globalConfig.js';
+
 const STORAGE_KEY = 'smoothr_cart_meta';
 let isSetup = false;
 
-const debug = window.SMOOTHR_CONFIG?.debug;
+const { debug } = getConfig();
 const log = (...args) => debug && console.log('smoothr:abandoned-cart', ...args);
 const warn = (...args) => debug && console.warn('smoothr:abandoned-cart', ...args);
 const err = (...args) => debug && console.error('smoothr:abandoned-cart', ...args);

--- a/storefronts/features/auth/index.js
+++ b/storefronts/features/auth/index.js
@@ -1,4 +1,5 @@
 import { supabase, ensureSupabaseSessionAuth } from '../../../supabase/supabaseClient.js';
+import { getConfig, mergeConfig } from '../config/globalConfig.js';
 import {
   initAuth as initAuthHelper,
   signInWithGoogle,
@@ -17,9 +18,7 @@ import {
   findMessageContainer
 } from '../../../supabase/authHelpers.js';
 
-// Ensure SMOOTHR_CONFIG is accessible in both browser and non-browser environments
-const globalScope = typeof window !== 'undefined' ? window : globalThis;
-const SMOOTHR_CONFIG = globalScope.SMOOTHR_CONFIG || {};
+const SMOOTHR_CONFIG = getConfig();
 
 let initialized = false;
 
@@ -384,10 +383,7 @@ const auth = {
     return window.Smoothr?.auth;
   }
 
-  if (typeof window !== 'undefined') {
-    window.SMOOTHR_CONFIG = { ...(window.SMOOTHR_CONFIG || {}), ...config };
-  }
-  Object.assign(SMOOTHR_CONFIG, config);
+  const merged = mergeConfig(config);
 
   const debugQuery =
     typeof window !== 'undefined' &&
@@ -395,8 +391,8 @@ const auth = {
   debug =
     typeof config.debug === 'boolean'
       ? config.debug
-      : typeof SMOOTHR_CONFIG.debug === 'boolean'
-        ? SMOOTHR_CONFIG.debug
+      : typeof merged.debug === 'boolean'
+        ? merged.debug
         : debugQuery;
 
   registerDOMBindings(bindAuthElements, bindSignOutButtons);

--- a/storefronts/features/auth/sdk-auth-entry.js
+++ b/storefronts/features/auth/sdk-auth-entry.js
@@ -5,14 +5,14 @@ import {
   lookupDashboardHomeUrl
 } from '../../../supabase/authHelpers.js';
 import * as currency from '../currency/index.js';
+import { getConfig } from '../config/globalConfig.js';
 
 if (typeof globalThis.setSelectedCurrency !== 'function') {
   globalThis.setSelectedCurrency = () => {};
 }
 
 const storeRedirects = { lookupRedirectUrl, lookupDashboardHomeUrl };
-const SMOOTHR_CONFIG =
-  (typeof window !== 'undefined' && window.SMOOTHR_CONFIG) || {};
+const SMOOTHR_CONFIG = getConfig();
 
 const Smoothr = { auth, loadConfig, storeRedirects, currency, SMOOTHR_CONFIG };
 export { auth, loadConfig, storeRedirects, currency, SMOOTHR_CONFIG };

--- a/storefronts/features/cart/addToCart.js
+++ b/storefronts/features/cart/addToCart.js
@@ -1,4 +1,5 @@
 import * as cart from '../../features/cart/index.js';
+import { getConfig } from '../config/globalConfig.js';
 
 // Ensure the cart module is available on the global Smoothr object before any
 // DOM bindings are attached. This prevents addItem calls from failing when the
@@ -19,7 +20,7 @@ let foundLogShown = false;
 const MAX_POLL_ATTEMPTS = 10;
 let pollAttempts = 0;
 
-const debug = window.SMOOTHR_CONFIG?.debug;
+const { debug } = getConfig();
 const log = (...args) => debug && console.log('[Smoothr Cart]', ...args);
 const warn = (...args) => debug && console.warn('[Smoothr Cart]', ...args);
 const err = (...args) => debug && console.error('[Smoothr Cart]', ...args);

--- a/storefronts/features/cart/index.js
+++ b/storefronts/features/cart/index.js
@@ -1,7 +1,8 @@
 // Core cart module for Smoothr SDK
+import { getConfig } from '../config/globalConfig.js';
 const STORAGE_KEY = 'smoothr_cart';
 
-const debug = window.SMOOTHR_CONFIG?.debug;
+const { debug } = getConfig();
 const log = (...args) => debug && console.log('[Smoothr Cart]', ...args);
 const warn = (...args) => debug && console.warn('[Smoothr Cart]', ...args);
 const err = (...args) => debug && console.error('[Smoothr Cart]', ...args);

--- a/storefronts/features/cart/renderCart.js
+++ b/storefronts/features/cart/renderCart.js
@@ -1,3 +1,5 @@
+import { getConfig } from '../config/globalConfig.js';
+
 function getSelectedCurrency(Smoothr) {
   if (typeof window === 'undefined') {
     return Smoothr?.currency?.baseCurrency || 'USD';
@@ -18,7 +20,7 @@ function hideTemplatesGlobally() {
 }
 
 export function renderCart() {
-  const debug = window.SMOOTHR_CONFIG?.debug;
+  const { debug } = getConfig();
   if (debug) console.log('🎨 renderCart() triggered');
   if (typeof document === 'undefined') return;
   setTimeout(() => hideTemplatesGlobally(), 50);

--- a/storefronts/features/checkout/gateways/authorizeNet.js
+++ b/storefronts/features/checkout/gateways/authorizeNet.js
@@ -5,6 +5,7 @@ import {
   getAuthorizeNetStyles,
   initAuthorizeStyles
 } from '../utils/authorizeNetIframeStyles.js';
+import { getConfig } from '../../config/globalConfig.js';
 
 let fieldsMounted = false;
 let mountPromise;
@@ -73,7 +74,7 @@ function getAcceptCredentials() {
   };
 }
 
-const DEBUG = !!window.SMOOTHR_CONFIG?.debug;
+const DEBUG = !!getConfig().debug;
 const log = (...a) => DEBUG && console.log('[AuthorizeNet]', ...a);
 const warn = (...a) => DEBUG && console.warn('[AuthorizeNet]', ...a);
 
@@ -89,7 +90,7 @@ function loadAcceptJs() {
     let script = document.querySelector('script[data-smoothr-accept]');
     if (!script) {
       script = document.createElement('script');
-      const env = window.SMOOTHR_CONFIG?.env?.toLowerCase();
+      const env = getConfig().env?.toLowerCase();
       const isProd = env === 'production' || env === 'prod';
       script.src = isProd
         ? 'https://js.authorize.net/v1/Accept.js'
@@ -110,7 +111,7 @@ function loadAcceptJs() {
 async function resolveCredentials() {
   if (clientKey && apiLoginID && transactionKey !== undefined)
     return { clientKey, apiLoginID };
-  const storeId = window.SMOOTHR_CONFIG?.storeId;
+  const storeId = getConfig().storeId;
   if (!storeId) return { clientKey: null, apiLoginID: null };
   const cred = await getPublicCredential(storeId, 'authorizeNet');
   clientKey = cred?.settings?.client_key || '';

--- a/storefronts/features/checkout/gateways/nmiGateway.js
+++ b/storefronts/features/checkout/gateways/nmiGateway.js
@@ -4,6 +4,7 @@ import { resolveTokenizationKey } from '../providers/nmiProvider.js'
 import { handleSuccessRedirect } from '../utils/handleSuccessRedirect.js'
 import { disableButton, enableButton } from '../utils/cartHash.js'
 import styleNmiIframes, { getNmiStyles } from '../utils/nmiIframeStyles.js'
+import { getConfig } from '../../config/globalConfig.js'
 
 let hasMounted = false
 let isConfigured = false
@@ -21,7 +22,7 @@ export async function mountCardFields() {
   hasMounted = true
   configPromise = new Promise(resolve => { resolveConfig = resolve })
 
-  const storeId = window.SMOOTHR_CONFIG.storeId
+  const storeId = getConfig().storeId
   const tokenKey = await resolveTokenizationKey(storeId, 'nmi', 'nmi')
   if (!tokenKey) {
     console.warn('[NMI] Tokenization key missing')

--- a/storefronts/features/checkout/gateways/paypal.js
+++ b/storefronts/features/checkout/gateways/paypal.js
@@ -1,6 +1,7 @@
 import { getPublicCredential } from '../getPublicCredential.js';
 import { handleSuccessRedirect } from '../utils/handleSuccessRedirect.js';
 import { disableButton, enableButton } from '../utils/cartHash.js';
+import { getConfig } from '../../config/globalConfig.js';
 
 let mounted = false;
 let isSubmitting = false;
@@ -34,7 +35,7 @@ export async function mountCardFields() {
   // prevent default Smoothr click handler
   container.addEventListener('click', e => e.stopImmediatePropagation(), true);
 
-  const storeId = window.SMOOTHR_CONFIG?.storeId;
+  const storeId = getConfig().storeId;
   const cred = await getPublicCredential(storeId, 'paypal');
   const clientId = cred?.settings?.client_id || cred?.api_key || '';
   if (!clientId) {
@@ -44,7 +45,7 @@ export async function mountCardFields() {
 
   await loadScript(`https://www.paypal.com/sdk/js?client-id=${clientId}`);
 
-  const apiBase = window.SMOOTHR_CONFIG?.apiBase || '';
+  const apiBase = getConfig().apiBase || '';
 
   const paypalButtons = window.paypal.Buttons({
       createOrder: async () => {
@@ -54,7 +55,7 @@ export async function mountCardFields() {
         window.Smoothr?.cart?.getTotal?.() ||
         parseInt(totalEl?.textContent?.replace(/[^0-9]/g, '') || '0', 10) ||
         0;
-      const currency = window.SMOOTHR_CONFIG?.baseCurrency || 'USD';
+      const currency = getConfig().baseCurrency || 'USD';
       const res = await fetch(`${apiBase}/api/checkout/paypal/createPayPalOrder`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -99,7 +100,7 @@ export async function mountCardFields() {
         window.Smoothr?.cart?.getTotal?.() ||
         parseInt(totalEl?.textContent?.replace(/[^0-9]/g, '') || '0', 10) ||
         0;
-      const currency = window.SMOOTHR_CONFIG?.baseCurrency || 'USD';
+      const currency = getConfig().baseCurrency || 'USD';
 
       const payload = {
         orderID: data.orderID,
@@ -113,7 +114,7 @@ export async function mountCardFields() {
         total,
         currency,
         customer_id: window.smoothr?.auth?.user?.value?.id || null,
-        platform: window.SMOOTHR_CONFIG?.platform
+        platform: getConfig().platform
       };
 
       const res = await fetch(`${apiBase}/api/checkout/paypal/capture-order`, {
@@ -144,7 +145,7 @@ export async function mountCardFields() {
             window.Smoothr?.cart?.getTotal?.() ||
             parseInt(totalEl?.textContent?.replace(/[^0-9]/g, '') || '0', 10) ||
             0;
-          const currency = window.SMOOTHR_CONFIG?.baseCurrency || 'USD';
+          const currency = getConfig().baseCurrency || 'USD';
           const res = await fetch(`${apiBase}/api/checkout/paypal/createPayPalOrder`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },

--- a/storefronts/features/checkout/gateways/stripeGateway.js
+++ b/storefronts/features/checkout/gateways/stripeGateway.js
@@ -6,6 +6,7 @@ import forceStripeIframeStyle, {
 
 import { getPublicCredential } from '../getPublicCredential.js';
 import { handleSuccessRedirect } from '../utils/handleSuccessRedirect.js';
+import { getConfig } from '../../config/globalConfig.js';
 let fieldsMounted = false;
 let mountAttempts = 0;
 let stripe;
@@ -15,7 +16,7 @@ let cachedKey;
 let cardNumberElement;
 let mountPromise;
 
-const debug = window.SMOOTHR_CONFIG?.debug;
+const debug = getConfig().debug;
 const log = (...args) => debug && console.log('[Smoothr Stripe]', ...args);
 const warn = (...args) => debug && console.warn('[Smoothr Stripe]', ...args);
 
@@ -54,8 +55,9 @@ export async function waitForInteractable(el, timeout = 1500) {
 
 async function resolveStripeKey() {
   if (cachedKey) return cachedKey;
-  const storeId = window.SMOOTHR_CONFIG?.storeId;
-  const config = window.SMOOTHR_CONFIG || {};
+  const cfg = getConfig();
+  const storeId = cfg?.storeId;
+  const config = cfg || {};
   if (
     config.active_payment_gateway &&
     config.active_payment_gateway !== 'stripe'
@@ -229,7 +231,7 @@ export function ready() {
 }
 
 export async function getStoreSettings() {
-  const data = window.SMOOTHR_CONFIG;
+  const data = getConfig();
   if (!data) {
     warn('Store settings not found');
     return null;

--- a/storefronts/features/checkout/providers/nmiProvider.js
+++ b/storefronts/features/checkout/providers/nmiProvider.js
@@ -1,17 +1,18 @@
 import { getPublicCredential } from '../getPublicCredential.js';
+import { getConfig } from '../../config/globalConfig.js';
 
 let cachedKey;
 
-const DEBUG = !!window.SMOOTHR_CONFIG?.debug;
+const DEBUG = !!getConfig().debug;
 const log = (...a) => DEBUG && console.log('[NMI]', ...a);
 const warn = (...a) => DEBUG && console.warn('[NMI]', ...a);
 
 export async function resolveTokenizationKey() {
   if (cachedKey !== undefined) return cachedKey;
-  const storeId = window.SMOOTHR_CONFIG?.storeId;
+  const storeId = getConfig().storeId;
   if (!storeId) return null;
 
-  const gateway = window.SMOOTHR_CONFIG?.active_payment_gateway || 'nmi';
+  const gateway = getConfig().active_payment_gateway || 'nmi';
 
   try {
     const cred = await getPublicCredential(storeId, 'nmi', gateway);

--- a/storefronts/features/checkout/utils/checkoutLogger.js
+++ b/storefronts/features/checkout/utils/checkoutLogger.js
@@ -1,7 +1,8 @@
 import waitForElement from './waitForElement.js';
+import { getConfig } from '../../config/globalConfig.js';
 
 export default function checkoutLogger(block = document) {
-  const debug = window.SMOOTHR_CONFIG?.debug;
+  const debug = getConfig().debug;
   const log = (...args) => debug && console.log('[Smoothr Checkout]', ...args);
   const warn = (...args) => debug && console.warn('[Smoothr Checkout]', ...args);
   const err = (...args) => debug && console.error('[Smoothr Checkout]', ...args);

--- a/storefronts/features/checkout/utils/gatewayDispatcher.js
+++ b/storefronts/features/checkout/utils/gatewayDispatcher.js
@@ -1,7 +1,8 @@
 import { handleSuccessRedirect } from './handleSuccessRedirect.js';
+import { getConfig } from '../../config/globalConfig.js';
 
 export default async function gatewayDispatcher(provider, payload, token, log, warn, err) {
-  const apiBase = window.SMOOTHR_CONFIG?.apiBase || '';
+  const apiBase = getConfig().apiBase || '';
   log('POST', `${apiBase}/api/checkout/${provider}`);
 
   if (!apiBase.startsWith('https://')) {

--- a/storefronts/features/checkout/utils/getActivePaymentGateway.js
+++ b/storefronts/features/checkout/utils/getActivePaymentGateway.js
@@ -1,7 +1,8 @@
 import resolveGateway from './resolveGateway.js';
+import { getConfig } from '../../config/globalConfig.js';
 
 export default function getActivePaymentGateway(log = () => {}, warn = () => {}) {
-  const cfg = window.SMOOTHR_CONFIG || {};
+  const cfg = getConfig();
 
   if (!cfg.active_payment_gateway) {
     warn('active_payment_gateway not configured');

--- a/storefronts/features/config/globalConfig.js
+++ b/storefronts/features/config/globalConfig.js
@@ -1,0 +1,14 @@
+export function getConfig() {
+  if (typeof window !== 'undefined') {
+    window.SMOOTHR_CONFIG = window.SMOOTHR_CONFIG || {};
+    return window.SMOOTHR_CONFIG;
+  }
+  globalThis.SMOOTHR_CONFIG = globalThis.SMOOTHR_CONFIG || {};
+  return globalThis.SMOOTHR_CONFIG;
+}
+
+export function mergeConfig(partial = {}) {
+  const cfg = getConfig();
+  Object.assign(cfg, partial);
+  return cfg;
+}

--- a/storefronts/features/config/sdkConfig.ts
+++ b/storefronts/features/config/sdkConfig.ts
@@ -1,6 +1,7 @@
 import supabase from '../../../supabase/supabaseClient.js';
+import { getConfig } from './globalConfig.js';
 
-const debug = typeof window !== 'undefined' && window.SMOOTHR_CONFIG?.debug;
+const debug = typeof window !== 'undefined' && getConfig().debug;
 const warn = (...args: any[]) => debug && console.warn('[Smoothr Config]', ...args);
 
 export async function loadPublicConfig(storeId: string) {

--- a/storefronts/features/currency/fetchLiveRates.js
+++ b/storefronts/features/currency/fetchLiveRates.js
@@ -1,9 +1,11 @@
-const debug = typeof window !== 'undefined' && window.SMOOTHR_CONFIG?.debug;
+import { getConfig } from '../config/globalConfig.js';
+
+const debug = typeof window !== 'undefined' && getConfig().debug;
 const log = (...args) => debug && console.log('[Smoothr Rates]', ...args);
 
 function getAuthToken() {
   return (
-    (typeof window !== 'undefined' && window.SMOOTHR_CONFIG?.liveRatesToken) ||
+    (typeof window !== 'undefined' && getConfig().liveRatesToken) ||
     (typeof process !== 'undefined' && process.env.LIVE_RATES_AUTH_TOKEN)
   );
 }

--- a/storefronts/features/currency/index.js
+++ b/storefronts/features/currency/index.js
@@ -1,4 +1,5 @@
 import { fetchExchangeRates } from './fetchLiveRates.js';
+import { getConfig, mergeConfig } from '../config/globalConfig.js';
 
 /**
  * Manages currency formatting, conversion and basic DOM integration.
@@ -117,16 +118,15 @@ export async function init(config = {}) {
     return window.Smoothr?.currency;
   }
 
+  mergeConfig(config);
   if (typeof window !== 'undefined') {
-    window.SMOOTHR_CONFIG = { ...(window.SMOOTHR_CONFIG || {}), ...config };
     const debugQuery =
-      new URLSearchParams(window.location.search).get('smoothr-debug') ===
-      'true';
+      new URLSearchParams(window.location.search).get('smoothr-debug') === 'true';
     debug =
       typeof config.debug === 'boolean'
         ? config.debug
-        : typeof window.SMOOTHR_CONFIG?.debug === 'boolean'
-          ? window.SMOOTHR_CONFIG.debug
+        : typeof getConfig().debug === 'boolean'
+          ? getConfig().debug
           : debugQuery;
   }
 

--- a/storefronts/features/discounts/discounts.ts
+++ b/storefronts/features/discounts/discounts.ts
@@ -1,6 +1,7 @@
 import { supabase } from '../../../supabase/supabaseClient.js';
+import { getConfig } from '../config/globalConfig.js';
 
-const debug = typeof window !== 'undefined' && window.SMOOTHR_CONFIG?.debug;
+const debug = typeof window !== 'undefined' && getConfig().debug;
 const log = (...args: any[]) => debug && console.log('[Smoothr Discounts]', ...args);
 const warn = (...args: any[]) => debug && console.warn('[Smoothr Discounts]', ...args);
 

--- a/storefronts/features/orders/index.js
+++ b/storefronts/features/orders/index.js
@@ -3,8 +3,9 @@
  */
 
 import { supabase } from '../../../supabase/supabaseClient.js';
+import { getConfig } from '../config/globalConfig.js';
 
-const debug = window.SMOOTHR_CONFIG?.debug;
+const { debug } = getConfig();
 const log = (...args) => debug && console.log('[Smoothr Orders]', ...args);
 const warn = (...args) => debug && console.warn('[Smoothr Orders]', ...args);
 const err = (...args) => debug && console.error('[Smoothr Orders]', ...args);

--- a/storefronts/smoothr-sdk.js
+++ b/storefronts/smoothr-sdk.js
@@ -1,4 +1,5 @@
 import { supabase } from '../supabase/supabaseClient.js';
+import { mergeConfig } from './features/config/globalConfig.js';
 
 const scriptEl = document.getElementById('smoothr-sdk');
 const storeId = scriptEl?.dataset?.storeId || null;
@@ -15,7 +16,7 @@ if (!scriptEl || !storeId) {
     );
   }
 } else {
-  const config = (window.SMOOTHR_CONFIG = { storeId, platform, debug });
+  const config = mergeConfig({ storeId, platform, debug });
   const Smoothr = (window.Smoothr = window.Smoothr || {});
   window.smoothr = window.smoothr || Smoothr;
   Smoothr.config = config;


### PR DESCRIPTION
## Summary
- add globalConfig helper for accessing `window.SMOOTHR_CONFIG`
- migrate loader and checkout logic to use `getConfig`/`mergeConfig`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893c958ec588325846551b17e9a243b