### PR TITLE
feat: send store ID with gateway credential requests

### DIFF
--- a/storefronts/core/credentials.js
+++ b/storefronts/core/credentials.js
@@ -1,33 +1,44 @@
-import { supabase, ensureSupabaseSessionAuth } from '../../supabase/supabaseClient.js';
+import supabase, { ensureSupabaseSessionAuth } from '../../supabase/supabaseClient.js';
+import { getConfig } from '../features/config/globalConfig.js';
 
 export async function getGatewayCredential(gateway) {
+  const debug =
+    typeof window !== 'undefined' &&
+    new URLSearchParams(window.location.search).has('smoothr-debug');
   try {
     await ensureSupabaseSessionAuth();
     const {
       data: { session }
     } = await supabase.auth.getSession();
     const access_token = session?.access_token;
-    if (!access_token) {
-      console.warn('[Smoothr] Missing access token for credential lookup');
-      return null;
-    }
+
+    const { storeId: store_id } = getConfig();
     const supabaseUrl = supabase.supabaseUrl || process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+    const headers = {
+      'Content-Type': 'application/json',
+      apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    };
+    if (access_token) {
+      headers.Authorization = `Bearer ${access_token}`;
+    }
+
     const res = await fetch(`${supabaseUrl}/functions/v1/get_gateway_credentials`, {
       method: 'POST',
-      headers: {
-        Authorization: `Bearer ${access_token}`,
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({ gateway })
+      headers,
+      body: JSON.stringify({ store_id, gateway })
     });
+
+    const data = await res.json();
     if (!res.ok) {
-      console.warn('[Smoothr] Credential fetch failed:', res.statusText || res.status);
-      return null;
+      debug &&
+        console.warn('[Smoothr] Credential fetch failed:', res.status, data?.message);
+      return { publishable_key: null, tokenization_key: null };
     }
-    return await res.json();
+    return data;
   } catch (e) {
-    console.warn('[Smoothr] Credential fetch error:', e?.message || e);
-    return null;
+    debug && console.warn('[Smoothr] Credential fetch error:', e?.message || e);
+    return { publishable_key: null, tokenization_key: null };
   }
 }
 


### PR DESCRIPTION
## Summary
- use singleton Supabase client for credential lookup
- include store_id and gateway in request body and apikey header
- log non-200 responses when `smoothr-debug` is enabled and return null keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68967f6db4948325b0a603e270b72d9d