### PR TITLE
chore: remove unused sdk auth adapter

### DIFF
--- a/storefronts/adapters/core/sdk-auth-entry.js
+++ b/storefronts/adapters/core/sdk-auth-entry.js
@@ -1,2 +1,0 @@
-export * from '../../features/auth/sdk-auth-entry.js';
-export { default } from '../../features/auth/sdk-auth-entry.js';


### PR DESCRIPTION
## Summary
- remove deprecated sdk auth adapter
- verify no remaining imports of the adapter

## Testing
- `npm --workspace storefronts test`
- `npm run test:supabase`


------
https://chatgpt.com/codex/tasks/task_e_6894794ca67483258b871f8115c1e07e