### PR TITLE
feat: add gateway credential helper

### DIFF
--- a/storefronts/core/credentials.js
+++ b/storefronts/core/credentials.js
@@ -1,0 +1,35 @@
+import { supabase, ensureSupabaseSessionAuth } from '../../supabase/supabaseClient.js';
+
+export async function getGatewayCredential(gateway) {
+  try {
+    await ensureSupabaseSessionAuth();
+    const {
+      data: { session }
+    } = await supabase.auth.getSession();
+    const access_token = session?.access_token;
+    if (!access_token) {
+      console.warn('[Smoothr] Missing access token for credential lookup');
+      return null;
+    }
+    const supabaseUrl = supabase.supabaseUrl || process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const res = await fetch(`${supabaseUrl}/functions/v1/get_gateway_credentials`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${access_token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ gateway })
+    });
+    if (!res.ok) {
+      console.warn('[Smoothr] Credential fetch failed:', res.statusText || res.status);
+      return null;
+    }
+    return await res.json();
+  } catch (e) {
+    console.warn('[Smoothr] Credential fetch error:', e?.message || e);
+    return null;
+  }
+}
+
+export default getGatewayCredential;
+


### PR DESCRIPTION
## Summary
- add helper to retrieve gateway credentials via Supabase edge function

## Testing
- `npm --workspace storefronts test`
- `npm run test:supabase`


------
https://chatgpt.com/codex/tasks/task_e_68966d576e188325842f8d44779bc6e6