### PR TITLE
chore: emit single sdk bundle

### DIFF
--- a/storefronts/vite.config.js
+++ b/storefronts/vite.config.js
@@ -33,19 +33,15 @@ export default defineConfig(({ mode }) => {
       rollupOptions: {
         external: [],
         input: {
-            'sdk-auth-entry': path.resolve(
-              __dirname,
-              'features/auth/sdk-auth-entry.js'
-            ),
-          checkout: path.resolve(__dirname, 'features/checkout/checkout-core.js'),
           'smoothr-sdk': path.resolve(__dirname, 'smoothr-sdk.js')
         },
         treeshake: true,
         preserveEntrySignatures: 'exports-only',
         output: {
           dir: path.resolve(__dirname, 'dist'),
-          entryFileNames: 'smoothr-[name].js',
-          format: 'es'
+          entryFileNames: '[name].js',
+          format: 'es',
+          inlineDynamicImports: true
         }
       },
       outDir: 'dist',


### PR DESCRIPTION
## Summary
- build only the Smoothr SDK bundle

## Testing
- `npx vite build`
- `npm test` *(fails: ReferenceError: alert is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6893dc5400a8832590d5a5ab4c8118b9