### PR TITLE
test: cover cors and edge config loading

### DIFF
--- a/storefronts/tests/sdk/auth-idempotent.test.js
+++ b/storefronts/tests/sdk/auth-idempotent.test.js
@@ -1,0 +1,64 @@
+import { describe, it, beforeEach, vi, expect } from 'vitest';
+
+vi.mock('../../features/auth/index.js', () => {
+  const authMock = {
+    initAuth: vi.fn().mockResolvedValue(),
+    user: null,
+    $$typeof: Symbol.for('react.test.json'),
+    type: 'module',
+    props: {},
+    children: [],
+    lookupRedirectUrl: vi.fn(),
+    lookupDashboardHomeUrl: vi.fn(),
+  };
+  return { default: authMock, ...authMock };
+});
+
+vi.mock('../../features/config/sdkConfig.ts', () => ({
+  loadPublicConfig: vi.fn().mockResolvedValue({}),
+}));
+
+const getSessionMock = vi.fn().mockResolvedValue({
+  data: { session: {} },
+});
+
+vi.mock('../../../supabase/browserClient.js', () => ({
+  supabase: {
+    auth: { getSession: getSessionMock },
+    from: vi.fn(),
+    supabaseUrl: 'https://mock.supabase.co',
+  },
+  ensureSupabaseSessionAuth: vi.fn().mockResolvedValue(),
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  process.env.NODE_ENV = 'production';
+  global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }));
+  global.localStorage = { getItem: vi.fn(), setItem: vi.fn(), removeItem: vi.fn() };
+  global.window = {
+    location: { origin: '', href: '', hostname: '' },
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  };
+  global.document = {
+    addEventListener: vi.fn((evt, cb) => {
+      if (evt === 'DOMContentLoaded') cb();
+    }),
+    querySelectorAll: vi.fn(() => []),
+    dispatchEvent: vi.fn(),
+    currentScript: { getAttribute: vi.fn(), dataset: { storeId: 's1' } },
+  };
+});
+
+describe('auth init session restoration', () => {
+  it('restores session only once', async () => {
+    const mod = await import('../../features/auth/init.js');
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await mod.init({ storeId: 's1' });
+    await mod.init({ storeId: 's1' });
+    expect(getSessionMock).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls.filter((c) => c[0] === '[Smoothr] Auth restored').length).toBe(1);
+  });
+});
+

