### PR TITLE
test: ensure renderCart triggers on remove button click

### DIFF
--- a/storefronts/tests/sdk/remove-button-bind.test.js
+++ b/storefronts/tests/sdk/remove-button-bind.test.js
@@ -7,7 +7,7 @@ describe('remove button binding', () => {
     vi.resetModules();
     button = { addEventListener: vi.fn(), getAttribute: vi.fn(() => '1') };
     global.console = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
-    global.window = { Smoothr: { cart: { removeItem: vi.fn() } } };
+    global.window = { Smoothr: { cart: { removeItem: vi.fn(), renderCart: vi.fn() } } };
     global.document = {
       querySelectorAll: vi.fn(sel => (sel === '[data-smoothr-remove]' ? [button] : []))
     };
@@ -17,6 +17,9 @@ describe('remove button binding', () => {
     const mod = await import('../../features/cart/renderCart.js');
     mod.bindRemoveFromCartButtons();
     mod.bindRemoveFromCartButtons();
+    await button.addEventListener.mock.calls[0][1]();
+    const { Smoothr } = window;
+    expect(Smoothr.cart.renderCart).toHaveBeenCalled();
     expect(button.addEventListener).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- add renderCart spy to remove button binding test
- verify renderCart is called when remove handler executes

## Testing
- `npm --workspace storefronts test`
- `npm run test:supabase`


------
https://chatgpt.com/codex/tasks/task_e_6894dac856d08325b0187e86c60508eb