### PR TITLE
feat: support canonical checkout trigger

### DIFF
--- a/storefronts/adapters/webflow/webflow-ecom-currency.js
+++ b/storefronts/adapters/webflow/webflow-ecom-currency.js
@@ -18,9 +18,10 @@ async function init() {
   if (debug) console.log('[Smoothr Checkout] Using gateway:', gateway);
 
   if (debug)
+    // TODO: Remove legacy [data-smoothr-pay] support once all projects are migrated.
     console.log(
       '[Smoothr Checkout] checkout trigger found',
-      document.querySelector('[data-smoothr-pay]')
+      document.querySelector('[data-smoothr="pay"], [data-smoothr-pay]')
     );
 
   if (gateway === 'nmi') {
@@ -31,7 +32,8 @@ async function init() {
     }
   }
 
-  const payButton = document.querySelector('[data-smoothr-pay]');
+  // TODO: Remove legacy [data-smoothr-pay] support once all projects are migrated.
+  const payButton = document.querySelector('[data-smoothr="pay"], [data-smoothr-pay]');
   if (payButton) {
     if (debug) console.log('[Smoothr Checkout] Pay div found and bound');
   } else {

--- a/storefronts/features/checkout/gateways/nmiGateway.js
+++ b/storefronts/features/checkout/gateways/nmiGateway.js
@@ -131,7 +131,10 @@ function configureCollectJS() {
         ])
       },
       callback(response) {
-        const buttons = Array.from(document.querySelectorAll('[data-smoothr-pay]'))
+        // TODO: Remove legacy [data-smoothr-pay] support once all projects are migrated.
+        const buttons = Array.from(
+          document.querySelectorAll('[data-smoothr="pay"], [data-smoothr-pay]')
+        )
         if (!response.token) {
           console.error('[NMI] Tokenization failed', response.reason)
           alert('Please check your payment details and try again.')
@@ -144,7 +147,10 @@ function configureCollectJS() {
     })
 
     // Guarded click handler
-    const buttons = Array.from(document.querySelectorAll('[data-smoothr-pay]'))
+    // TODO: Remove legacy [data-smoothr-pay] support once all projects are migrated.
+    const buttons = Array.from(
+      document.querySelectorAll('[data-smoothr="pay"], [data-smoothr-pay]')
+    )
     const tokenFn = CollectJS.tokenize || CollectJS.requestToken || CollectJS.startPaymentRequest || null
     buttons.forEach(btn => {
       btn.addEventListener('click', ev => {
@@ -164,7 +170,12 @@ function configureCollectJS() {
   } catch (e) {
     console.error('[NMI] Config error', e)
     alert('Setup error. Refresh or contact support.')
-    resetSubmission(Array.from(document.querySelectorAll('[data-smoothr-pay]')))
+    // TODO: Remove legacy [data-smoothr-pay] support once all projects are migrated.
+    resetSubmission(
+      Array.from(
+        document.querySelectorAll('[data-smoothr="pay"], [data-smoothr-pay]')
+      )
+    )
     rejectConfig(e)
   }
 }

--- a/storefronts/features/checkout/gateways/paypal.js
+++ b/storefronts/features/checkout/gateways/paypal.js
@@ -14,7 +14,8 @@ export function initPayPal(opts) {
 
 export async function mountCardFields() {
   if (mounted) return;
-  const container = document.querySelector('[data-smoothr-pay]');
+  // TODO: Remove legacy [data-smoothr-pay] support once all projects are migrated.
+  const container = document.querySelector('[data-smoothr="pay"], [data-smoothr-pay]');
   if (!container) return;
   mounted = true;
 
@@ -114,9 +115,12 @@ export async function mountCardFields() {
       onError: err => console.error('[Smoothr PayPal]', err)
     });
 
-  document.querySelectorAll('[data-smoothr-pay]').forEach(el => {
-    paypalButtons.render(el);
-  });
+  // TODO: Remove legacy [data-smoothr-pay] support once all projects are migrated.
+  document
+    .querySelectorAll('[data-smoothr="pay"], [data-smoothr-pay]')
+    .forEach(el => {
+      paypalButtons.render(el);
+    });
 
   // --- Hosted Fields Integration ---
   // After the Buttons render, check if the HostedFields API is available.
@@ -166,8 +170,11 @@ export async function mountCardFields() {
       }
     })
       .then(hostedFields => {
-        // Attach click handlers to any element with [data-smoothr-pay]
-        document.querySelectorAll('[data-smoothr-pay]').forEach(btn => {
+        // Attach click handlers to any element with [data-smoothr="pay"] or [data-smoothr-pay]
+        // TODO: Remove legacy [data-smoothr-pay] support once all projects are migrated.
+        document
+          .querySelectorAll('[data-smoothr="pay"], [data-smoothr-pay]')
+          .forEach(btn => {
           btn.addEventListener('click', async ev => {
             ev.preventDefault();
             if (isSubmitting) return;

--- a/storefronts/features/checkout/init.js
+++ b/storefronts/features/checkout/init.js
@@ -19,7 +19,10 @@ import loadScriptOnce from '../../utils/loadScriptOnce.js';
 let initialized = false;
 
 function forEachPayButton(fn) {
-  document.querySelectorAll('[data-smoothr-pay]').forEach(fn);
+  // TODO: Remove legacy [data-smoothr-pay] support once all projects are migrated.
+  document
+    .querySelectorAll('[data-smoothr="pay"], [data-smoothr-pay]')
+    .forEach(fn);
 }
 
 function showLoginPopup() {
@@ -103,18 +106,20 @@ export async function init(config = {}) {
   log(`Using gateway: ${provider}`);
 
   // mount fields common to all gateways
-  await select('[data-smoothr-pay]');
-  let payButtons = document.querySelectorAll('[data-smoothr-pay]');
+  // TODO: Remove legacy [data-smoothr-pay] support once all projects are migrated.
+  await select('[data-smoothr="pay"], [data-smoothr-pay]');
+  // TODO: Remove legacy [data-smoothr-pay] support once all projects are migrated.
+  let payButtons = document.querySelectorAll('[data-smoothr="pay"], [data-smoothr-pay]');
   if (debug) console.log('[Smoothr] Found pay buttons:', payButtons.length);
   if (!payButtons.length) {
     const path = window.location?.pathname || '';
     const isCheckoutPath = /checkout|cart/.test(path);
     if (debug) {
-      warn('No checkout trigger found. Add a [data-smoothr-pay] element or delay init.');
+      warn('No checkout trigger found. Add a [data-smoothr="pay"] element or delay init.');
     } else if (isCheckoutPath) {
       console.warn(
         '[Smoothr Checkout]',
-        'No checkout trigger found. Add a [data-smoothr-pay] element or delay init.'
+        'No checkout trigger found. Add a [data-smoothr="pay"] element or delay init.'
       );
     }
     return;
@@ -209,7 +214,7 @@ export async function init(config = {}) {
       isSubmitting = true;
       forEachPayButton(disableButton);
       clearErrorMessages();
-      log('[data-smoothr-pay] triggered');
+      log('[data-smoothr="pay"] triggered');
 
       const {
         email,


### PR DESCRIPTION
## Summary
- support canonical `[data-smoothr="pay"]` trigger across checkout init and gateways while still accepting legacy `[data-smoothr-pay]`
- add TODO notes to retire legacy selector once migration completes

## Testing
- `npm --workspace storefronts test` *(fails: tests/sdk/gateway-dispatch.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6895f4a5ce688325adec72784a8fbcb2