### PR TITLE
Update gateway loader test to expect script options

### DIFF
--- a/storefronts/tests/sdk/gateway-loader.test.js
+++ b/storefronts/tests/sdk/gateway-loader.test.js
@@ -100,6 +100,6 @@ describe("gateway loader", () => {
     const { loadScriptMock } = setupEnv(provider, path);
     const { init } = await import("../../features/checkout/init.js");
     await init({ active_payment_gateway: provider, storeId: "1" });
-    expect(loadScriptMock).toHaveBeenCalledWith(url);
+    expect(loadScriptMock).toHaveBeenCalledWith(url, expect.any(Object));
   });
 });


### PR DESCRIPTION
## Summary
- update gateway loader test to allow loadScriptOnce to receive options

## Testing
- `npm test` *(fails: checkout and loadScriptOnce tests)*

------
https://chatgpt.com/codex/tasks/task_e_68951e2a031883259a9b81c9d4655a71