### PR TITLE
refactor: remove legacy Smoothr attribute selectors

### DIFF
--- a/storefronts/README.md
+++ b/storefronts/README.md
@@ -114,7 +114,7 @@ persisted in `localStorage`.
 
 ## Cart UI helpers
 
-Helpers for rendering the cart and binding `[data-smoothr-add]` buttons live in
+Helpers for rendering the cart and binding `[data-smoothr="add-to-cart"]` buttons live in
 `./features/cart`. Import them as needed:
 
 ```javascript

--- a/storefronts/adapters/README.md
+++ b/storefronts/adapters/README.md
@@ -68,7 +68,7 @@ item. Fields inside the template can use the following bindings:
 - `data-smoothr-price`
 - `data-smoothr-subtotal`
 - `data-smoothr-image`
-- `data-smoothr-remove`
+- `data-smoothr="remove-from-cart"`
 - `data-smoothr-total` (outside the template)
 
 When `renderCart()` runs it removes previously rendered rows, clones the
@@ -82,7 +82,7 @@ styles.
     <img data-smoothr-image />
     <span data-smoothr-name></span>
     <span data-smoothr-price></span>
-    <button data-smoothr-remove>Remove</button>
+    <button data-smoothr="remove-from-cart">Remove</button>
   </div>
 </div>
 <div>Total: <span data-smoothr-total></span></div>

--- a/storefronts/features/cart/addToCart.js
+++ b/storefronts/features/cart/addToCart.js
@@ -23,9 +23,9 @@ export function bindAddToCartButtons() {
     return;
   }
 
-  const buttons = document.querySelectorAll('[data-smoothr-add]');
+  const buttons = document.querySelectorAll('[data-smoothr="add-to-cart"]');
   if (debug && !foundLogShown)
-    log(`found ${buttons.length} [data-smoothr-add] elements`);
+    log(`found ${buttons.length} [data-smoothr="add-to-cart"] elements`);
   foundLogShown = true;
 
   if (buttons.length === 0) {
@@ -38,7 +38,7 @@ export function bindAddToCartButtons() {
     Smoothr.cart.addButtonPollingRetries = pollAttempts;
     if (pollAttempts >= MAX_POLL_ATTEMPTS) {
       warn(
-        `No [data-smoothr-add] elements after ${MAX_POLL_ATTEMPTS} attempts—feature disabled`
+        `No [data-smoothr="add-to-cart"] elements after ${MAX_POLL_ATTEMPTS} attempts—feature disabled`
       );
       Smoothr.cart.addButtonPollingDisabled = true;
       return;
@@ -52,7 +52,7 @@ export function bindAddToCartButtons() {
   }
 
     buttons.forEach(btn => {
-      if (debug) log('🔗 binding [data-smoothr-add] button', btn);
+      if (debug) log('🔗 binding [data-smoothr="add-to-cart"] button', btn);
       if (btn.__smoothrBound) return;
       btn.__smoothrBound = true;
 

--- a/storefronts/features/cart/renderCart.js
+++ b/storefronts/features/cart/renderCart.js
@@ -27,17 +27,19 @@ export function bindRemoveFromCartButtons() {
   const Smoothr = window.Smoothr || window.smoothr;
   if (!Smoothr?.cart) return;
 
-  document.querySelectorAll('[data-smoothr-remove]').forEach(btn => {
-    if (btn.__smoothrBound) return;
-    const id = btn.getAttribute('data-smoothr-remove');
-    btn.addEventListener('click', async () => {
+  document
+    .querySelectorAll('[data-smoothr="remove-from-cart"]')
+    .forEach(btn => {
+      if (btn.__smoothrBound) return;
+      const id = btn.getAttribute('data-product-id');
+      btn.addEventListener('click', async () => {
       await Smoothr.cart.removeItem(id);
       if (typeof Smoothr.cart.renderCart === 'function') {
         await Smoothr.cart.renderCart();
       }
+      });
+      btn.__smoothrBound = true;
     });
-    btn.__smoothrBound = true;
-  });
 }
 
 export function renderCart() {
@@ -141,18 +143,20 @@ export function renderCart() {
         }
       }
 
-      clone.querySelectorAll('[data-smoothr-remove]').forEach(btn => {
-        btn.setAttribute('data-smoothr-remove', item.product_id);
-        if (!btn.__smoothrBound) {
-          btn.addEventListener('click', async () => {
-            await Smoothr.cart.removeItem(item.product_id);
-            if (typeof Smoothr.cart.renderCart === 'function') {
-              await Smoothr.cart.renderCart();
-            }
-          });
-          btn.__smoothrBound = true;
+      clone.querySelectorAll('[data-smoothr="remove-from-cart"]').forEach(
+        btn => {
+          btn.setAttribute('data-product-id', item.product_id);
+          if (!btn.__smoothrBound) {
+            btn.addEventListener('click', async () => {
+              await Smoothr.cart.removeItem(item.product_id);
+              if (typeof Smoothr.cart.renderCart === 'function') {
+                await Smoothr.cart.renderCart();
+              }
+            });
+            btn.__smoothrBound = true;
+          }
         }
-      });
+      );
 
       template.parentNode.insertBefore(clone, template.nextSibling);
     });

--- a/storefronts/smoothr-sdk.js
+++ b/storefronts/smoothr-sdk.js
@@ -79,7 +79,6 @@ if (!scriptEl || !storeId) {
     const hasCheckoutTrigger = document.querySelector('[data-smoothr="pay"]');
     const hasCartTrigger =
       document.querySelector('[data-smoothr="add-to-cart"]') ||
-      document.querySelector('[data-smoothr-add]') ||
       document.querySelector('[data-smoothr-total]') ||
       document.querySelector('[data-smoothr-cart]');
 

--- a/storefronts/tests/adapters/addToCart.test.js
+++ b/storefronts/tests/adapters/addToCart.test.js
@@ -174,7 +174,7 @@ describe("webflow add-to-cart binding", () => {
     expect(window.Smoothr.cart.addButtonPollingRetries).toBe(10);
     expect(warnSpy).toHaveBeenLastCalledWith(
       "[Smoothr Cart]",
-      "No [data-smoothr-add] elements after 10 attempts—feature disabled"
+      "No [data-smoothr=\"add-to-cart\"] elements after 10 attempts—feature disabled"
     );
     warnSpy.mockRestore();
     vi.useRealTimers();

--- a/storefronts/tests/adapters/renderCart.test.js
+++ b/storefronts/tests/adapters/renderCart.test.js
@@ -37,7 +37,7 @@ beforeEach(async () => {
   imageEl.setAttribute('data-smoothr-image', '');
 
   const removeBtn = document.createElement('button');
-  removeBtn.setAttribute('data-smoothr-remove', '');
+  removeBtn.setAttribute('data-smoothr', 'remove-from-cart');
 
   template.append(
     imageEl,
@@ -125,7 +125,9 @@ describe('renderCart', () => {
   it('remove buttons trigger cart.removeItem', async () => {
     const renderCart = await loadRenderCart();
     renderCart();
-    const btn = container.querySelector('.cart-rendered [data-smoothr-remove]');
+    const btn = container.querySelector(
+      '.cart-rendered [data-smoothr="remove-from-cart"]'
+    );
     btn.click();
     expect(removeItemMock).toHaveBeenCalledWith('p2');
   });

--- a/storefronts/tests/sdk/cart-currency-format.test.js
+++ b/storefronts/tests/sdk/cart-currency-format.test.js
@@ -11,7 +11,7 @@ describe("cart totals use currency formatter", () => {
         if (sel === "[data-smoothr-total]") return [totalEl];
         if (sel === "[data-smoothr-template]") return [];
         if (sel === "[data-smoothr-cart]") return [];
-        if (sel === "[data-smoothr-remove]") return [];
+        if (sel === "[data-smoothr=\"remove-from-cart\"]") return [];
         return [];
       }),
     };

--- a/storefronts/tests/sdk/cart-dom-trigger.test.js
+++ b/storefronts/tests/sdk/cart-dom-trigger.test.js
@@ -41,7 +41,6 @@ describe("cart DOM trigger", () => {
 
   it.each([
     '[data-smoothr="add-to-cart"]',
-    '[data-smoothr-add]',
     '[data-smoothr-total]',
     '[data-smoothr-cart]'
   ])("imports cart when %s is present", async selector => {

--- a/storefronts/tests/sdk/cart-feature-loading.test.js
+++ b/storefronts/tests/sdk/cart-feature-loading.test.js
@@ -37,7 +37,6 @@ describe("cart feature loading", () => {
 
   it.each([
     '[data-smoothr="add-to-cart"]',
-    '[data-smoothr-add]',
     '[data-smoothr-total]',
     '[data-smoothr-cart]'
   ])("initializes cart when trigger %s exists", async selector => {

--- a/storefronts/tests/sdk/cart-idempotency.test.js
+++ b/storefronts/tests/sdk/cart-idempotency.test.js
@@ -21,7 +21,7 @@ describe("cart init idempotency", () => {
     };
     global.document = {
       querySelectorAll: vi.fn((sel) =>
-        sel === "[data-smoothr-add]" ? [button] : []
+        sel === "[data-smoothr=\"add-to-cart\"]" ? [button] : []
       ),
     };
   });

--- a/storefronts/tests/sdk/remove-button-bind.test.js
+++ b/storefronts/tests/sdk/remove-button-bind.test.js
@@ -5,11 +5,16 @@ let button;
 describe('remove button binding', () => {
   beforeEach(() => {
     vi.resetModules();
-    button = { addEventListener: vi.fn(), getAttribute: vi.fn(() => '1') };
+    button = {
+      addEventListener: vi.fn(),
+      getAttribute: vi.fn(attr => (attr === 'data-product-id' ? '1' : null))
+    };
     global.console = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
     global.window = { Smoothr: { cart: { removeItem: vi.fn(), renderCart: vi.fn() } } };
     global.document = {
-      querySelectorAll: vi.fn(sel => (sel === '[data-smoothr-remove]' ? [button] : []))
+      querySelectorAll: vi.fn(sel =>
+        sel === '[data-smoothr="remove-from-cart"]' ? [button] : []
+      )
     };
   });
 


### PR DESCRIPTION
## Summary
- use canonical data-smoothr selectors for cart buttons
- document updated cart attributes
- drop legacy selector checks from SDK

## Testing
- `npm --workspace storefronts test`


------
https://chatgpt.com/codex/tasks/task_e_689609bcab2883258e9a9ef7e131e727