### PR TITLE
refactor(currency): isolate DOM init

### DIFF
--- a/storefronts/features/currency/init.js
+++ b/storefronts/features/currency/init.js
@@ -99,7 +99,11 @@ export async function init(config = {}) {
     window.smoothr = window.smoothr || Smoothr;
     Smoothr.currency = {
       setCurrency: setSelectedCurrency,
-      getRates: getRates || (() => ({}))
+      getCurrency: getSelectedCurrency,
+      getRates: getRates || (() => ({})),
+      convertPrice,
+      formatPrice,
+      baseCurrency
     };
     window.smoothr.currency = Smoothr.currency;
   }


### PR DESCRIPTION
## Summary
- strip DOM/config code from `currency/index.js`, leaving only conversion utilities
- expose DOM-driven setup via `currency.init` re-exported from `init.js`
- ensure `init.js` registers full currency API on `window.Smoothr`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68948a56248c832588c31a13cbc48ba2