### PR TITLE
feat: expand cart triggers

### DIFF
--- a/storefronts/smoothr-sdk.js
+++ b/storefronts/smoothr-sdk.js
@@ -75,7 +75,9 @@ if (!scriptEl || !storeId) {
 
     const hasCartTrigger =
       document.querySelector('[data-smoothr="add-to-cart"]') ||
-      document.querySelector('[data-smoothr-add]');
+      document.querySelector('[data-smoothr-add]') ||
+      document.querySelector('[data-smoothr-total]') ||
+      document.querySelector('[data-smoothr-cart]');
 
     if (hasCartTrigger) {
       try {

--- a/storefronts/tests/sdk/cart-dom-trigger.test.js
+++ b/storefronts/tests/sdk/cart-dom-trigger.test.js
@@ -39,7 +39,12 @@ describe("cart DOM trigger", () => {
     delete globalThis[globalKey];
   });
 
-  it("imports cart when [data-smoothr=\"add-to-cart\"] is present", async () => {
+  it.each([
+    '[data-smoothr="add-to-cart"]',
+    '[data-smoothr-add]',
+    '[data-smoothr-total]',
+    '[data-smoothr-cart]'
+  ])("imports cart when %s is present", async selector => {
     const scriptEl = { dataset: { storeId: "1" } };
     global.window = {
       location: { search: "" },
@@ -50,26 +55,7 @@ describe("cart DOM trigger", () => {
       readyState: "complete",
       addEventListener: vi.fn(),
       querySelectorAll: vi.fn(() => []),
-      querySelector: vi.fn(sel => (sel === '[data-smoothr="add-to-cart"]' ? {} : null)),
-      getElementById: vi.fn(() => scriptEl),
-    };
-    await import("../../smoothr-sdk.js");
-    await flushPromises();
-    expect(cartInitMock).toHaveBeenCalled();
-  });
-
-  it("imports cart when [data-smoothr-add] is present", async () => {
-    const scriptEl = { dataset: { storeId: "1" } };
-    global.window = {
-      location: { search: "" },
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-    };
-    global.document = {
-      readyState: "complete",
-      addEventListener: vi.fn(),
-      querySelectorAll: vi.fn(() => []),
-      querySelector: vi.fn(sel => (sel === '[data-smoothr-add]' ? {} : null)),
+      querySelector: vi.fn(sel => (sel === selector ? {} : null)),
       getElementById: vi.fn(() => scriptEl),
     };
     await import("../../smoothr-sdk.js");

--- a/storefronts/tests/sdk/cart-feature-loading.test.js
+++ b/storefronts/tests/sdk/cart-feature-loading.test.js
@@ -35,7 +35,12 @@ describe("cart feature loading", () => {
     delete globalThis[globalKey];
   });
 
-  it("initializes cart when trigger exists", async () => {
+  it.each([
+    '[data-smoothr="add-to-cart"]',
+    '[data-smoothr-add]',
+    '[data-smoothr-total]',
+    '[data-smoothr-cart]'
+  ])("initializes cart when trigger %s exists", async selector => {
     const scriptEl = { dataset: { storeId: "1" } };
     global.location = { search: "" };
     global.window = {
@@ -47,7 +52,7 @@ describe("cart feature loading", () => {
       readyState: "complete",
       addEventListener: vi.fn(),
       querySelectorAll: vi.fn(() => []),
-      querySelector: vi.fn(sel => sel === '[data-smoothr="add-to-cart"]' ? {} : null),
+      querySelector: vi.fn(sel => (sel === selector ? {} : null)),
       getElementById: vi.fn(() => scriptEl),
     };
 


### PR DESCRIPTION
## Summary
- expand cart initialization triggers to include total and cart elements
- test cart initialization for all supported DOM triggers

## Testing
- `npm test tests/sdk/cart-dom-trigger.test.js tests/sdk/cart-feature-loading.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6894d0f406688325972f1d10f9e27d40