### PR TITLE
feat: conditionally load cart feature when triggers exist

### DIFF
--- a/storefronts/smoothr-sdk.js
+++ b/storefronts/smoothr-sdk.js
@@ -72,6 +72,22 @@ if (!scriptEl || !storeId) {
     } catch (err) {
       debug && console.warn('[Smoothr SDK] Currency init failed', err);
     }
+
+    const hasCartTrigger =
+      document.querySelector('[data-smoothr="add-to-cart"]') ||
+      document.querySelector('[data-smoothr-add]');
+
+    if (hasCartTrigger) {
+      try {
+        log('Initializing cart feature');
+        const cart = await import('./features/cart/init.js');
+        await cart.init(config);
+      } catch (err) {
+        debug && console.warn('[Smoothr SDK] Cart init failed', err);
+      }
+    } else {
+      log('No cart triggers found, skipping cart initialization');
+    }
   })();
 }
 

--- a/storefronts/tests/sdk/cart-feature-loading.test.js
+++ b/storefronts/tests/sdk/cart-feature-loading.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const cartInitMock = vi.fn();
+const globalKey = '__supabaseAuthClientsmoothr-browser-client';
+
+function flushPromises() {
+  return new Promise(setImmediate);
+}
+
+describe("cart feature loading", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    cartInitMock.mockReset();
+    global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }));
+    global.console = { log: vi.fn(), warn: vi.fn() };
+    vi.doMock("../../supabase/supabaseClient.js", () => ({
+      supabase: {
+        from: vi.fn(() => ({
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue({ data: null }) }))
+          }))
+        }))
+      }
+    }));
+    vi.doMock("../../features/auth/init.js", () => ({ init: vi.fn() }));
+    vi.doMock("../../features/currency/index.js", () => ({ init: vi.fn().mockResolvedValue() }));
+    vi.doMock("../../features/cart/init.js", () => ({ init: cartInitMock }));
+  });
+
+  afterEach(() => {
+    vi.doUnmock("../../supabase/supabaseClient.js");
+    vi.doUnmock("../../features/auth/init.js");
+    vi.doUnmock("../../features/currency/index.js");
+    vi.doUnmock("../../features/cart/init.js");
+    delete globalThis[globalKey];
+  });
+
+  it("initializes cart when trigger exists", async () => {
+    const scriptEl = { dataset: { storeId: "1" } };
+    global.location = { search: "" };
+    global.window = {
+      location: { search: "" },
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    global.document = {
+      readyState: "complete",
+      addEventListener: vi.fn(),
+      querySelectorAll: vi.fn(() => []),
+      querySelector: vi.fn(sel => sel === '[data-smoothr="add-to-cart"]' ? {} : null),
+      getElementById: vi.fn(() => scriptEl),
+    };
+
+    await import("../../smoothr-sdk.js");
+    await flushPromises();
+    expect(cartInitMock).toHaveBeenCalled();
+  });
+
+  it("logs when cart triggers are absent", async () => {
+    const scriptEl = { dataset: { storeId: "1" } };
+    global.location = { search: "?smoothr-debug=true" };
+    global.window = {
+      location: { search: "?smoothr-debug=true" },
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    const logSpy = console.log;
+    global.document = {
+      readyState: "complete",
+      addEventListener: vi.fn(),
+      querySelectorAll: vi.fn(() => []),
+      querySelector: vi.fn(() => null),
+      getElementById: vi.fn(() => scriptEl),
+    };
+
+    await import("../../smoothr-sdk.js");
+    await flushPromises();
+    expect(cartInitMock).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith("[Smoothr SDK]", "No cart triggers found, skipping cart initialization");
+  });
+});
+

--- a/storefronts/tests/sdk/platform-detection.test.js
+++ b/storefronts/tests/sdk/platform-detection.test.js
@@ -25,6 +25,7 @@ describe("platform detection", () => {
       readyState: "complete",
       addEventListener: vi.fn(),
       querySelectorAll: vi.fn(() => []),
+      querySelector: vi.fn(() => null),
       getElementById: vi.fn(() => scriptEl),
     };
   });


### PR DESCRIPTION
## Summary
- conditionally import and initialize cart feature only when cart triggers are present
- log debug message when cart triggers missing or cart init fails
- cover cart autoload logic with tests and fix platform detection test setup

## Testing
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=test npx vitest run storefronts/tests/sdk/cart-feature-loading.test.js storefronts/tests/sdk/platform-detection.test.js`
- `npm test` *(fails: __vite_ssr_import_1__.supabase.from(...).select is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6894b9ab7b2483259d7b066b3e1e0128