### PR TITLE
Add checkout and gateway loader tests

### DIFF
--- a/storefronts/tests/sdk/checkout-trigger.test.js
+++ b/storefronts/tests/sdk/checkout-trigger.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const checkoutInitMock = vi.fn();
+const globalKey = "__supabaseAuthClientsmoothr-browser-client";
+
+function flushPromises() {
+  return new Promise(setImmediate);
+}
+
+describe("checkout DOM trigger", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    checkoutInitMock.mockReset();
+    global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }));
+    global.console = { log: vi.fn(), warn: vi.fn() };
+    vi.doMock("../../supabase/supabaseClient.js", () => ({
+      supabase: {
+        from: vi.fn(() => ({
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue({ data: null }) }))
+          }))
+        }))
+      }
+    }));
+    vi.doMock("../../features/auth/init.js", () => ({ init: vi.fn() }));
+    vi.doMock("../../features/currency/index.js", () => ({ init: vi.fn().mockResolvedValue() }));
+    vi.doMock("../../features/cart/init.js", () => ({ init: vi.fn() }));
+    vi.doMock("../../features/checkout/init.js", () => ({ init: checkoutInitMock }));
+  });
+
+  afterEach(() => {
+    vi.doUnmock("../../supabase/supabaseClient.js");
+    vi.doUnmock("../../features/auth/init.js");
+    vi.doUnmock("../../features/currency/index.js");
+    vi.doUnmock("../../features/cart/init.js");
+    vi.doUnmock("../../features/checkout/init.js");
+    delete globalThis[globalKey];
+    delete global.window;
+    delete global.document;
+  });
+
+  it("initializes checkout when trigger exists", async () => {
+    const scriptEl = { dataset: { storeId: "1" } };
+    global.location = { search: "" };
+    global.window = {
+      location: { search: "" },
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    global.document = {
+      readyState: "complete",
+      addEventListener: vi.fn(),
+      querySelectorAll: vi.fn(() => []),
+      querySelector: vi.fn(sel => (sel === '[data-smoothr="pay"]' ? {} : null)),
+      getElementById: vi.fn(() => scriptEl),
+    };
+
+    await import("../../smoothr-sdk.js");
+    await flushPromises();
+    expect(checkoutInitMock).toHaveBeenCalled();
+  });
+
+  it("skips checkout when trigger absent", async () => {
+    const scriptEl = { dataset: { storeId: "1" } };
+    global.location = { search: "" };
+    global.window = {
+      location: { search: "" },
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    global.document = {
+      readyState: "complete",
+      addEventListener: vi.fn(),
+      querySelectorAll: vi.fn(() => []),
+      querySelector: vi.fn(() => null),
+      getElementById: vi.fn(() => scriptEl),
+    };
+
+    await import("../../smoothr-sdk.js");
+    await flushPromises();
+    expect(checkoutInitMock).not.toHaveBeenCalled();
+  });
+});

--- a/storefronts/tests/sdk/gateway-dispatch.test.js
+++ b/storefronts/tests/sdk/gateway-dispatch.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const mocked = [];
+
+function trackMock(path, factory) {
+  mocked.push(path);
+  return vi.doMock(path, factory);
+}
+
+function setupEnv(modulePath) {
+  let mounted = false;
+  const mountCheckoutMock = vi.fn(() => {
+    mounted = true;
+  });
+  trackMock(modulePath, () => ({
+    default: {
+      mountCheckout: mountCheckoutMock,
+      mountCardFields: mountCheckoutMock,
+      isMounted: () => mounted
+    }
+  }));
+  trackMock("../../features/checkout/utils/checkoutLogger.js", () => ({
+    default: () => ({
+      log: vi.fn(),
+      warn: vi.fn(),
+      err: vi.fn(),
+      select: vi.fn(async () => ({})),
+      q: vi.fn(() => null)
+    })
+  }));
+  trackMock("../../features/checkout/utils/collectFormFields.js", () => ({
+    default: vi.fn(() => ({ emailField: {} }))
+  }));
+  trackMock("../../features/checkout/utils/inputFormatters.js", () => ({
+    default: vi.fn()
+  }));
+  trackMock("../../features/config/sdkConfig.ts", () => ({
+    loadPublicConfig: vi.fn(async () => null)
+  }));
+  trackMock("../../features/config/globalConfig.js", () => {
+    let cfg = {};
+    return {
+      mergeConfig: obj => Object.assign(cfg, obj),
+      getConfig: () => cfg
+    };
+  });
+  trackMock("../../utils/platformReady.js", () => ({
+    platformReady: vi.fn(async () => {})
+  }));
+  trackMock("../../utils/loadScriptOnce.js", () => ({
+    default: vi.fn()
+  }));
+
+  const payBtn = { tagName: "button", addEventListener: vi.fn() };
+  global.document = {
+    querySelector: vi.fn(sel => {
+      if (sel === "[data-smoothr-pay]") return payBtn;
+      if (sel === "#smoothr-card-styles") return null;
+      return null;
+    }),
+    querySelectorAll: vi.fn(sel => (sel === "[data-smoothr-pay]" ? [payBtn] : [])),
+    createElement: vi.fn(() => ({ style: {}, id: "", textContent: "" })),
+    head: { appendChild: vi.fn() }
+  };
+  global.window = {
+    location: { pathname: "", search: "" },
+    Smoothr: { cart: { getCart: () => ({ items: [] }), getTotal: () => 0 } },
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  };
+  return { mountCheckoutMock };
+}
+
+describe("gateway dispatch", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    mocked.forEach(m => vi.doUnmock(m));
+    mocked.length = 0;
+    delete global.window;
+    delete global.document;
+  });
+
+  it.each([
+    ["stripe", "../../features/checkout/gateways/stripeGateway.js"],
+    ["authorizeNet", "../../features/checkout/gateways/authorizeNet.js"],
+    ["paypal", "../../features/checkout/gateways/paypal.js"],
+    ["nmi", "../../features/checkout/gateways/nmiGateway.js"],
+    ["segpay", "../../features/checkout/gateways/segpay.js"]
+  ])("dispatches to %s", async (provider, path) => {
+    const { mountCheckoutMock } = setupEnv(path);
+    const { init } = await import("../../features/checkout/init.js");
+    await init({ active_payment_gateway: provider, storeId: "1" });
+    expect(mountCheckoutMock).toHaveBeenCalled();
+  });
+});

