### PR TITLE
feat: secure public store settings retrieval

### DIFF
--- a/storefronts/tests/functions/get_public_store_settings.cors.test.ts
+++ b/storefronts/tests/functions/get_public_store_settings.cors.test.ts
@@ -17,12 +17,8 @@ beforeEach(() => {
   handler = undefined as any;
   (globalThis as any).Deno = { env: { get: () => '' } };
   createClientMock = vi.fn(() => ({
-    from: () => ({
-      select: () => ({
-        eq: () => ({
-          maybeSingle: async () => ({ data: { foo: 'bar' }, error: null }),
-        }),
-      }),
+    rpc: () => ({
+      maybeSingle: async () => ({ data: { foo: 'bar' }, error: null }),
     }),
   }));
 

--- a/supabase/functions/get_public_store_settings/index.ts
+++ b/supabase/functions/get_public_store_settings/index.ts
@@ -97,7 +97,7 @@ serve(async (req)=>{
         });
       }
     }
-    const { data, error } = await supabase.from("public_store_settings").select("*").eq("store_id", store_id).maybeSingle();
+    const { data, error } = await supabase.rpc("get_public_store_settings", { p_store_id: store_id }).maybeSingle();
     if (error) {
       errorLog("Query error", error);
       return new Response(JSON.stringify({

--- a/supabase/get_public_store_settings.sql
+++ b/supabase/get_public_store_settings.sql
@@ -1,0 +1,11 @@
+create or replace function public.get_public_store_settings(p_store_id uuid)
+returns public.public_store_settings
+language sql
+security definer
+set search_path = public
+as $$
+  select * from public_store_settings where store_id = p_store_id;
+$$;
+
+grant execute on function public.get_public_store_settings(uuid) to anon;
+grant execute on function public.get_public_store_settings(uuid) to authenticated;

--- a/supabase/rls-policies-audit.sql
+++ b/supabase/rls-policies-audit.sql
@@ -32,11 +32,14 @@
 --   discounts_admin_write: all (public) 
 
 -- Table: notifications
---   notifications_admin_select: select (public) 
---   notifications_admin_write: all (public) 
+--   notifications_admin_select: select (public)
+--   notifications_admin_write: all (public)
+
+-- Table: public_store_settings
+--   public_read: select (anon, authenticated)
 
 -- Table: order_items
---   order_items_customer_select: select (public) 
+--   order_items_customer_select: select (public)
 
 -- Table: orders
 --   orders_customer_select_insert: select, insert (public) 

--- a/supabase/rls-policies.sql
+++ b/supabase/rls-policies.sql
@@ -314,9 +314,18 @@ for select
 to public
 using (((referrer_id = auth.uid()) OR (EXISTS ( SELECT 1
    FROM user_stores us
-  WHERE ((us.customer_id = auth.uid()) AND (us.role = 'admin'::text))))));
+   WHERE ((us.customer_id = auth.uid()) AND (us.role = 'admin'::text))))));
 
+drop policy if exists "public_read" on "public"."public_store_settings";
+create policy "public_read"
+on "public"."public_store_settings"
+as permissive
+for select
+to anon, authenticated
+using ((store_id = current_setting('request.jwt.claim.store_id', true)::uuid));
 
+grant select on table "public"."public_store_settings" to "anon";
+grant select on table "public"."public_store_settings" to "authenticated";
 drop policy if exists "referrals_admin_write" on "public"."referrals";
 create policy "referrals_admin_write"
 on "public"."referrals"


### PR DESCRIPTION
## Summary
- enforce `public_store_settings` access by JWT `store_id` via new RLS policy and grants
- add security-definer SQL function for safe public settings retrieval and expose via RPC
- update edge and unit tests to use RPC-based public store settings fetch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897a5d392208325aaad4d53638fcf92