### PR TITLE
test: mock credentials helper

### DIFF
--- a/storefronts/tests/providers/provider-nmi-mount.test.ts
+++ b/storefronts/tests/providers/provider-nmi-mount.test.ts
@@ -53,7 +53,7 @@ beforeEach(async () => {
 
   getCredMock = vi.fn(async () => ({ tokenization_key: 'tok_key' }));
 
-  vi.mock('../../features/checkout/core/credentials.js', () => ({
+  vi.mock('../../core/credentials.js', () => ({
     getGatewayCredential: (...args: any[]) => getCredMock(...args)
   }));
 
@@ -96,6 +96,18 @@ describe('mountNMI', () => {
     await triggerMount();
     await expect(ready()).resolves.toBeUndefined();
     expect(window.CollectJS.configure).toHaveBeenCalled();
+  });
+
+  it('warns and rejects when tokenization key is missing', { timeout: 20000 }, async () => {
+    getCredMock.mockResolvedValue(null);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    const readyPromise = mountNMI();
+    await expect(readyPromise).rejects.toThrow('Tokenization key missing');
+    expect(warnSpy).toHaveBeenCalled();
+    expect(alertSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+    alertSpy.mockRestore();
   });
 
   it('rejects and logs error if CollectJS fails to load', { timeout: 20000 }, async () => {

--- a/storefronts/tests/sdk/stripe-mount.test.js
+++ b/storefronts/tests/sdk/stripe-mount.test.js
@@ -9,7 +9,7 @@ vi.mock('../../features/checkout/utils/stripeIframeStyles.js', () => ({
   getFonts: vi.fn(() => []),
   elementStyleFromContainer: vi.fn(() => ({}))
 }));
-vi.mock('../../features/checkout/core/credentials.js', () => ({
+vi.mock('../../core/credentials.js', () => ({
   getGatewayCredential: (...args) => getCredMock(...args)
 }));
 
@@ -114,6 +114,19 @@ describe('stripe element mounting', () => {
     expect(styleSpy).toHaveBeenCalledWith('[data-smoothr-card-number]', cardNumberEl);
     expect(styleSpy).toHaveBeenCalledWith('[data-smoothr-card-expiry]', cardExpiryEl);
     expect(styleSpy).toHaveBeenCalledWith('[data-smoothr-card-cvc]', cardCvcEl);
+  });
+
+  it('warns and aborts when credential lookup returns null', async () => {
+    getCredMock.mockResolvedValue(null);
+    global.window.SMOOTHR_CONFIG.debug = true;
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { mountCardFields } = await import('../../features/checkout/gateways/stripeGateway.js');
+    await mountCardFields();
+    await vi.advanceTimersByTimeAsync(500);
+    vi.useRealTimers();
+    expect(warnSpy).toHaveBeenCalled();
+    expect(elementsCreate).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 
   it('waitForVisible resolves when width becomes visible', async () => {


### PR DESCRIPTION
## Summary
- mock getGatewayCredential in stripe and NMI mount tests
- assert credential lookups and handle missing key

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689678b073c08325a99dcfd6bdcfed98