### PR TITLE
refactor: enhance CORS and headers for edge functions

### DIFF
--- a/storefronts/tests/functions/get_public_store_settings.cors.test.ts
+++ b/storefronts/tests/functions/get_public_store_settings.cors.test.ts
@@ -4,12 +4,13 @@ let handler: (req: Request) => Promise<Response>;
 let createClientMock: any;
 
 function expectCors(res: Response) {
-  expect(res.headers.get('access-control-allow-origin')).toBe('https://smoothr-cms.webflow.io');
+  expect(res.headers.get('access-control-allow-origin')).toBe('*');
   expect(res.headers.get('access-control-allow-methods')).toBe('POST, OPTIONS');
   expect(res.headers.get('access-control-allow-headers')).toBe('authorization, apikey, content-type');
   expect(res.headers.get('vary')).toBe('Origin');
   if (res.status !== 204) {
     expect(res.headers.get('content-type')).toBe('application/json');
+    expect(res.headers.get('cache-control')).toBe('public, max-age=60, stale-while-revalidate=600');
   }
 }
 

--- a/supabase/docs/FUNCTIONS.md
+++ b/supabase/docs/FUNCTIONS.md
@@ -6,7 +6,7 @@ This document describes available Edge Functions, their inputs, outputs, CORS ru
 - **Method:** POST
 - **Input:** JSON body `{ "store_id": "<uuid>" }`
 - **Output:** Public store settings object with null values removed.
