### PR TITLE
feat(webflow): normalize legacy attrs dynamically

### DIFF
--- a/storefronts/adapters/README.md
+++ b/storefronts/adapters/README.md
@@ -4,6 +4,13 @@ Adapters for Webflow, Framer, Webstudio, and other platforms.
 
 Cart DOM helpers like `addToCart.js` and `renderCart.js` now live in `../features/cart`.
 
+## Legacy Attribute Normalization
+
+The Webflow adapter upgrades deprecated attributes like `data-smoothr-pay` or
+`data-smoothr-add` to their modern `data-smoothr` equivalents on DOM ready. A
+`MutationObserver` watches for elements inserted later and normalizes them as
+well. Set `window.SMOOTHR_CONFIG.debug = true` to log each normalized element.
+
 ## Currency dropdown
 
 `currencyDomAdapter.js` replaces any element marked with `data-smoothr-price` or

--- a/storefronts/tests/adapters/webflow-legacy-normalization-dynamic.test.js
+++ b/storefronts/tests/adapters/webflow-legacy-normalization-dynamic.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('../../adapters/webflow/currencyDomAdapter.js', () => ({
+  initCurrencyDom: vi.fn(),
+}));
+
+import { initAdapter } from '../../adapters/webflow.js';
+
+class MockElement {
+  constructor(legacyAttr) {
+    this.attributes = { [legacyAttr]: '' };
+    this.legacyAttr = legacyAttr;
+    this.nodeType = 1;
+  }
+  getAttribute(attr) {
+    return this.attributes[attr];
+  }
+  setAttribute(attr, val) {
+    this.attributes[attr] = String(val);
+  }
+  hasAttribute(attr) {
+    return attr in this.attributes;
+  }
+  querySelectorAll(sel) {
+    return sel === `[${this.legacyAttr}]` ? [this] : [];
+  }
+}
+
+describe('webflow adapter dynamic legacy normalization', () => {
+  let observer;
+
+  beforeEach(() => {
+    global.document = {
+      readyState: 'complete',
+      body: {},
+      querySelectorAll: vi.fn(() => []),
+    };
+
+    global.MutationObserver = class {
+      constructor(cb) {
+        this.cb = cb;
+        observer = this;
+      }
+      observe() {}
+      disconnect() {}
+      trigger(mutations) {
+        this.cb(mutations, this);
+      }
+    };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    delete global.document;
+    delete global.MutationObserver;
+    observer = undefined;
+  });
+
+  it('normalizes late-inserted legacy attributes', () => {
+    const { observeDOMChanges } = initAdapter({});
+    observeDOMChanges();
+
+    const el = new MockElement('data-smoothr-pay');
+
+    observer.trigger([{ addedNodes: [el] }]);
+
+    expect(el.attributes['data-smoothr']).toBe('pay');
+  });
+});


### PR DESCRIPTION
## Summary
- normalize legacy Webflow attributes with a shared map and debug logging
- watch DOM mutations for late legacy attributes and export `observeDOMChanges`
- document legacy attribute normalization and test dynamic handling

## Testing
- `npm --workspace storefronts test`

------
https://chatgpt.com/codex/tasks/task_e_6895e774e7f883259863499b6a352c9a