### PR TITLE
Unify Smoothr debug flag handling

### DIFF
--- a/storefronts/adapters/webflow/webflow-ecom-currency.js
+++ b/storefronts/adapters/webflow/webflow-ecom-currency.js
@@ -1,18 +1,16 @@
 // Smoothr Checkout Script for Webflow with integrated NMI
 import { mountNMI } from '../../features/checkout/gateways/nmiGateway.js';
+import { getConfig } from '../../features/config/globalConfig.js';
 
 async function init() {
-  if (!window.SMOOTHR_CONFIG) {
-    console.error('[Smoothr Checkout] Config not found');
-    return;
-  }
-  const debug = Boolean(window.SMOOTHR_CONFIG?.debug);
+  const cfg = getConfig();
+  const debug = Boolean(cfg.debug);
   if (debug) {
     console.log('[Smoothr Checkout] SDK initialized');
-    console.log('[Smoothr Checkout] SMOOTHR_CONFIG', window.SMOOTHR_CONFIG);
+    console.log('[Smoothr Checkout] SMOOTHR_CONFIG', cfg);
   }
 
-  const gateway = window.SMOOTHR_CONFIG.active_payment_gateway;
+  const gateway = cfg.active_payment_gateway;
   if (gateway === undefined) {
     console.error('[Smoothr Checkout] No active payment gateway configured');
     return;
@@ -44,7 +42,7 @@ async function init() {
 
 // Run init on load
 document.addEventListener('DOMContentLoaded', () => {
-  if (window.SMOOTHR_CONFIG?.active_payment_gateway) {
+  if (getConfig().active_payment_gateway) {
     init();
   } else {
     console.error('[Smoothr Checkout] Skipping init — no active gateway');

--- a/storefronts/features/auth/index.js
+++ b/storefronts/features/auth/index.js
@@ -387,7 +387,7 @@ const auth = {
 
   const debugQuery =
     typeof window !== 'undefined' &&
-    new URLSearchParams(window.location.search).get('smoothr-debug') === 'true';
+    new URLSearchParams(window.location.search).has('smoothr-debug');
   debug =
     typeof config.debug === 'boolean'
       ? config.debug

--- a/storefronts/smoothr-sdk.js
+++ b/storefronts/smoothr-sdk.js
@@ -10,7 +10,7 @@ const scriptEl = document.getElementById('smoothr-sdk');
 const storeId = scriptEl?.dataset?.storeId || null;
 const platform =
   scriptEl?.dataset?.platform || scriptEl?.getAttribute?.('platform') || null;
-const debug = new URLSearchParams(window.location.search).get('smoothr-debug') === 'true';
+const debug = new URLSearchParams(window.location.search).has('smoothr-debug');
 
 if (!scriptEl || !storeId) {
   if (debug) {


### PR DESCRIPTION
## Summary
- Detect `smoothr-debug` via presence check and propagate debug state through config
- Remove direct global debug reads in Webflow currency adapter
- Align auth feature with new debug flag detection

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895e936528c83258546126787f06d47