### PR TITLE
refactor: remove automatic currency DOM init

### DIFF
--- a/storefronts/adapters/README.md
+++ b/storefronts/adapters/README.md
@@ -20,7 +20,11 @@ the chosen currency in `localStorage`.
   <option value="EUR">EUR</option>
 </select>
 <script type="module">
-  import { setSelectedCurrency } from '../adapters/webflow/currencyDomAdapter.js';
+  import {
+    setSelectedCurrency,
+    initCurrencyDom
+  } from '../adapters/webflow/currencyDomAdapter.js';
+  initCurrencyDom();
   document
     .getElementById('currency-select')
     .addEventListener('change', e => setSelectedCurrency(e.target.value));
@@ -32,8 +36,7 @@ updated when the currency changes so you can access the converted amount via
 JavaScript.
 
 All elements with price attributes, including `[data-product-price]`, are
-formatted automatically when `initCurrencyDom()` runs on page load and whenever
-the currency changes.
+formatted when `initCurrencyDom()` runs and whenever the currency changes.
 
 ### Automatic price detection
 

--- a/storefronts/adapters/webflow.js
+++ b/storefronts/adapters/webflow.js
@@ -1,10 +1,23 @@
+import { initCurrencyDom } from './webflow/currencyDomAdapter.js';
+
 export function initAdapter(config) {
   // Placeholder for future Webflow-specific setup using `config` if needed.
   return {
     domReady: () =>
       new Promise(resolve => {
-        if (document.readyState !== 'loading') resolve();
-        else document.addEventListener('DOMContentLoaded', resolve, { once: true });
+        if (document.readyState !== 'loading') {
+          initCurrencyDom();
+          resolve();
+        } else {
+          document.addEventListener(
+            'DOMContentLoaded',
+            () => {
+              initCurrencyDom();
+              resolve();
+            },
+            { once: true }
+          );
+        }
       })
   };
 }

--- a/storefronts/adapters/webflow/currencyDomAdapter.js
+++ b/storefronts/adapters/webflow/currencyDomAdapter.js
@@ -54,7 +54,3 @@ export function initCurrencyDom() {
   replacePrices();
   document.addEventListener('smoothr:currencychange', replacePrices);
 }
-
-if (typeof window !== 'undefined') {
-  initCurrencyDom();
-}


### PR DESCRIPTION
## Summary
- avoid side-effectful currency DOM init and export `initCurrencyDom`
- Webflow adapter calls `initCurrencyDom` when DOM ready
- document explicit `initCurrencyDom` usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894971e98b88325a19cb077fec339d7