### PR TITLE
feat(cart): expose remove button binding

### DIFF
--- a/storefronts/features/cart/init.js
+++ b/storefronts/features/cart/init.js
@@ -1,7 +1,7 @@
 import { mergeConfig } from '../config/globalConfig.js';
 import * as cart from './index.js';
 import { bindAddToCartButtons } from './addToCart.js';
-import { renderCart } from './renderCart.js';
+import { renderCart, bindRemoveFromCartButtons } from './renderCart.js';
 
 let initialized = false;
 
@@ -22,6 +22,7 @@ export async function init(config = {}) {
 
   bindAddToCartButtons();
   renderCart();
+  bindRemoveFromCartButtons();
 
   initialized = true;
   return typeof window !== 'undefined' ? window.Smoothr.cart : undefined;

--- a/storefronts/features/cart/renderCart.js
+++ b/storefronts/features/cart/renderCart.js
@@ -22,6 +22,19 @@ export function formatCartPrice(baseAmount, Smoothr, currency) {
   return { displayAmount, text };
 }
 
+export function bindRemoveFromCartButtons() {
+  if (typeof document === 'undefined') return;
+  const Smoothr = window.Smoothr || window.smoothr;
+  if (!Smoothr?.cart) return;
+
+  document.querySelectorAll('[data-smoothr-remove]').forEach(btn => {
+    if (btn.__smoothrBound) return;
+    const id = btn.getAttribute('data-smoothr-remove');
+    btn.addEventListener('click', () => Smoothr.cart.removeItem(id));
+    btn.__smoothrBound = true;
+  });
+}
+
 export function renderCart() {
   const { debug } = getConfig();
   if (debug) console.log('🎨 renderCart() triggered');
@@ -135,12 +148,7 @@ export function renderCart() {
     });
   });
 
-  document.querySelectorAll('[data-smoothr-remove]').forEach(btn => {
-    if (btn.__smoothrBound) return;
-    const id = btn.getAttribute('data-smoothr-remove');
-    btn.addEventListener('click', () => Smoothr.cart.removeItem(id));
-    btn.__smoothrBound = true;
-  });
+  bindRemoveFromCartButtons();
 }
 
 

--- a/storefronts/tests/sdk/remove-button-bind.test.js
+++ b/storefronts/tests/sdk/remove-button-bind.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+let button;
+
+describe('remove button binding', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    button = { addEventListener: vi.fn(), getAttribute: vi.fn(() => '1') };
+    global.console = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    global.window = { Smoothr: { cart: { removeItem: vi.fn() } } };
+    global.document = {
+      querySelectorAll: vi.fn(sel => (sel === '[data-smoothr-remove]' ? [button] : []))
+    };
+  });
+
+  it('attaches only one listener per element', async () => {
+    const mod = await import('../../features/cart/renderCart.js');
+    mod.bindRemoveFromCartButtons();
+    mod.bindRemoveFromCartButtons();
+    expect(button.addEventListener).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- export bindRemoveFromCartButtons to handle cart item removal listeners
- invoke bindRemoveFromCartButtons from renderCart and init for idempotent binding
- add test verifying remove button binding attaches a single listener

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894ced1407c8325a318941b26326031