### PR TITLE
test: update gateway dispatch selectors

### DIFF
--- a/storefronts/tests/sdk/gateway-dispatch.test.js
+++ b/storefronts/tests/sdk/gateway-dispatch.test.js
@@ -51,14 +51,23 @@ function setupEnv(modulePath) {
     default: vi.fn()
   }));
 
-  const payBtn = { tagName: "button", addEventListener: vi.fn() };
+  const payBtn = {
+    tagName: "button",
+    addEventListener: vi.fn(),
+    dataset: { smoothr: "pay" }
+  };
   global.document = {
     querySelector: vi.fn(sel => {
-      if (sel === "[data-smoothr-pay]") return payBtn;
+      if (sel === "[data-smoothr=\"pay\"]") return payBtn;
+      if (sel === "[data-smoothr=\"pay\"], [data-smoothr-pay]") return payBtn;
       if (sel === "#smoothr-card-styles") return null;
       return null;
     }),
-    querySelectorAll: vi.fn(sel => (sel === "[data-smoothr-pay]" ? [payBtn] : [])),
+    querySelectorAll: vi.fn(sel =>
+      sel === "[data-smoothr=\"pay\"], [data-smoothr-pay]" || sel === "[data-smoothr=\"pay\"]"
+        ? [payBtn]
+        : []
+    ),
     createElement: vi.fn(() => ({ style: {}, id: "", textContent: "" })),
     head: { appendChild: vi.fn() }
   };


### PR DESCRIPTION
## Summary
- adjust gateway dispatch test DOM to use canonical `[data-smoothr="pay"]` selector
- add dataset on mock pay button and support combined selector

## Testing
- `npm --workspace storefronts test`


------
https://chatgpt.com/codex/tasks/task_e_6896041966048325b7179f21f83e42e7