### PR TITLE
Use gateway credentials in Stripe gateway

### DIFF
--- a/storefronts/features/checkout/core/credentials.js
+++ b/storefronts/features/checkout/core/credentials.js
@@ -1,0 +1,1 @@
+export { getGatewayCredential } from '../../../core/credentials.js';

--- a/storefronts/tests/sdk/stripe-mount.test.js
+++ b/storefronts/tests/sdk/stripe-mount.test.js
@@ -9,8 +9,8 @@ vi.mock('../../features/checkout/utils/stripeIframeStyles.js', () => ({
   getFonts: vi.fn(() => []),
   elementStyleFromContainer: vi.fn(() => ({}))
 }));
-vi.mock('../../features/checkout/getPublicCredential.js', () => ({
-  getPublicCredential: (...args) => getCredMock(...args)
+vi.mock('../../features/checkout/core/credentials.js', () => ({
+  getGatewayCredential: (...args) => getCredMock(...args)
 }));
 
 let domReadyCb;
@@ -73,7 +73,7 @@ describe('stripe element mounting', () => {
     await vi.advanceTimersByTimeAsync(500);
     vi.useRealTimers();
 
-    expect(getCredMock).toHaveBeenCalledWith('store-1', 'stripe', 'stripe');
+    expect(getCredMock).toHaveBeenCalledWith('stripe');
 
     expect(elementsCreate).toHaveBeenCalledWith(
       'cardNumber',


### PR DESCRIPTION
## Summary
- switch Stripe gateway to fetch publishable key with `getGatewayCredential`
- expose gateway credential helper within checkout core
- align tests with new credential lookup logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68966eac97948325993bb3160cd13fc0