### PR TITLE
Refactor auth session readiness and config loading

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -77,38 +77,8 @@ async function domReady() {
   }
 }
 
-export async function init(config = {}) {
-  if (initialized) return window.Smoothr?.auth;
-
-  const script =
-    typeof document !== 'undefined'
-      ? document.currentScript || document.getElementById('smoothr-sdk')
-      : null;
-  const storeId =
-    config.storeId || script?.getAttribute?.('data-store-id') || script?.dataset?.storeId;
-
-  mergeConfig({ ...config, storeId });
-
-  if (!storeId) {
-    console.warn(
-      '[Smoothr SDK] No storeId found — auth metadata will be incomplete'
-    );
-  }
-
-  if (
-    typeof window !== 'undefined' &&
-    window.location?.hash?.includes('access_token')
-  ) {
-    const { error } = await authClient.auth.getSessionFromUrl({
-      storeSession: true
-    });
-    if (error) {
-      console.warn('[Smoothr SDK] Error parsing session from URL:', error);
-    }
-  }
-
+export async function waitForSessionReady() {
   await ensureSupabaseSessionAuth();
-
   try {
     const {
       data: { session }
@@ -145,6 +115,39 @@ export async function init(config = {}) {
   } catch {
     // ignore session check errors
   }
+}
+
+export async function init(config = {}) {
+  if (initialized) return window.Smoothr?.auth;
+
+  const script =
+    typeof document !== 'undefined'
+      ? document.currentScript || document.getElementById('smoothr-sdk')
+      : null;
+  const storeId =
+    config.storeId || script?.getAttribute?.('data-store-id') || script?.dataset?.storeId;
+
+  mergeConfig({ ...config, storeId });
+
+  if (!storeId) {
+    console.warn(
+      '[Smoothr SDK] No storeId found — auth metadata will be incomplete'
+    );
+  }
+
+  if (
+    typeof window !== 'undefined' &&
+    window.location?.hash?.includes('access_token')
+  ) {
+    const { error } = await authClient.auth.getSessionFromUrl({
+      storeSession: true
+    });
+    if (error) {
+      console.warn('[Smoothr SDK] Error parsing session from URL:', error);
+    }
+  }
+
+  await waitForSessionReady();
 
   try {
     await loadConfig(storeId || '00000000-0000-0000-0000-000000000000');

--- a/storefronts/smoothr-sdk.js
+++ b/storefronts/smoothr-sdk.js
@@ -1,5 +1,6 @@
-import { supabase } from '../supabase/supabaseClient.js';
 import { mergeConfig } from './features/config/globalConfig.js';
+import { loadPublicConfig } from './features/config/sdkConfig.ts';
+import { waitForSessionReady } from './features/auth/init.js';
 
 // Ensure legacy global currency helper exists
 if (typeof globalThis.setSelectedCurrency !== 'function') {
@@ -36,12 +37,9 @@ if (!scriptEl || !storeId) {
   (async () => {
     if (storeId) {
       try {
+        await waitForSessionReady();
         log('Fetching store settings');
-        const { data } = await supabase
-          .from('public_store_settings')
-          .select('active_payment_gateway')
-          .eq('store_id', storeId)
-          .maybeSingle();
+        const data = await loadPublicConfig(storeId);
         config.settings = { ...(config.settings || {}), ...(data || {}) };
         log('Store settings loaded', config.settings);
       } catch (err) {


### PR DESCRIPTION
## Summary
- Extract session restoration and ghost token cleanup into reusable `waitForSessionReady`
- Use `waitForSessionReady` in SDK startup and load store settings via `loadPublicConfig`

## Testing
- `npm --workspace storefronts test`
- `npm run test:supabase`


------
https://chatgpt.com/codex/tasks/task_e_68962391ecec8325beaf309112c13a90