### PR TITLE
feat(webflow): timeout dom ready

### DIFF
--- a/storefronts/adapters/webflow.js
+++ b/storefronts/adapters/webflow.js
@@ -1,11 +1,19 @@
 import { initCurrencyDom } from './webflow/currencyDomAdapter.js';
+import { getConfig } from '../features/config/globalConfig.js';
 
 export function initAdapter(config) {
   // Placeholder for future Webflow-specific setup using `config` if needed.
   return {
     domReady: () =>
-      new Promise(resolve => {
+      new Promise((resolve, reject) => {
+        const timeoutId = setTimeout(() => {
+          if (getConfig().debug)
+            console.warn('[Smoothr Webflow] DOM ready timeout');
+          reject(new Error('DOM ready timeout'));
+        }, 5000);
+
         const run = () => {
+          clearTimeout(timeoutId);
           initCurrencyDom();
           resolve();
         };

--- a/storefronts/tests/adapters/webflow-domReady.test.js
+++ b/storefronts/tests/adapters/webflow-domReady.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('../../adapters/webflow/currencyDomAdapter.js', () => ({
+  initCurrencyDom: vi.fn(),
+}));
+
+import { initAdapter } from '../../adapters/webflow.js';
+import { initCurrencyDom } from '../../adapters/webflow/currencyDomAdapter.js';
+
+describe('webflow adapter domReady', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    globalThis.SMOOTHR_CONFIG = {};
+    global.document = {
+      readyState: 'loading',
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('resolves when DOMContentLoaded fires', async () => {
+    let listener;
+    document.addEventListener.mockImplementation((evt, cb) => {
+      if (evt === 'DOMContentLoaded') listener = cb;
+    });
+
+    const { domReady } = initAdapter({});
+    const p = domReady();
+    listener && listener();
+    await expect(p).resolves.toBeUndefined();
+    expect(initCurrencyDom).toHaveBeenCalled();
+  });
+
+  it('rejects after timeout when DOMContentLoaded never fires', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    globalThis.SMOOTHR_CONFIG = { debug: true };
+
+    const { domReady } = initAdapter({});
+    const p = domReady();
+    const expectation = expect(p).rejects.toThrow('DOM ready timeout');
+    await vi.advanceTimersByTimeAsync(5000);
+    await expectation;
+    expect(warnSpy).toHaveBeenCalledWith('[Smoothr Webflow] DOM ready timeout');
+    expect(initCurrencyDom).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- reject Webflow adapter domReady after 5s timeout and warn in debug mode
- cover domReady success and timeout paths in Webflow adapter tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689505f0197083259ba5a1b4c9a0e11c