### PR TITLE
Refactor currency feature import

### DIFF
--- a/storefronts/smoothr-sdk.js
+++ b/storefronts/smoothr-sdk.js
@@ -67,7 +67,8 @@ if (!scriptEl || !storeId) {
 
     try {
       log('Initializing currency feature');
-      await import('./features/currency/init.js').then(m => m.init(config));
+      const currency = await import('./features/currency/index.js');
+      await currency.init(config);
     } catch (err) {
       debug && console.warn('[Smoothr SDK] Currency init failed', err);
     }

--- a/storefronts/tests/sdk/currency-loader-idempotency.test.js
+++ b/storefronts/tests/sdk/currency-loader-idempotency.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../../features/currency/fetchLiveRates.js', () => ({
+  fetchExchangeRates: vi.fn().mockResolvedValue({})
+}));
+
+describe('currency loader idempotency', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    global.window = {};
+    global.document = {
+      readyState: 'complete',
+      addEventListener: vi.fn(),
+      querySelectorAll: vi.fn(() => [])
+    };
+    global.localStorage = {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn()
+    };
+  });
+
+  it('allows multiple loader calls without reinitializing', async () => {
+    const currency = await import('../../features/currency/index.js');
+    const first = await currency.init({ baseCurrency: 'USD' });
+    const second = await currency.init({ baseCurrency: 'USD' });
+    expect(second).toBe(first);
+    expect(global.document.addEventListener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/storefronts/tests/sdk/platform-detection.test.js
+++ b/storefronts/tests/sdk/platform-detection.test.js
@@ -4,7 +4,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("../../features/auth/init.js", () => ({
   init: vi.fn(),
 }));
-vi.mock("../../features/currency/init.js", () => ({
+vi.mock("../../features/currency/index.js", () => ({
   init: vi.fn(),
 }));
 

--- a/storefronts/tests/sdk/script-element-validation.test.js
+++ b/storefronts/tests/sdk/script-element-validation.test.js
@@ -2,7 +2,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 vi.mock('../../features/auth/init.js', () => ({ init: vi.fn() }));
-vi.mock('../../features/currency/init.js', () => ({ init: vi.fn() }));
+vi.mock('../../features/currency/index.js', () => ({ init: vi.fn() }));
 
 describe('Smoothr SDK script element validation', () => {
   let warnSpy;


### PR DESCRIPTION
## Summary
- load currency feature via `./features/currency/index.js` namespace
- update tests for new currency import
- add idempotency test for currency loader

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894913f5564832595ac132b17d6a92c