### PR TITLE
feat: add mountCheckout entry points

### DIFF
--- a/storefronts/features/checkout/gateways/authorizeNet.js
+++ b/storefronts/features/checkout/gateways/authorizeNet.js
@@ -201,6 +201,11 @@ export async function mountCardFields() {
   return mountPromise;
 }
 
+export async function mountCheckout(config) {
+  if (isMounted()) return;
+  await mountCardFields(config);
+}
+
 export function isMounted() {
   return fieldsMounted;
 }
@@ -343,6 +348,7 @@ export async function createPaymentMethod() {
 
 export default {
   mountCardFields,
+  mountCheckout,
   isMounted,
   ready,
   getReadiness,

--- a/storefronts/features/checkout/gateways/nmiGateway.js
+++ b/storefronts/features/checkout/gateways/nmiGateway.js
@@ -35,6 +35,11 @@ export async function mountCardFields() {
   return configPromise
 }
 
+export async function mountCheckout(config) {
+  if (hasMounted) return configPromise
+  return mountCardFields(config)
+}
+
 /**
  * Inject CollectJS and configure
  */
@@ -152,17 +157,15 @@ function resetSubmission(buttons) {
   buttons.forEach(enableButton)
 }
 
-// Exports & auto-mount
-export const mountNMI = mountCardFields
+// Exports
+export const mountNMI = mountCheckout
 export function isMounted() { return isConfigured }
 export function ready() { return isConfigured }
 export async function createPaymentMethod() { return { error:{message:'use CollectJS callback'}, payment_method:null } }
-export default { mountCardFields, isMounted, ready, createPaymentMethod }
+export default { mountCardFields, mountCheckout, isMounted, ready, createPaymentMethod }
 
 if (typeof window !== 'undefined') {
   window.Smoothr = window.Smoothr || {}
   // expose for provider-nmi-global.test.ts
   window.Smoothr.mountNMIFields = mountNMI
-  if (document.readyState === 'complete') mountCardFields()
-  else document.addEventListener('DOMContentLoaded', mountCardFields)
 }

--- a/storefronts/features/checkout/gateways/paypal.js
+++ b/storefronts/features/checkout/gateways/paypal.js
@@ -195,6 +195,11 @@ export async function mountCardFields() {
   }
 }
 
+export async function mountCheckout(config) {
+  if (isMounted()) return;
+  await mountCardFields(config);
+}
+
 export function isMounted() {
   return mounted;
 }
@@ -210,6 +215,7 @@ export async function createPaymentMethod() {
 export default {
   initPayPal,
   mountCardFields,
+  mountCheckout,
   isMounted,
   ready,
   createPaymentMethod

--- a/storefronts/features/checkout/gateways/segpay.js
+++ b/storefronts/features/checkout/gateways/segpay.js
@@ -7,6 +7,11 @@ export function mountCardFields() {
   fieldsMounted = true;
 }
 
+export async function mountCheckout(config) {
+  if (isMounted()) return;
+  await mountCardFields(config);
+}
+
 export function isMounted() {
   return fieldsMounted;
 }
@@ -22,6 +27,7 @@ export async function createPaymentMethod() {
 
 export default {
   mountCardFields,
+  mountCheckout,
   isMounted,
   ready,
   createPaymentMethod

--- a/storefronts/features/checkout/gateways/stripeGateway.js
+++ b/storefronts/features/checkout/gateways/stripeGateway.js
@@ -20,8 +20,6 @@ const debug = getConfig().debug;
 const log = (...args) => debug && console.log('[Smoothr Stripe]', ...args);
 const warn = (...args) => debug && console.warn('[Smoothr Stripe]', ...args);
 
-initStripeStyles();
-
 export async function waitForVisible(el, timeout = 1000) {
   if (!el || typeof el.getBoundingClientRect !== 'function') return;
   log('Waiting for element to be visible', el);
@@ -222,6 +220,12 @@ export async function mountCardFields() {
   return mountPromise;
 }
 
+export async function mountCheckout(config) {
+  if (isMounted()) return;
+  initStripeStyles();
+  await mountCardFields(config);
+}
+
 export function isMounted() {
   return fieldsMounted;
 }
@@ -265,6 +269,7 @@ export async function createPaymentMethod(billing_details) {
 
 export default {
   mountCardFields,
+  mountCheckout,
   isMounted,
   ready,
   getStoreSettings,


### PR DESCRIPTION
## Summary
- expose async `mountCheckout` for all checkout gateways and update exports
- defer Stripe iframe style init to `mountCheckout`
- drop NMI gateway auto-mount to keep gateways inert

## Testing
- `npm test` *(fails: Test timed out in 10000ms)*
- `npm run test:supabase`


------
https://chatgpt.com/codex/tasks/task_e_6894e8cd2c7c8325a53f57522737774f