--- a/storefronts/tests/sdk/load-config-merge.test.js
+++ b/storefronts/tests/sdk/load-config-merge.test.js
@@ -1,5 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import * as core from '../../features/auth/init.js';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 vi.mock('../../features/auth/index.js', () => {
   const authMock = {
@@ -15,44 +14,33 @@ vi.mock('../../features/auth/index.js', () => {
   return { default: authMock, ...authMock };
 });
 
+let from;
 vi.mock('../../../supabase/browserClient.js', () => {
   const getSession = vi.fn().mockResolvedValue({
-    data: { session: { access_token: 'test-token' } }
+    data: { session: { access_token: 'test-token' } },
   });
-
-  const setSession = vi.fn();
   const ensureSupabaseSessionAuth = vi.fn().mockResolvedValue();
-
-  const single = vi.fn(() =>
-    Promise.resolve({
-      data: { foo: 'bar' },
-      error: null
-    })
-  );
-  const eq = vi.fn(() => ({ single }));
-  const select = vi.fn(() => ({ eq }));
-  const from = vi.fn(() => ({ select }));
-
-  return {
-    supabase: {
-      auth: { getSession, setSession },
-      from
-    },
-    ensureSupabaseSessionAuth
+  from = vi.fn();
+  const client = {
+    auth: { getSession },
+    from,
+    supabaseUrl: 'https://mock.supabase.co',
   };
+  return { supabase: client, default: client, ensureSupabaseSessionAuth };
 });
 
 beforeEach(() => {
   vi.resetModules();
+  vi.stubEnv('NODE_ENV', 'production');
 
   global.window = {
     SMOOTHR_CONFIG: {
       apiBase: 'https://example.com',
-      storeId: '00000000-0000-0000-0000-000000000000'
+      storeId: '00000000-0000-0000-0000-000000000000',
     },
     location: { origin: '', href: '', hostname: '' },
     addEventListener: vi.fn(),
-    removeEventListener: vi.fn()
+    removeEventListener: vi.fn(),
   };
 
   global.document = {
@@ -65,7 +53,7 @@ beforeEach(() => {
         attr === 'data-store-id'
           ? '00000000-0000-0000-0000-000000000000'
           : null
-      )
+      ),
     })),
     currentScript: {
       dataset: { storeId: '00000000-0000-0000-0000-000000000000' },
@@ -73,42 +61,55 @@ beforeEach(() => {
         attr === 'data-store-id'
           ? '00000000-0000-0000-0000-000000000000'
           : null
-      )
-    }
+      ),
+    },
   };
 
   global.fetch = vi.fn(() =>
-    Promise.resolve({ ok: true, json: () => Promise.resolve({ rates: {} }) })
+    Promise.resolve({ ok: true, json: () => Promise.resolve({ foo: 'bar' }) })
   );
 
   global.localStorage = {
     getItem: vi.fn(),
     setItem: vi.fn(),
-    removeItem: vi.fn()
+    removeItem: vi.fn(),
   };
 
   console.log('Test setup: SMOOTHR_CONFIG=', global.window.SMOOTHR_CONFIG);
 });
 
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
 describe('loadConfig merge', () => {
   it('preserves existing config values', async () => {
     console.log('Starting test: loadConfig merge');
-    const { loadConfig } = await import(
-      '../../features/auth/init.js'
+    const { loadPublicConfig } = await import(
+      '../../features/config/sdkConfig.ts'
     );
-    await loadConfig('00000000-0000-0000-0000-000000000000');
-
-    console.log(
-      'SMOOTHR_CONFIG after loadConfig:',
-      global.window.SMOOTHR_CONFIG
+    const { mergeConfig } = await import(
+      '../../features/config/globalConfig.js'
     );
+    const data = await loadPublicConfig(
+      '00000000-0000-0000-0000-000000000000'
+    );
+    const updates = {};
+    for (const [key, value] of Object.entries(data || {})) {
+      const camelKey = key.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+      updates[camelKey] = value;
+    }
+    updates.storeId = '00000000-0000-0000-0000-000000000000';
+    mergeConfig(updates);
 
+    expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(global.window.SMOOTHR_CONFIG).toEqual(
       expect.objectContaining({
         apiBase: 'https://example.com',
         foo: 'bar',
-        storeId: '00000000-0000-0000-0000-000000000000'
+        storeId: '00000000-0000-0000-0000-000000000000',
       })
     );
+    expect(from).not.toHaveBeenCalled();
   }, 5000);
 });

--- a/supabase/functions/get_gateway_credentials.cors.test.ts
+++ b/supabase/functions/get_gateway_credentials.cors.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+let handler: (req: Request) => Promise<Response>;
+let createClientMock: any;
+
+function expectCors(res: Response) {
+  expect(res.headers.get('access-control-allow-origin')).toBe('https://smoothr-cms.webflow.io');
+  expect(res.headers.get('access-control-allow-methods')).toBe('POST, OPTIONS');
+  expect(res.headers.get('access-control-allow-headers')).toBe('authorization, apikey, content-type');
+  expect(res.headers.get('vary')).toBe('Origin');
+}
+
+beforeEach(() => {
+  handler = undefined as any;
+  (globalThis as any).Deno = { env: { get: () => '' } };
+  createClientMock = vi.fn(() => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({ data: null, error: { message: 'nope' } }),
+          }),
+        }),
+      }),
+    }),
+  }));
+
+  vi.mock('https://deno.land/std@0.177.0/http/server.ts', () => ({
+    serve: (fn: any) => {
+      handler = fn;
+    },
+  }));
+  vi.mock('https://esm.sh/@supabase/supabase-js@2', () => ({
+    createClient: createClientMock,
+  }));
+});
+
+afterEach(() => {
+  vi.resetModules();
+  vi.restoreAllMocks();
+  delete (globalThis as any).Deno;
+});
+
+describe('get_gateway_credentials CORS', () => {
+  it('includes CORS headers on OPTIONS', async () => {
+    await import('./get_gateway_credentials/index.ts');
+    const res = await handler(new Request('http://localhost', { method: 'OPTIONS' }));
+    expect(res.status).toBe(204);
+    expectCors(res);
+  });
+
+  it('includes CORS headers on invalid method', async () => {
+    await import('./get_gateway_credentials/index.ts');
+    const res = await handler(new Request('http://localhost', { method: 'GET' }));
+    expect(res.status).toBe(400);
+    expectCors(res);
+  });
+
+  it('includes CORS headers on 403 response', async () => {
+    await import('./get_gateway_credentials/index.ts');
+    const res = await handler(
+      new Request('http://localhost', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ store_id: 's', gateway: 'g' }),
+      }),
+    );
+    expect(res.status).toBe(403);
+    expectCors(res);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add CORS coverage for get_gateway_credentials function
- mock edge config endpoint and ensure Supabase table lookups aren't hit
- verify auth init restores session only once

## Testing
- `npm --workspace storefronts test`
- `npm run test:supabase`


------
https://chatgpt.com/codex/tasks/task_e_6896947240a08325b0ec52919028d55d