### PR TITLE
Refactor Authorize.Net credential resolution

### DIFF
--- a/storefronts/tests/adapters/authorizeNet-gateway.test.js
+++ b/storefronts/tests/adapters/authorizeNet-gateway.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 let styleSpy = vi.fn();
+let getCredMock;
 
 vi.mock('../../features/checkout/utils/authorizeNetIframeStyles.js', async () => {
   const actual = await vi.importActual('../../features/checkout/utils/authorizeNetIframeStyles.js');
@@ -13,17 +14,9 @@ vi.mock('../../features/checkout/utils/authorizeNetIframeStyles.js', async () =>
   };
 });
 
-vi.mock('../../../supabase/supabaseClient.js', () => {
-  const maybeSingle = vi.fn(async () => ({
-    data: { settings: { client_key: 'client', api_login_id: 'id' } },
-    error: null
-  }));
-  const eq2 = vi.fn(() => ({ maybeSingle }));
-  const eq1 = vi.fn(() => ({ eq: eq2 }));
-  const select = vi.fn(() => ({ eq: eq1 }));
-  const from = vi.fn(() => ({ select }));
-  return { supabase: { from }, ensureSupabaseSessionAuth: vi.fn() };
-});
+vi.mock('../../features/checkout/core/credentials.js', () => ({
+  getGatewayCredential: (...args) => getCredMock(...args)
+}));
 
 let createPaymentMethod;
 let mountCardFields;
@@ -34,7 +27,12 @@ beforeEach(async () => {
   vi.resetModules();
   styleSpy = vi.fn();
   document.body.innerHTML = '';
-  window.SMOOTHR_CONFIG = { storeId: 'store-1', debug: true };
+  getCredMock = vi.fn(async () => ({
+    client_key: 'client',
+    api_login_id: 'id',
+    transaction_key: 'tkey'
+  }));
+  window.SMOOTHR_CONFIG = { debug: true };
 
   ['card-number', 'card-expiry', 'card-cvc'].forEach(attr => {
     const div = document.createElement('div');

--- a/storefronts/tests/providers/provider-nmi-mount.test.ts
+++ b/storefronts/tests/providers/provider-nmi-mount.test.ts
@@ -53,8 +53,8 @@ beforeEach(async () => {
 
   getCredMock = vi.fn(async () => ({ tokenization_key: 'tok_key' }));
 
-  vi.mock('../../features/checkout/getPublicCredential.js', () => ({
-    getPublicCredential: getCredMock
+  vi.mock('../../features/checkout/core/credentials.js', () => ({
+    getGatewayCredential: (...args: any[]) => getCredMock(...args)
   }));
 
   window.SMOOTHR_CONFIG = { storeId: 'store-1', active_payment_gateway: 'nmi' } as any;
@@ -87,7 +87,7 @@ describe('mountNMI', () => {
 
   it('loads tokenization key and injects script', { timeout: 20000 }, async () => {
     await triggerMount();
-    expect(getCredMock).toHaveBeenCalledWith('store-1', 'nmi', 'nmi');
+    expect(getCredMock).toHaveBeenCalledWith('nmi');
     const attrs = loadScriptOnce.mock.calls[0][1].attrs;
     expect(attrs['data-tokenization-key']).toBe('tok_key');
   });


### PR DESCRIPTION
## Summary
- use getGatewayCredential in Authorize.Net gateway
- warn when client_key, api_login_id, or transaction_key are missing
- update tests to mock new credential lookup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689672be2b1083258dc7ec8848ffdec1