### PR TITLE
refactor: init currency dom via webflow adapter

### DIFF
--- a/storefronts/adapters/webflow.js
+++ b/storefronts/adapters/webflow.js
@@ -5,18 +5,15 @@ export function initAdapter(config) {
   return {
     domReady: () =>
       new Promise(resolve => {
-        if (document.readyState !== 'loading') {
+        const run = () => {
           initCurrencyDom();
           resolve();
+        };
+
+        if (document.readyState !== 'loading') {
+          run();
         } else {
-          document.addEventListener(
-            'DOMContentLoaded',
-            () => {
-              initCurrencyDom();
-              resolve();
-            },
-            { once: true }
-          );
+          document.addEventListener('DOMContentLoaded', run, { once: true });
         }
       })
   };

--- a/storefronts/adapters/webflow/webflow-ecom-currency.js
+++ b/storefronts/adapters/webflow/webflow-ecom-currency.js
@@ -1,5 +1,4 @@
 // Smoothr Checkout Script for Webflow with integrated NMI
-import { initCurrencyDom } from '../../adapters/webflow/currencyDomAdapter.js';
 import { mountNMI } from '../../features/checkout/gateways/nmiGateway.js';
 
 async function initCheckout() {
@@ -39,8 +38,6 @@ async function initCheckout() {
     console.warn('[Smoothr Checkout] Pay div not found');
   }
 
-  // Initialize shared DOM price formatter
-  initCurrencyDom();
 }
 
 // Run init on load


### PR DESCRIPTION
## Summary
- call currency DOM initializer from the Webflow adapter
- remove currency DOM initialization from the Webflow ecommerce script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894a331f5c8832583d4f1f1e1457008