--- a/storefronts/tests/sdk/gateway-loader.test.js
+++ b/storefronts/tests/sdk/gateway-loader.test.js
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const mocked = [];
+
+function trackMock(path, factory) {
+  mocked.push(path);
+  return vi.doMock(path, factory);
+}
+
+function setupEnv(provider, modulePath) {
+  const loadScriptMock = vi.fn();
+  let mounted = false;
+  const mountMock = vi.fn(() => {
+    mounted = true;
+  });
+  trackMock(modulePath, () => ({
+    default: {
+      mountCheckout: mountMock,
+      mountCardFields: mountMock,
+      isMounted: () => mounted
+    }
+  }));
+  trackMock("../../features/checkout/utils/checkoutLogger.js", () => ({
+    default: () => ({
+      log: vi.fn(),
+      warn: vi.fn(),
+      err: vi.fn(),
+      select: vi.fn(async () => ({})),
+      q: vi.fn(() => null)
+    })
+  }));
+  trackMock("../../features/checkout/utils/collectFormFields.js", () => ({
+    default: vi.fn(() => ({ emailField: {} }))
+  }));
+  trackMock("../../features/checkout/utils/inputFormatters.js", () => ({
+    default: vi.fn()
+  }));
+  trackMock("../../features/config/sdkConfig.ts", () => ({
+    loadPublicConfig: vi.fn(async () => null)
+  }));
+  trackMock("../../features/config/globalConfig.js", () => {
+    let cfg = {};
+    return {
+      mergeConfig: obj => Object.assign(cfg, obj),
+      getConfig: () => cfg
+    };
+  });
+  trackMock("../../utils/platformReady.js", () => ({
+    platformReady: vi.fn(async () => {})
+  }));
+  trackMock("../../utils/loadScriptOnce.js", () => ({
+    default: loadScriptMock
+  }));
+
+  const payBtn = { tagName: "button", addEventListener: vi.fn() };
+  global.document = {
+    querySelector: vi.fn(sel => {
+      if (sel === "[data-smoothr-pay]") return payBtn;
+      if (sel === "#smoothr-card-styles") return null;
+      return null;
+    }),
+    querySelectorAll: vi.fn(sel => (sel === "[data-smoothr-pay]" ? [payBtn] : [])),
+    createElement: vi.fn(() => ({ style: {}, id: "", textContent: "" })),
+    head: { appendChild: vi.fn() }
+  };
+  global.window = {
+    location: { pathname: "", search: "" },
+    Smoothr: { cart: { getCart: () => ({ items: [] }), getTotal: () => 0 } },
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  };
+  return { loadScriptMock };
+}
+
+describe("gateway loader", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    mocked.forEach(m => vi.doUnmock(m));
+    mocked.length = 0;
+    delete global.window;
+    delete global.document;
+  });
+
+  it.each([
+    ["stripe", "https://js.stripe.com/v3/", "../../features/checkout/gateways/stripeGateway.js"],
+    [
+      "authorizeNet",
+      "https://jstest.authorize.net/v1/Accept.js",
+      "../../features/checkout/gateways/authorizeNet.js"
+    ],
+    [
+      "nmi",
+      "https://secure.nmi.com/token/Collect.js",
+      "../../features/checkout/gateways/nmiGateway.js"
+    ]
+  ])("loads script for %s", async (provider, url, path) => {
+    const { loadScriptMock } = setupEnv(provider, path);
+    const { init } = await import("../../features/checkout/init.js");
+    await init({ active_payment_gateway: provider, storeId: "1" });
+    expect(loadScriptMock).toHaveBeenCalledWith(url);
+  });
+});


### PR DESCRIPTION
## Summary
- test checkout feature initializes only when pay trigger exists
- verify gateway loader calls loadScriptOnce with proper SDK URL
- ensure gateway dispatcher imports correct module and mounts checkout

## Testing
- `npx vitest run tests/sdk/checkout-trigger.test.js tests/sdk/gateway-loader.test.js tests/sdk/gateway-dispatch.test.js`
- `npm test` *(fails: Test timed out in tests/adapters/checkout.test.js, tests/providers/provider-nmi-mount.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6894ed8e96688325ab05ab510a100487