### PR TITLE
chore: set Vite base URL

### DIFF
--- a/storefronts/vite.config.js
+++ b/storefronts/vite.config.js
@@ -8,6 +8,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
   return {
+    base: 'https://sdk.smoothr.io/',
     optimizeDeps: {
       include: ['@supabase/supabase-js']
     },


### PR DESCRIPTION
## Summary
- add base URL for deployed SDK in Vite config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893ce1dca208325acabde5df13987cc