### PR TITLE
fix: clear ghost Supabase sessions

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -110,6 +110,43 @@ export async function init(config = {}) {
   await ensureSupabaseSessionAuth();
 
   try {
+    const {
+      data: { session }
+    } = await authClient.auth.getSession();
+    if (!session) {
+      let hasGhostTokens = false;
+      try {
+        const raw = authClient.auth.storage?.getItem?.(
+          authClient.auth.storageKey
+        );
+        if (raw) {
+          const parsed = JSON.parse(raw);
+          const tokenHolder = parsed?.currentSession || parsed;
+          hasGhostTokens = Boolean(
+            tokenHolder?.access_token || tokenHolder?.refresh_token
+          );
+        }
+      } catch {
+        // ignore JSON/storage errors
+      }
+      if (hasGhostTokens) {
+        console.warn(
+          '[Smoothr] Detected ghost session — clearing broken Supabase state'
+        );
+        try {
+          await authClient.auth.signOut({ scope: 'local' });
+        } catch {
+          // ignore signOut errors
+        }
+      }
+    } else {
+      console.log('[Smoothr] Auth restored');
+    }
+  } catch {
+    // ignore session check errors
+  }
+
+  try {
     await loadConfig(storeId || '00000000-0000-0000-0000-000000000000');
   } catch (err) {
     if (


### PR DESCRIPTION
## Summary
- clear ghost Supabase sessions by checking for stored tokens when no session is returned
- log auth restoration or ghost-session cleanup and sign out locally to avoid cascading logout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68961bf3813c83258475433e75ca0b76