### PR TITLE
test: update gateway failure message

### DIFF
--- a/storefronts/tests/adapters/checkout.test.js
+++ b/storefronts/tests/adapters/checkout.test.js
@@ -265,7 +265,7 @@ describe('checkout', () => {
     const init = await loadCheckout();
     await init();
     expect(console.error).toHaveBeenCalledWith(
-      '[Smoothr Checkout] Failed to load gateway script',
+      '[Smoothr Checkout] Failed to load Stripe SDK',
       expect.any(Error)
     );
     expect(console.warn).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- fix checkout adapter test to expect provider-specific SDK load failure message

## Testing
- `npm test` (fails: ReferenceError: document is not defined)


------
https://chatgpt.com/codex/tasks/task_e_68952333aec08325b1695bea3cd8f032