### PR TITLE
docs: update SDK script reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,7 @@ The storefront SDK publishes lightweight bundles that can be loaded directly:
 
 ```html
 <!-- Core Smoothr SDK bundle -->
-<script
-  type="module"
-  src="https://sdk.smoothr.io/smoothr-sdk.js"
-></script>
+<script type="module" src="https://sdk.smoothr.io/smoothr-sdk.js"></script>
 
 <!-- Checkout bundle -->
 <script type="module" src="https://sdk.smoothr.io/features/checkout/checkout-core.js"></script>
@@ -296,9 +293,8 @@ successful deployment with the commit hash and UTC timestamp.
 
 All pushes to the `main` branch trigger the workflow defined at
 `.github/workflows/build-and-deploy.yml`. The workflow uses Node.js 20,
-installs dependencies, runs tests, builds the storefront SDK, performs the
-postbuild check (including a scan for any `import.meta.env` references), and
-deploys `storefronts/dist` to Cloudflare Pages.
+installs dependencies, runs tests, builds the storefront SDK, and deploys
+`storefronts/dist` to Cloudflare Pages.
 
 To configure deployment secrets go to **Settings → Secrets and variables →
 Actions** in GitHub and add:

--- a/storefronts/README.md
+++ b/storefronts/README.md
@@ -281,7 +281,7 @@ npm run build
 The SDK is built and deployed automatically whenever code is pushed to the
 `main` branch. The GitHub Actions workflow installs dependencies with `npm ci`,
 runs the test suite, builds the bundle, copies the checkout script into
-`dist`, performs the postbuild check and then deploys `dist` to Cloudflare Pages.
+`dist`, and deploys `dist` to Cloudflare Pages.
 The deployed commit and timestamp are recorded in the repository's `DEPLOY_LOG.md`
 file.
 


### PR DESCRIPTION
## Summary
- document hosted SDK script instead of internal entry file
- remove outdated check-sdk mention from CI/CD docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689480c4bb90832580990b6339eb9110