### PR TITLE
refactor: defer add-to-cart binding

### DIFF
--- a/storefronts/README.md
+++ b/storefronts/README.md
@@ -119,11 +119,11 @@ Helpers for rendering the cart and binding `[data-smoothr-add]` buttons live in
 
 ```javascript
 import { renderCart } from './features/cart/renderCart.js';
-import { initCartBindings } from './features/cart/addToCart.js';
+import { bindAddToCartButtons } from './features/cart/addToCart.js';
 ```
 
 Call `renderCart()` after page load to display items and totals. Use
-`initCartBindings()` to attach click handlers for adding products.
+`bindAddToCartButtons()` to attach click handlers for adding products.
 
 ## Checkout
 

--- a/storefronts/features/cart/addToCart.js
+++ b/storefronts/features/cart/addToCart.js
@@ -1,18 +1,4 @@
-import * as cart from '../../features/cart/index.js';
 import { getConfig } from '../config/globalConfig.js';
-
-// Ensure the cart module is available on the global Smoothr object before any
-// DOM bindings are attached. This prevents addItem calls from failing when the
-// module isn't imported elsewhere.
-if (typeof window !== 'undefined') {
-  window.Smoothr = window.Smoothr || {};
-  // Use a shallow copy so the cart object remains extensible
-  window.Smoothr.cart = {
-    ...cart,
-    addButtonPollingRetries: 0,
-    addButtonPollingDisabled: false
-  };
-}
 
 let initLogShown = false;
 let noButtonsWarned = false;
@@ -25,9 +11,9 @@ const log = (...args) => debug && console.log('[Smoothr Cart]', ...args);
 const warn = (...args) => debug && console.warn('[Smoothr Cart]', ...args);
 const err = (...args) => debug && console.error('[Smoothr Cart]', ...args);
 
-export function initCartBindings() {
+export function bindAddToCartButtons() {
   if (debug && !initLogShown) {
-    log('🧩 initCartBindings loaded and executing');
+    log('🧩 bindAddToCartButtons loaded and executing');
     initLogShown = true;
   }
   if (typeof document === 'undefined') return;
@@ -61,7 +47,7 @@ export function initCartBindings() {
       warn('no buttons found; retrying...');
       noButtonsWarned = true;
     }
-    setTimeout(initCartBindings, 500);
+    setTimeout(bindAddToCartButtons, 500);
     return;
   }
 
@@ -120,20 +106,9 @@ export function initCartBindings() {
         } else {
           warn('renderCart not found');
         }
-      } catch (err) {
-        err('addToCart failed', err);
+      } catch (error) {
+        err('addToCart failed', error);
       }
     });
   });
-}
-
-export function initAddToCart() {
-  document.addEventListener('DOMContentLoaded', () => {
-    log('✅ DOM ready – calling initCartBindings');
-    initCartBindings();
-  });
-}
-
-if (typeof window !== 'undefined') {
-  initAddToCart();
 }

--- a/storefronts/features/cart/init.js
+++ b/storefronts/features/cart/init.js
@@ -1,6 +1,6 @@
 import { mergeConfig } from '../config/globalConfig.js';
 import * as cart from './index.js';
-import { initCartBindings as bindAddToCartButtons } from './addToCart.js';
+import { bindAddToCartButtons } from './addToCart.js';
 import { renderCart } from './renderCart.js';
 
 let initialized = false;

--- a/storefronts/tests/adapters/addToCart.test.js
+++ b/storefronts/tests/adapters/addToCart.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-let initAddToCart;
+let bindAddToCartButtons;
 
 class CustomEvt {
   constructor(type, init) {
@@ -58,9 +58,6 @@ describe("webflow add-to-cart binding", () => {
       global.window.dispatchEvent(new CustomEvt('smoothr:cart:updated'));
     });
     global.document = {
-      addEventListener: vi.fn((evt, cb) => {
-        if (evt === "DOMContentLoaded") cb();
-      }),
       querySelectorAll: vi.fn(() => [btn]),
     };
     global.window = {
@@ -70,23 +67,24 @@ describe("webflow add-to-cart binding", () => {
       }),
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
+      location: { pathname: "" },
     };
     global.window.SMOOTHR_CONFIG = { debug: true };
     global.CustomEvent = CustomEvt;
-    ({ initAddToCart } = await import("../../features/cart/addToCart.js"));
+    ({ bindAddToCartButtons } = await import("../../features/cart/addToCart.js"));
     // Override cart methods after module initializes
     global.window.Smoothr.cart.addItem = addItemMock;
     global.window.Smoothr.cart.getCart = vi.fn(() => ({}));
   });
 
   it("binds click handler once", () => {
-    initAddToCart();
-    initAddToCart();
+    bindAddToCartButtons();
+    bindAddToCartButtons();
     expect(btn.addEventListener).toHaveBeenCalledTimes(1);
   });
 
   it("adds item and dispatches update", () => {
-    initAddToCart();
+    bindAddToCartButtons();
     events.click();
     expect(addItemMock).toHaveBeenCalledWith({
       product_id: "1",
@@ -109,7 +107,7 @@ describe("webflow add-to-cart binding", () => {
     };
     wrapper.parentElement = ancestor;
 
-    initAddToCart();
+    bindAddToCartButtons();
     events.click();
 
     expect(addItemMock).toHaveBeenCalledWith({
@@ -128,7 +126,7 @@ describe("webflow add-to-cart binding", () => {
     wrapper.querySelector.mockImplementation(() => null);
     wrapper.parentElement = null;
 
-    initAddToCart();
+    bindAddToCartButtons();
     events.click();
 
     expect(addItemMock).toHaveBeenCalledWith({
@@ -147,7 +145,7 @@ describe("webflow add-to-cart binding", () => {
   it("detects wrapper when button is nested deeply", () => {
     // simulate button nested inside two levels of divs within wrapper
     btn.parentElement = { matches: vi.fn(() => false), parentElement: wrapper };
-    initAddToCart();
+    bindAddToCartButtons();
     events.click();
 
     expect(btn.closest).toHaveBeenCalledWith("[data-smoothr-product]");
@@ -168,7 +166,7 @@ describe("webflow add-to-cart binding", () => {
     const warnSpy = vi
       .spyOn(console, "warn")
       .mockImplementation(() => {});
-    initAddToCart();
+    bindAddToCartButtons();
     for (let i = 0; i < 10; i++) {
       vi.runOnlyPendingTimers();
     }


### PR DESCRIPTION
## Summary
- replace auto-run add-to-cart logic with `bindAddToCartButtons`
- invoke `bindAddToCartButtons` from cart init
- document and test new binding approach

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894b29c3fe483258046b58d764af5ea