### PR TITLE
Expose gateway credentials via anon RPC

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -6,7 +6,7 @@ verify_jwt = false
 
 [functions.get_gateway_credentials]
 enabled = true
-verify_jwt = true
+verify_jwt = false
 import_map = "./functions/get_gateway_credentials/deno.json"
 entrypoint = "./functions/get_gateway_credentials/index.ts"
 

--- a/supabase/functions/get_gateway_credentials.cors.test.ts
+++ b/supabase/functions/get_gateway_credentials.cors.test.ts
@@ -14,14 +14,8 @@ beforeEach(() => {
   handler = undefined as any;
   (globalThis as any).Deno = { env: { get: () => '' } };
   createClientMock = vi.fn(() => ({
-    from: () => ({
-      select: () => ({
-        eq: () => ({
-          eq: () => ({
-            maybeSingle: async () => ({ data: null, error: { message: 'nope' } }),
-          }),
-        }),
-      }),
+    rpc: () => ({
+      maybeSingle: async () => ({ data: null, error: { message: 'nope' } }),
     }),
   }));
 

--- a/supabase/get_public_gateway_credentials.sql
+++ b/supabase/get_public_gateway_credentials.sql
@@ -1,0 +1,17 @@
+create or replace function public.get_public_gateway_credentials(store_id uuid, gateway text)
+returns table(publishable_key text, tokenization_key text)
+language sql
+security definer
+set search_path = public
+as $$
+  select
+    settings->>'publishable_key' as publishable_key,
+    settings->>'tokenization_key' as tokenization_key
+  from store_integrations
+  where store_id = get_public_gateway_credentials.store_id
+    and sandbox = false
+    and coalesce(gateway, settings->>'gateway') = get_public_gateway_credentials.gateway
+  limit 1;
+$$;
+
+grant execute on function public.get_public_gateway_credentials(uuid, text) to anon;


### PR DESCRIPTION
## Summary
- disable JWT verification for `get_gateway_credentials`
- add `get_public_gateway_credentials` SECURITY DEFINER RPC
- call new RPC from `get_gateway_credentials` edge function

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897a834e9dc8325af15fe0d206800fa