-- **CORS:** `Access-Control-Allow-Origin: https://smoothr-cms.webflow.io`
+- **CORS:** configurable via `FUNCTION_ALLOWED_ORIGINS`; defaults to `*` outside production and `https://smoothr-cms.webflow.io` in production
 - **Sample:**
   ```bash
   curl -X POST \
@@ -19,7 +19,7 @@ This document describes available Edge Functions, their inputs, outputs, CORS ru
 - **Method:** POST
 - **Input:** JSON body `{ "store_id": "<uuid>", "gateway": "<gateway>" }`
 - **Output:** `{ publishable_key, tokenization_key, gateway, store_id }`
-- **CORS:** `Access-Control-Allow-Origin: https://smoothr-cms.webflow.io`
+- **CORS:** configurable via `FUNCTION_ALLOWED_ORIGINS`; defaults to `*` outside production and `https://smoothr-cms.webflow.io` in production
 - **Sample:**
   ```bash
   curl -X POST \

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,0 +1,35 @@
+const WEBFLOW_ORIGIN = 'https://smoothr-cms.webflow.io';
+
+function isProd() {
+  return Deno.env.get('NODE_ENV') === 'production';
+}
+
+export function getCorsHeaders(req: Request): Record<string, string> {
+  const allowedEnv = Deno.env.get('FUNCTION_ALLOWED_ORIGINS');
+  const allowedOrigins = allowedEnv
+    ? allowedEnv.split(',').map(o => o.trim()).filter(Boolean)
+    : null;
+
+  const defaultOrigin = isProd() ? WEBFLOW_ORIGIN : '*';
+  const requestOrigin = req.headers.get('Origin');
+  let origin = defaultOrigin;
+
+  if (allowedOrigins && allowedOrigins.length > 0) {
+    if (allowedOrigins.includes('*')) {
+      origin = '*';
+    } else if (requestOrigin && allowedOrigins.includes(requestOrigin)) {
+      origin = requestOrigin;
+    } else {
+      origin = allowedOrigins[0];
+    }
+  } else if (defaultOrigin !== '*' && requestOrigin === defaultOrigin) {
+    origin = requestOrigin;
+  }
+
+  return {
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'authorization, apikey, content-type',
+    Vary: 'Origin',
+  };
+}

--- a/supabase/functions/get_gateway_credentials.cors.test.ts
+++ b/supabase/functions/get_gateway_credentials.cors.test.ts
@@ -4,10 +4,14 @@ let handler: (req: Request) => Promise<Response>;
 let createClientMock: any;
 
 function expectCors(res: Response) {
-  expect(res.headers.get('access-control-allow-origin')).toBe('https://smoothr-cms.webflow.io');
+  expect(res.headers.get('access-control-allow-origin')).toBe('*');
   expect(res.headers.get('access-control-allow-methods')).toBe('POST, OPTIONS');
   expect(res.headers.get('access-control-allow-headers')).toBe('authorization, apikey, content-type');
   expect(res.headers.get('vary')).toBe('Origin');
+  if (res.status !== 204) {
+    expect(res.headers.get('content-type')).toBe('application/json');
+    expect(res.headers.get('cache-control')).toBe('public, max-age=60, stale-while-revalidate=600');
+  }
 }
 
 beforeEach(() => {

--- a/supabase/functions/get_gateway_credentials/index.ts
+++ b/supabase/functions/get_gateway_credentials/index.ts
@@ -1,120 +1,114 @@
+// verify_jwt disabled at deploy; function is POST-only; returns safe fields
 import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "https://smoothr-cms.webflow.io",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-  "Access-Control-Allow-Headers": "authorization, apikey, content-type",
-  Vary: "Origin"
-};
-serve(async (req)=>{
-  const url = new URL(req.url);
-  const debug = url.searchParams.has("smoothr-debug");
-  const log = (...args)=>debug && console.log("[get_gateway_credentials]", ...args);
-  const errorLog = (...args)=>debug && console.error("[get_gateway_credentials]", ...args);
+import { getCorsHeaders } from "../_shared/cors.ts";
+
+const CACHE_HEADER = "public, max-age=60, stale-while-revalidate=600";
+
+serve(async (req) => {
+  let corsHeaders: Record<string, string> | undefined;
   try {
+    corsHeaders = getCorsHeaders(req);
+    const url = new URL(req.url);
+    const debug = url.searchParams.has("smoothr-debug");
+    const log = (...args: any[]) => debug && console.log("[get_gateway_credentials]", ...args);
+    const errorLog = (...args: any[]) => debug && console.error("[get_gateway_credentials]", ...args);
     if (req.method === "OPTIONS") {
       return new Response(null, {
         status: 204,
-        headers: {
-          ...corsHeaders
-        }
+        headers: { ...corsHeaders, "Cache-Control": CACHE_HEADER },
       });
     }
     if (req.method !== "POST") {
-      return new Response(JSON.stringify({
-        error: "invalid_request",
-        message: "method must be POST"
-      }), {
-        status: 400,
-        headers: {
-          ...corsHeaders,
-          "Content-Type": "application/json"
-        }
-      });
+      return new Response(
+        JSON.stringify({ error: "invalid_request", message: "method must be POST" }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json", "Cache-Control": CACHE_HEADER },
+        },
+      );
     }
-    let body;
+    const contentType = req.headers.get("content-type");
+    if (!contentType || !contentType.toLowerCase().includes("application/json")) {
+      return new Response(
+        JSON.stringify({ error: "invalid_request", message: "content-type must be application/json" }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json", "Cache-Control": CACHE_HEADER },
+        },
+      );
+    }
+    let body: any;
     try {
       body = await req.json();
     } catch (err) {
       errorLog("Invalid JSON", err);
-      return new Response(JSON.stringify({
-        error: "invalid_request",
-        message: "invalid JSON body"
-      }), {
-        status: 400,
-        headers: {
-          ...corsHeaders,
-          "Content-Type": "application/json"
-        }
-      });
+      return new Response(
+        JSON.stringify({ error: "invalid_request", message: "invalid JSON body" }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json", "Cache-Control": CACHE_HEADER },
+        },
+      );
     }
     const { store_id, gateway } = body ?? {};
     if (typeof store_id !== "string" || !store_id) {
-      return new Response(JSON.stringify({
-        error: "invalid_request",
-        message: "store_id is required"
-      }), {
-        status: 400,
-        headers: {
-          ...corsHeaders,
-          "Content-Type": "application/json"
-        }
-      });
+      return new Response(
+        JSON.stringify({ error: "invalid_request", message: "store_id is required" }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json", "Cache-Control": CACHE_HEADER },
+        },
+      );
     }
     if (typeof gateway !== "string" || !gateway) {
-      return new Response(JSON.stringify({
-        error: "invalid_request",
-        message: "gateway is required"
-      }), {
-        status: 400,
-        headers: {
-          ...corsHeaders,
-          "Content-Type": "application/json"
-        }
-      });
+      return new Response(
+        JSON.stringify({ error: "invalid_request", message: "gateway is required" }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json", "Cache-Control": CACHE_HEADER },
+        },
+      );
     }
-    const supabase = createClient(Deno.env.get("SUPABASE_URL"), Deno.env.get("SUPABASE_ANON_KEY"));
+    const supabase = createClient();
     const { data, error } = await supabase
       .rpc("get_public_gateway_credentials", { store_id, gateway })
       .maybeSingle();
     if (error) {
       errorLog("Query error", error);
-      return new Response(JSON.stringify({
-        error: "forbidden",
-        message: error.message
-      }), {
-        status: 403,
-        headers: {
-          ...corsHeaders,
-          "Content-Type": "application/json"
-        }
-      });
+      return new Response(
+        JSON.stringify({ error: "forbidden", message: error.message }),
+        {
+          status: 403,
+          headers: { ...corsHeaders, "Content-Type": "application/json", "Cache-Control": CACHE_HEADER },
+        },
+      );
     }
     const responsePayload = {
       publishable_key: data?.publishable_key ?? null,
       tokenization_key: data?.tokenization_key ?? null,
-      gateway: data?.gateway ?? gateway,
-      store_id: data?.store_id ?? store_id
+      gateway,
+      store_id,
     };
     log("response", responsePayload);
     return new Response(JSON.stringify(responsePayload), {
-      headers: {
-        ...corsHeaders,
-        "Content-Type": "application/json"
-      }
+      headers: { ...corsHeaders, "Content-Type": "application/json", "Cache-Control": CACHE_HEADER },
     });
   } catch (err) {
-    errorLog("Unexpected error", err);
     const message = err instanceof Error ? err.message : String(err);
-    return new Response(JSON.stringify({
-      error: "server_error",
-      message
-    }), {
+    const headers = {
+      ...(corsHeaders ?? {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "POST, OPTIONS",
+        "Access-Control-Allow-Headers": "authorization, apikey, content-type",
+        Vary: "Origin",
+      }),
+      "Content-Type": "application/json",
+      "Cache-Control": CACHE_HEADER,
+    };
+    return new Response(JSON.stringify({ error: "server_error", message }), {
       status: 500,
-      headers: {
-        ...corsHeaders,
-        "Content-Type": "application/json"
-      }
+      headers,
     });
   }
 });

--- a/supabase/functions/get_public_store_settings/index.ts
+++ b/supabase/functions/get_public_store_settings/index.ts
@@ -1,136 +1,152 @@
+// verify_jwt disabled at deploy; function is POST-only; returns safe fields
 import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "https://smoothr-cms.webflow.io",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-  "Access-Control-Allow-Headers": "authorization, apikey, content-type",
-  Vary: "Origin"
-};
-serve(async (req)=>{
-  const url = new URL(req.url);
-  const debug = url.searchParams.has("smoothr-debug");
-  const log = (...args)=>debug && console.log("[get_public_store_settings]", ...args);
-  const errorLog = (...args)=>debug && console.error("[get_public_store_settings]", ...args);
+import { getCorsHeaders } from "../_shared/cors.ts";
+
+const CACHE_HEADER = "public, max-age=60, stale-while-revalidate=600";
+
+const SAFE_FIELDS = new Set([
+  "store_id",
+  "theme",
+  "logo",
+  "currency",
+  "debug",
+  "api_base",
+  "platform",
+  "rate_source",
+  "base_currency",
+  "active_payment_gateway",
+  "account_deleted_redirect_url",
+  "dashboard_home_url",
+  "login_redirect_url",
+  "logout_redirect_url",
+  "password_reset_redirect_url",
+  "payment_failure_redirect_url",
+  "payment_success_redirect_url",
+  "signup_redirect_url",
+]);
+
+serve(async (req) => {
+  let corsHeaders: Record<string, string> | undefined;
   try {
+    corsHeaders = getCorsHeaders(req);
+    const url = new URL(req.url);
+    const debug = url.searchParams.has("smoothr-debug");
+    const log = (...args: any[]) => debug && console.log("[get_public_store_settings]", ...args);
+    const errorLog = (...args: any[]) => debug && console.error("[get_public_store_settings]", ...args);
     if (req.method === "OPTIONS") {
       return new Response(null, {
         status: 204,
-        headers: {
-          ...corsHeaders
-        }
+        headers: { ...corsHeaders, "Cache-Control": CACHE_HEADER },
       });
     }
     if (req.method !== "POST") {
-      return new Response(JSON.stringify({
-        error: "invalid_request",
-        message: "method must be POST"
-      }), {
-        status: 400,
-        headers: {
-          ...corsHeaders,
-          "Content-Type": "application/json"
-        }
-      });
+      return new Response(
+        JSON.stringify({ error: "invalid_request", message: "method must be POST" }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json", "Cache-Control": CACHE_HEADER },
+        },
+      );
     }
-    let body;
+    const contentType = req.headers.get("content-type");
+    if (!contentType || !contentType.toLowerCase().includes("application/json")) {
+      return new Response(
+        JSON.stringify({ error: "invalid_request", message: "content-type must be application/json" }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json", "Cache-Control": CACHE_HEADER },
+        },
+      );
+    }
+    let body: any;
     try {
       body = await req.json();
     } catch (err) {
       errorLog("Invalid JSON", err);
-      return new Response(JSON.stringify({
-        error: "invalid_request",
-        message: "invalid JSON body"
-      }), {
-        status: 400,
-        headers: {
-          ...corsHeaders,
-          "Content-Type": "application/json"
-        }
-      });
+      return new Response(
+        JSON.stringify({ error: "invalid_request", message: "invalid JSON body" }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json", "Cache-Control": CACHE_HEADER },
+        },
+      );
     }
     const { store_id } = body ?? {};
     if (typeof store_id !== "string" || !store_id) {
-      return new Response(JSON.stringify({
-        error: "invalid_request",
-        message: "store_id is required"
-      }), {
-        status: 400,
-        headers: {
-          ...corsHeaders,
-          "Content-Type": "application/json"
-        }
-      });
+      return new Response(
+        JSON.stringify({ error: "invalid_request", message: "store_id is required" }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json", "Cache-Control": CACHE_HEADER },
+        },
+      );
     }
     const authHeader = req.headers.get("Authorization");
-    const supabase = createClient(Deno.env.get("SUPABASE_URL"), Deno.env.get("SUPABASE_ANON_KEY"), authHeader ? {
-      global: {
-        headers: {
-          Authorization: authHeader
-        }
-      }
-    } : undefined);
+    const supabase = createClient(
+      undefined,
+      undefined,
+      authHeader ? { global: { headers: { Authorization: authHeader } } } : undefined,
+    );
     if (authHeader) {
       const { data: user, error } = await supabase.auth.getUser();
       if (error || !user?.user) {
-        return new Response(JSON.stringify({
-          error: "invalid_request",
-          message: "invalid token"
-        }), {
-          status: 401,
-          headers: {
-            ...corsHeaders,
-            "Content-Type": "application/json"
-          }
-        });
+        return new Response(
+          JSON.stringify({ error: "invalid_request", message: "invalid token" }),
+          {
+            status: 401,
+            headers: { ...corsHeaders, "Content-Type": "application/json", "Cache-Control": CACHE_HEADER },
+          },
+        );
       }
       const claimStoreId = user.user.user_metadata?.store_id;
       if (claimStoreId && claimStoreId !== store_id) {
-        return new Response(JSON.stringify({
-          error: "invalid_request",
-          message: "store_id claim mismatch"
-        }), {
-          status: 400,
-          headers: {
-            ...corsHeaders,
-            "Content-Type": "application/json"
-          }
-        });
+        return new Response(
+          JSON.stringify({ error: "invalid_request", message: "store_id claim mismatch" }),
+          {
+            status: 400,
+            headers: { ...corsHeaders, "Content-Type": "application/json", "Cache-Control": CACHE_HEADER },
+          },
+        );
       }
     }
-    const { data, error } = await supabase.rpc("get_public_store_settings", { p_store_id: store_id }).maybeSingle();
+    const { data, error } = await supabase
+      .rpc("get_public_store_settings", { p_store_id: store_id })
+      .maybeSingle();
     if (error) {
       errorLog("Query error", error);
-      return new Response(JSON.stringify({
-        error: "forbidden",
-        message: error.message
-      }), {
-        status: 403,
-        headers: {
-          ...corsHeaders,
-          "Content-Type": "application/json"
-        }
-      });
+      return new Response(
+        JSON.stringify({ error: "forbidden", message: error.message }),
+        {
+          status: 403,
+          headers: { ...corsHeaders, "Content-Type": "application/json", "Cache-Control": CACHE_HEADER },
+        },
+      );
     }
-    const sanitized = data ? Object.fromEntries(Object.entries(data).filter(([, v])=>v != null)) : {};
+    const sanitized = data
+      ? Object.fromEntries(
+          Object.entries(data).filter(([k, v]) => SAFE_FIELDS.has(k) && v != null),
+        )
+      : {};
     log("response", sanitized);
     return new Response(JSON.stringify(sanitized), {
-      headers: {
-        ...corsHeaders,
-        "Content-Type": "application/json"
-      }
+      headers: { ...corsHeaders, "Content-Type": "application/json", "Cache-Control": CACHE_HEADER },
     });
   } catch (err) {
-    errorLog("Unexpected error", err);
     const message = err instanceof Error ? err.message : String(err);
-    return new Response(JSON.stringify({
-      error: "server_error",
-      message
-    }), {
+    const headers = {
+      ...(corsHeaders ?? {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "POST, OPTIONS",
+        "Access-Control-Allow-Headers": "authorization, apikey, content-type",
+        Vary: "Origin",
+      }),
+      "Content-Type": "application/json",
+      "Cache-Control": CACHE_HEADER,
+    };
+    return new Response(JSON.stringify({ error: "server_error", message }), {
       status: 500,
-      headers: {
-        ...corsHeaders,
-        "Content-Type": "application/json"
-      }
+      headers,
     });
   }
 });


### PR DESCRIPTION
## Summary
- centralize CORS logic with configurable origins
- harden edge functions for POST-only JSON requests and return safe fields
- document new CORS behavior for get_public_store_settings and get_gateway_credentials

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897be8d2de88325ad0cd726a86e9e6c