### PR TITLE
Normalize legacy Webflow attributes

### DIFF
--- a/storefronts/adapters/webflow.js
+++ b/storefronts/adapters/webflow.js
@@ -3,6 +3,26 @@ import { getConfig } from '../features/config/globalConfig.js';
 
 export function initAdapter(config) {
   // Placeholder for future Webflow-specific setup using `config` if needed.
+
+  const normalizeLegacyAttributes = () => {
+    const mapping = {
+      'data-smoothr-pay': 'pay',
+      'data-smoothr-add': 'add-to-cart',
+      'data-smoothr-remove': 'remove-from-cart',
+      'data-smoothr-login': 'login',
+      'data-smoothr-logout': 'logout',
+      'data-smoothr-currency': 'currency'
+    };
+
+    Object.entries(mapping).forEach(([legacyAttr, canonical]) => {
+      document.querySelectorAll(`[${legacyAttr}]`).forEach((el) => {
+        if (!el.hasAttribute('data-smoothr')) {
+          el.setAttribute('data-smoothr', canonical);
+        }
+      });
+    });
+  };
+
   return {
     domReady: () =>
       new Promise((resolve, reject) => {
@@ -15,6 +35,7 @@ export function initAdapter(config) {
         const run = () => {
           clearTimeout(timeoutId);
           initCurrencyDom();
+          normalizeLegacyAttributes();
           resolve();
         };
 

--- a/storefronts/tests/adapters/webflow-domReady.test.js
+++ b/storefronts/tests/adapters/webflow-domReady.test.js
@@ -15,6 +15,7 @@ describe('webflow adapter domReady', () => {
       readyState: 'loading',
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
+      querySelectorAll: vi.fn(() => []),
     };
   });
 

--- a/storefronts/tests/adapters/webflow-legacyAttributes.test.js
+++ b/storefronts/tests/adapters/webflow-legacyAttributes.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('../../adapters/webflow/currencyDomAdapter.js', () => ({
+  initCurrencyDom: vi.fn(),
+}));
+
+import { initAdapter } from '../../adapters/webflow.js';
+
+describe('webflow adapter legacy attribute normalization', () => {
+  let elements;
+
+  beforeEach(() => {
+    elements = {};
+    const createEl = (legacyAttr, existing) => {
+      const attrs = { [legacyAttr]: '' };
+      if (existing !== undefined) attrs['data-smoothr'] = existing;
+      return {
+        attributes: attrs,
+        getAttribute(attr) {
+          return this.attributes[attr];
+        },
+        setAttribute(attr, val) {
+          this.attributes[attr] = String(val);
+        },
+        hasAttribute(attr) {
+          return attr in this.attributes;
+        },
+      };
+    };
+
+    elements.pay = createEl('data-smoothr-pay');
+    elements.add = createEl('data-smoothr-add');
+    elements.addExisting = createEl('data-smoothr-add', 'existing');
+    elements.remove = createEl('data-smoothr-remove');
+    elements.login = createEl('data-smoothr-login');
+    elements.logout = createEl('data-smoothr-logout');
+    elements.currency = createEl('data-smoothr-currency');
+
+    const selectorMap = {
+      '[data-smoothr-pay]': [elements.pay],
+      '[data-smoothr-add]': [elements.add, elements.addExisting],
+      '[data-smoothr-remove]': [elements.remove],
+      '[data-smoothr-login]': [elements.login],
+      '[data-smoothr-logout]': [elements.logout],
+      '[data-smoothr-currency]': [elements.currency],
+    };
+
+    global.document = {
+      readyState: 'complete',
+      querySelectorAll: vi.fn((sel) => selectorMap[sel] || []),
+    };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    delete global.document;
+  });
+
+  it('normalizes legacy attributes on domReady', async () => {
+    const { domReady } = initAdapter({});
+    await domReady();
+
+    expect(elements.pay.attributes['data-smoothr']).toBe('pay');
+    expect(elements.add.attributes['data-smoothr']).toBe('add-to-cart');
+    expect(elements.remove.attributes['data-smoothr']).toBe('remove-from-cart');
+    expect(elements.login.attributes['data-smoothr']).toBe('login');
+    expect(elements.logout.attributes['data-smoothr']).toBe('logout');
+    expect(elements.currency.attributes['data-smoothr']).toBe('currency');
+    expect(elements.addExisting.attributes['data-smoothr']).toBe('existing');
+  });
+});
+


### PR DESCRIPTION
## Summary
- normalize legacy Webflow data attributes to canonical `data-smoothr`
- cover legacy attribute normalization in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689528b6719c8325a521b19981e2a8b5