### PR TITLE
test: add cart remove button binding test

### DIFF
--- a/storefronts/tests/sdk/cart-remove-button.test.js
+++ b/storefronts/tests/sdk/cart-remove-button.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+let button;
+let removeItem;
+
+describe('cart remove button', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    removeItem = vi.fn();
+    button = {
+      addEventListener: vi.fn((event, handler) => {
+        if (event === 'click') button._handler = handler;
+      }),
+      getAttribute: vi.fn(() => '1'),
+      click: () => button._handler && button._handler()
+    };
+    global.window = { Smoothr: { cart: { removeItem } } };
+    global.document = {
+      querySelectorAll: vi.fn(sel => (sel === '[data-smoothr-remove]' ? [button] : []))
+    };
+  });
+
+  it('removes items on click without double-binding', async () => {
+    const mod = await import('../../features/cart/renderCart.js');
+    mod.bindRemoveFromCartButtons();
+    mod.bindRemoveFromCartButtons();
+    button.click();
+    expect(removeItem).toHaveBeenCalledTimes(1);
+    expect(removeItem).toHaveBeenCalledWith('1');
+  });
+});


### PR DESCRIPTION
## Summary
- add test covering cart removal button to ensure removeItem triggers only once even with repeated init

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894d3fc051c83258b43744035e50797