### PR TITLE
refactor: cache session ready promise

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -77,44 +77,49 @@ async function domReady() {
   }
 }
 
-export async function waitForSessionReady() {
-  await ensureSupabaseSessionAuth();
-  try {
-    const {
-      data: { session }
-    } = await authClient.auth.getSession();
-    if (!session) {
-      let hasGhostTokens = false;
-      try {
-        const raw = authClient.auth.storage?.getItem?.(
-          authClient.auth.storageKey
-        );
-        if (raw) {
-          const parsed = JSON.parse(raw);
-          const tokenHolder = parsed?.currentSession || parsed;
-          hasGhostTokens = Boolean(
-            tokenHolder?.access_token || tokenHolder?.refresh_token
-          );
-        }
-      } catch {
-        // ignore JSON/storage errors
-      }
-      if (hasGhostTokens) {
-        console.warn(
-          '[Smoothr] Detected ghost session — clearing broken Supabase state'
-        );
+let sessionReadyPromise;
+export function waitForSessionReady() {
+  if (sessionReadyPromise) return sessionReadyPromise;
+  sessionReadyPromise = (async () => {
+    await ensureSupabaseSessionAuth();
+    try {
+      const {
+        data: { session }
+      } = await authClient.auth.getSession();
+      if (!session) {
+        let hasGhostTokens = false;
         try {
-          await authClient.auth.signOut({ scope: 'local' });
+          const raw = authClient.auth.storage?.getItem?.(
+            authClient.auth.storageKey
+          );
+          if (raw) {
+            const parsed = JSON.parse(raw);
+            const tokenHolder = parsed?.currentSession || parsed;
+            hasGhostTokens = Boolean(
+              tokenHolder?.access_token || tokenHolder?.refresh_token
+            );
+          }
         } catch {
-          // ignore signOut errors
+          // ignore JSON/storage errors
         }
+        if (hasGhostTokens) {
+          console.warn(
+            '[Smoothr] Detected ghost session — clearing broken Supabase state'
+          );
+          try {
+            await authClient.auth.signOut({ scope: 'local' });
+          } catch {
+            // ignore signOut errors
+          }
+        }
+      } else {
+        console.log('[Smoothr] Auth restored');
       }
-    } else {
-      console.log('[Smoothr] Auth restored');
+    } catch {
+      // ignore session check errors
     }
-  } catch {
-    // ignore session check errors
-  }
+  })();
+  return sessionReadyPromise;
 }
 
 export async function init(config = {}) {

--- a/storefronts/smoothr-sdk.js
+++ b/storefronts/smoothr-sdk.js
@@ -1,6 +1,5 @@
 import { mergeConfig } from './features/config/globalConfig.js';
 import { loadPublicConfig } from './features/config/sdkConfig.ts';
-import { waitForSessionReady } from './features/auth/init.js';
 
 // Ensure legacy global currency helper exists
 if (typeof globalThis.setSelectedCurrency !== 'function') {
@@ -37,7 +36,6 @@ if (!scriptEl || !storeId) {
   (async () => {
     if (storeId) {
       try {
-        await waitForSessionReady();
         log('Fetching store settings');
         const data = await loadPublicConfig(storeId);
         if (!data && debug) {
@@ -65,7 +63,8 @@ if (!scriptEl || !storeId) {
 
     try {
       log('Initializing auth feature');
-      await import('./features/auth/init.js').then(m => m.init(config));
+      const auth = await import('./features/auth/init.js');
+      await auth.init(config);
     } catch (err) {
       debug && console.warn('[Smoothr SDK] Auth init failed', err);
     }


### PR DESCRIPTION
## Summary
- cache Supabase session readiness to avoid repeated logs
- streamline Smoothr SDK auth initialization to rely on internal session restoration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896930c40388325b978ef5d109e8528