### PR TITLE
refactor: export initCmsCurrency from init module

### DIFF
--- a/storefronts/features/currency/cms-currency.js
+++ b/storefronts/features/currency/cms-currency.js
@@ -1,5 +1,6 @@
 export {
   setSelectedCurrency,
   getSelectedCurrency,
-  init as initCmsCurrency
 } from './index.js';
+
+export { init as initCmsCurrency } from './init.js';


### PR DESCRIPTION
## Summary
- re-export `initCmsCurrency` from `init.js`
- keep currency selection exports from `index.js`

## Testing
- `npm test` *(fails: `Credential lookup failed: TypeError: fetch failed`)*

------
https://chatgpt.com/codex/tasks/task_e_6894904de78c832581c1a9acf6167e9d