### PR TITLE
test: add cart feature tests

### DIFF
--- a/storefronts/tests/sdk/cart-currency-format.test.js
+++ b/storefronts/tests/sdk/cart-currency-format.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+describe("cart totals use currency formatter", () => {
+  let totalEl;
+  beforeEach(() => {
+    vi.resetModules();
+    totalEl = { dataset: {}, setAttribute: vi.fn(), textContent: "" };
+    global.console = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    global.document = {
+      querySelectorAll: vi.fn((sel) => {
+        if (sel === "[data-smoothr-total]") return [totalEl];
+        if (sel === "[data-smoothr-template]") return [];
+        if (sel === "[data-smoothr-cart]") return [];
+        if (sel === "[data-smoothr-remove]") return [];
+        return [];
+      }),
+    };
+    global.window = {
+      Smoothr: {
+        cart: {
+          getCart: vi.fn(() => ({ items: [] })),
+          getTotal: vi.fn(() => 500),
+        },
+        currency: {
+          getCurrency: vi.fn(() => "USD"),
+          convertPrice: vi.fn((v) => v),
+          formatPrice: vi.fn(() => "formatted"),
+          baseCurrency: "USD",
+        },
+      },
+    };
+  });
+
+  it("formats totals via Smoothr.currency.formatPrice", async () => {
+    const { renderCart } = await import("../../features/cart/renderCart.js");
+    renderCart();
+    expect(window.Smoothr.currency.formatPrice).toHaveBeenCalledWith(5, "USD");
+    expect(totalEl.textContent).toBe("formatted");
+  });
+});

--- a/storefronts/tests/sdk/cart-dom-trigger.test.js
+++ b/storefronts/tests/sdk/cart-dom-trigger.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const cartInitMock = vi.fn();
+const globalKey = "__supabaseAuthClientsmoothr-browser-client";
+
+function flushPromises() {
+  return new Promise(setImmediate);
+}
+
+describe("cart DOM trigger", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    cartInitMock.mockReset();
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    );
+    global.console = { log: vi.fn(), warn: vi.fn() };
+    vi.doMock("../../supabase/supabaseClient.js", () => ({
+      supabase: {
+        from: vi.fn(() => ({
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({ data: null })
+            }))
+          }))
+        }))
+      }
+    }));
+    vi.doMock("../../features/auth/init.js", () => ({ init: vi.fn() }));
+    vi.doMock("../../features/currency/index.js", () => ({ init: vi.fn().mockResolvedValue() }));
+    vi.doMock("../../features/cart/init.js", () => ({ init: cartInitMock }));
+  });
+
+  afterEach(() => {
+    vi.doUnmock("../../supabase/supabaseClient.js");
+    vi.doUnmock("../../features/auth/init.js");
+    vi.doUnmock("../../features/currency/index.js");
+    vi.doUnmock("../../features/cart/init.js");
+    delete globalThis[globalKey];
+  });
+
+  it("imports cart when [data-smoothr=\"add-to-cart\"] is present", async () => {
+    const scriptEl = { dataset: { storeId: "1" } };
+    global.window = {
+      location: { search: "" },
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    global.document = {
+      readyState: "complete",
+      addEventListener: vi.fn(),
+      querySelectorAll: vi.fn(() => []),
+      querySelector: vi.fn(sel => (sel === '[data-smoothr="add-to-cart"]' ? {} : null)),
+      getElementById: vi.fn(() => scriptEl),
+    };
+    await import("../../smoothr-sdk.js");
+    await flushPromises();
+    expect(cartInitMock).toHaveBeenCalled();
+  });
+
+  it("imports cart when [data-smoothr-add] is present", async () => {
+    const scriptEl = { dataset: { storeId: "1" } };
+    global.window = {
+      location: { search: "" },
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    global.document = {
+      readyState: "complete",
+      addEventListener: vi.fn(),
+      querySelectorAll: vi.fn(() => []),
+      querySelector: vi.fn(sel => (sel === '[data-smoothr-add]' ? {} : null)),
+      getElementById: vi.fn(() => scriptEl),
+    };
+    await import("../../smoothr-sdk.js");
+    await flushPromises();
+    expect(cartInitMock).toHaveBeenCalled();
+  });
+
+  it("skips cart when no triggers present", async () => {
+    const scriptEl = { dataset: { storeId: "1" } };
+    global.window = {
+      location: { search: "" },
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    global.document = {
+      readyState: "complete",
+      addEventListener: vi.fn(),
+      querySelectorAll: vi.fn(() => []),
+      querySelector: vi.fn(() => null),
+      getElementById: vi.fn(() => scriptEl),
+    };
+    await import("../../smoothr-sdk.js");
+    await flushPromises();
+    expect(cartInitMock).not.toHaveBeenCalled();
+  });
+});

--- a/storefronts/tests/sdk/cart-idempotency.test.js
+++ b/storefronts/tests/sdk/cart-idempotency.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+let button;
+
+describe("cart init idempotency", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    button = { addEventListener: vi.fn() };
+    global.console = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    global.localStorage = {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
+    global.window = {
+      Smoothr: {},
+      location: { pathname: "", search: "" },
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    };
+    global.document = {
+      querySelectorAll: vi.fn((sel) =>
+        sel === "[data-smoothr-add]" ? [button] : []
+      ),
+    };
+  });
+
+  it("returns same instance and binds listeners once", async () => {
+    const cartMod = await import("../../features/cart/init.js");
+    const first = await cartMod.init({ storeId: "1" });
+    const second = await cartMod.init({ storeId: "1" });
+    expect(first).toBe(second);
+    expect(button.addEventListener).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add cart init idempotency test ensuring multiple init calls reuse instance and avoid re-binding
- verify cart totals use Smoothr.currency.formatPrice
- ensure SDK only loads cart feature when DOM triggers exist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894bdca2ce88325b7983123e8ec4892