### PR TITLE
Revoke public credential view access

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ the `publishable_key` and `secret_key` under the `settings` column:
 }
 ```
 
-The checkout SDK reads `publishable_key` from the
-`public_store_integration_credentials` view when fetching configuration for a
+The checkout SDK reads `publishable_key` via the
+`get_public_gateway_credentials` function when fetching configuration for a
 store. Activate the gateway by setting
 `public_store_settings.active_payment_gateway` to `stripe` (or override it on
 the client via `window.SMOOTHR_CONFIG.active_payment_gateway`).
@@ -200,7 +200,7 @@ the client via `window.SMOOTHR_CONFIG.active_payment_gateway`).
 To enable NMI create a row in the `store_integrations` table with `gateway`
 set to `nmi` (or set `settings.gateway` to `nmi`) and store both the API key
 and tokenization key under the `settings` column. The tokenization key is
-exposed anonymously through the `public_store_integration_credentials` view,
+exposed anonymously via the `get_public_gateway_credentials` function,
 which coalesces the `gateway` column with `settings.gateway`:
 
 ```json
@@ -214,10 +214,7 @@ Retrieve the key with Supabase:
 
 ```js
 const { data } = await supabase
-  .from('public_store_integration_credentials')
-  .select('tokenization_key')
-  .eq('store_id', '<store-id>')
-  .eq('gateway', 'nmi')
+  .rpc('get_public_gateway_credentials', { store_id: '<store-id>', gateway: 'nmi' })
   .maybeSingle();
 const key = data?.tokenization_key;
 ```

--- a/storefronts/README.md
+++ b/storefronts/README.md
@@ -192,7 +192,7 @@ setting on the client by defining the following snippet before loading the SDK:
 A Network Merchants (NMI) integration is also supported. Create a new record in
 `store_integrations` with either `gateway` or `settings.gateway` set to `nmi`
 and place your credentials in the `settings` JSON column. The
-`public_store_integration_credentials` view coalesces the `gateway` column with
+`get_public_gateway_credentials` function coalesces the `gateway` column with
 `settings.gateway` so either approach works:
 
 ```json
@@ -201,15 +201,12 @@ and place your credentials in the `settings` JSON column. The
   "tokenization_key": "<TOKENIZATION_KEY>"
 }
 ```
-The tokenization key can be fetched anonymously from the
-`public_store_integration_credentials` view:
+The tokenization key can be fetched anonymously via the
+`get_public_gateway_credentials` function:
 
 ```js
 const { data } = await supabase
-  .from('public_store_integration_credentials')
-  .select('tokenization_key')
-  .eq('store_id', '<store-id>')
-  .eq('gateway', 'nmi')
+  .rpc('get_public_gateway_credentials', { store_id: '<store-id>', gateway: 'nmi' })
   .maybeSingle();
 const key = data?.tokenization_key;
 ```

--- a/supabase/rls-policies.sql
+++ b/supabase/rls-policies.sql
@@ -326,6 +326,7 @@ using ((store_id = current_setting('request.jwt.claim.store_id', true)::uuid));
 
 grant select on table "public"."public_store_settings" to "anon";
 grant select on table "public"."public_store_settings" to "authenticated";
+revoke select on table "public"."public_store_integration_credentials" from "anon";
 drop policy if exists "referrals_admin_write" on "public"."referrals";
 create policy "referrals_admin_write"
 on "public"."referrals"


### PR DESCRIPTION
## Summary
- Revoke SELECT on `public_store_integration_credentials` from `anon`
- Document retrieving credentials through `get_public_gateway_credentials`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897aa865f4483258f6504c61e6c4e8f