### PR TITLE
chore: audit and fix broken imports

### DIFF
--- a/scripts/check-imports.mjs
+++ b/scripts/check-imports.mjs
@@ -1,0 +1,233 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const repoRoot = path.resolve(fileURLToPath(import.meta.url), '..', '..');
+const tmpFile = path.join(repoRoot, '.tmp', 'imports.raw.txt');
+const reportJson = path.join(repoRoot, '.tmp', 'imports.report.json');
+const reportCsv = path.join(repoRoot, '.tmp', 'imports.report.csv');
+
+// Extensions considered during resolution
+const extensions = ['.js', '.ts', '.mjs', '.cjs', '.jsx', '.tsx'];
+
+// Load tsconfig aliases
+function loadTsconfigAliases() {
+  const aliases = [];
+  const tsconfigPath = path.join(repoRoot, 'smoothr', 'tsconfig.json');
+  if (fs.existsSync(tsconfigPath)) {
+    try {
+      const tsconfig = JSON.parse(fs.readFileSync(tsconfigPath, 'utf8'));
+      const paths = tsconfig?.compilerOptions?.paths || {};
+      for (const key in paths) {
+        const normalizedKey = key.replace('*', '');
+        const targets = paths[key];
+        if (Array.isArray(targets) && targets.length > 0) {
+          let target = targets[0].replace('*', '');
+          const abs = path.resolve(path.dirname(tsconfigPath), target);
+          aliases.push({ from: normalizedKey, to: abs });
+        }
+      }
+    } catch (e) {
+      console.error('Failed to parse tsconfig.json:', e);
+    }
+  }
+  return aliases;
+}
+
+const aliases = loadTsconfigAliases();
+
+function applyAliases(spec) {
+  for (const a of aliases) {
+    if (spec.startsWith(a.from)) {
+      return { applied: true, path: path.join(a.to, spec.slice(a.from.length)) };
+    }
+  }
+  return { applied: false, path: spec };
+}
+
+function normalizeSpecifier(spec) {
+  const startsWithDot = spec.startsWith('./');
+  let norm = path.posix.normalize(spec).replace(/\\+/g, '/');
+  if (startsWithDot && !norm.startsWith('./')) {
+    norm = './' + norm;
+  }
+  return norm.endsWith('/') && !spec.endsWith('/') ? norm.slice(0, -1) : norm;
+}
+
+// Recursively find a case-correct path
+function findCaseCorrectPath(targetPath) {
+  const parts = targetPath.split(path.sep);
+  let current = path.isAbsolute(targetPath) ? path.sep : '';
+  for (const part of parts) {
+    if (!part) continue;
+    const dir = current || path.sep;
+    if (!fs.existsSync(dir)) return null;
+    const entries = fs.readdirSync(dir);
+    const match = entries.find(e => e.toLowerCase() === part.toLowerCase());
+    if (!match) return null;
+    current = path.join(dir, match);
+  }
+  return current;
+}
+
+function resolveLocal(fromFile, spec) {
+  const fileDir = path.dirname(fromFile);
+  let normalized = normalizeSpecifier(spec);
+  let absolute;
+  if (normalized.startsWith('/')) {
+    absolute = path.join(repoRoot, normalized);
+  } else {
+    const aliasRes = applyAliases(normalized);
+    normalized = aliasRes.applied ? normalized : normalized; // keep spec
+    absolute = aliasRes.applied
+      ? aliasRes.path
+      : path.resolve(fileDir, normalized);
+  }
+  const result = { resolved: false, fix: null, reason: '' };
+  const tryPaths = [];
+  const hasExt = path.extname(absolute) !== '';
+  if (fs.existsSync(absolute)) {
+    if (fs.statSync(absolute).isDirectory()) {
+      for (const ext of extensions) {
+        const idx = path.join(absolute, 'index' + ext);
+        if (fs.existsSync(idx)) {
+          const rel = path.relative(fileDir, idx).replace(/\\/g, '/');
+          let newSpec = rel.startsWith('.') ? rel : './' + rel;
+          const ext = path.extname(newSpec);
+          if (['.ts', '.tsx', '.jsx'].includes(ext)) {
+            newSpec = newSpec.slice(0, -ext.length) + '.js';
+          }
+          result.resolved = true;
+          result.fix = normalizeSpecifier(newSpec);
+          result.reason = 'directory-import';
+          return result;
+        }
+      }
+      result.reason = 'directory-missing-index';
+      return result;
+    }
+    // existing file, but check case
+    const caseCorrect = findCaseCorrectPath(absolute);
+    if (caseCorrect && caseCorrect !== absolute) {
+      const rel = path.relative(fileDir, caseCorrect).replace(/\\/g, '/');
+      let newSpec = rel.startsWith('.') ? rel : './' + rel;
+      result.resolved = true;
+      result.fix = normalizeSpecifier(newSpec);
+      result.reason = 'case-mismatch';
+      return result;
+    }
+    result.resolved = true;
+    return result;
+  }
+
+  if (hasExt) {
+    const base = absolute.slice(0, -path.extname(absolute).length);
+    for (const ext of extensions) {
+      tryPaths.push(base + ext);
+    }
+  } else {
+    for (const ext of extensions) {
+      tryPaths.push(absolute + ext);
+    }
+  }
+  for (const p of tryPaths) {
+    if (fs.existsSync(p)) {
+      const rel = path.relative(fileDir, p).replace(/\\/g, '/');
+      let newSpec = rel.startsWith('.') ? rel : './' + rel;
+      const ext = path.extname(newSpec);
+      if (['.ts', '.tsx', '.jsx'].includes(ext)) {
+        newSpec = newSpec.slice(0, -ext.length) + '.js';
+      }
+      result.resolved = true;
+      result.fix = normalizeSpecifier(newSpec);
+      result.reason = 'extension';
+      return result;
+    }
+  }
+
+  // case-insensitive search
+  const caseCorrect = findCaseCorrectPath(absolute);
+  if (caseCorrect && caseCorrect !== absolute) {
+    const rel = path.relative(fileDir, caseCorrect).replace(/\\/g, '/');
+    let newSpec = rel.startsWith('.') ? rel : './' + rel;
+    result.resolved = true;
+    result.fix = normalizeSpecifier(newSpec);
+    result.reason = 'case-mismatch';
+    return result;
+  }
+
+  // legacy storefronts path
+  if (spec.includes('storefronts/supabase/')) {
+    const newPath = spec.replace('storefronts/supabase/', 'supabase/');
+    const relCand = resolveLocal(fromFile, newPath);
+    if (relCand.resolved) {
+      result.resolved = true;
+      result.fix = relCand.fix || newPath;
+      result.reason = 'legacy-supabase-path';
+      return result;
+    }
+  }
+
+  result.reason = 'not-found';
+  return result;
+}
+
+function processFile(file, line, spec) {
+  const ext = path.extname(file);
+  if (!extensions.includes(ext)) return null;
+  const isLocal = spec.startsWith('./') || spec.startsWith('../') || spec.startsWith('/') || aliases.some(a => spec.startsWith(a.from));
+  const entry = { file, line, spec, reason: '', fix: '' };
+  if (!isLocal) return null; // ignore bare modules
+  const res = resolveLocal(file, spec);
+  if (!res.resolved) {
+    entry.reason = res.reason;
+    return entry;
+  }
+  if (res.fix && res.fix !== spec) {
+    entry.reason = res.reason;
+    entry.fix = res.fix;
+    applyFix(file, line, spec, res.fix);
+    return entry;
+  }
+  return null; // no issue
+}
+
+function applyFix(file, line, oldSpec, newSpec) {
+  const contents = fs.readFileSync(file, 'utf8').split('\n');
+  const idx = line - 1;
+  if (idx >= contents.length) return;
+  const regex = new RegExp(oldSpec.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g');
+  contents[idx] = contents[idx].replace(regex, newSpec);
+  fs.writeFileSync(file, contents.join('\n'));
+}
+
+function main() {
+  if (!fs.existsSync(tmpFile)) {
+    console.error('Missing', tmpFile);
+    process.exit(1);
+  }
+  const lines = fs.readFileSync(tmpFile, 'utf8').split('\n').filter(Boolean);
+  const seen = new Set();
+  const issues = [];
+  for (const l of lines) {
+    const [file, lineStr, ...rest] = l.split(':');
+    const lineNum = parseInt(lineStr, 10);
+    const content = rest.join(':');
+    const match = content.match(/['\"]([^'\"]+)['\"]/);
+    if (!match) continue;
+    const spec = match[1];
+    const key = file + ':' + lineNum + ':' + spec;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const issue = processFile(path.resolve(repoRoot, file), lineNum, spec);
+    if (issue) issues.push(issue);
+  }
+  fs.writeFileSync(reportJson, JSON.stringify(issues, null, 2));
+  const csvLines = ['file,line,original,failure_reason,fix'];
+  for (const i of issues) {
+    csvLines.push(`${i.file},${i.line},${i.spec},${i.reason},${i.fix}`);
+  }
+  fs.writeFileSync(reportCsv, csvLines.join('\n'));
+}
+
+main();

--- a/shared/checkout/createOrder.ts
+++ b/shared/checkout/createOrder.ts
@@ -1,4 +1,4 @@
-import { supabase } from '../supabase/serverClient';
+import { supabase } from '../supabase/serverClient.js';
 
 const generateOrderNumber =
   (globalThis as any).generateOrderNumber as ((storeId: string) => Promise<string>) | undefined;

--- a/shared/checkout/getStoreIntegration.ts
+++ b/shared/checkout/getStoreIntegration.ts
@@ -1,4 +1,4 @@
-import { createServerSupabaseClient } from '../supabase/serverClient';
+import { createServerSupabaseClient } from '../supabase/serverClient.js';
 
 // Add ?smoothr-debug to the URL to enable debug logging
 const debug =

--- a/shared/checkout/handleCheckout.ts
+++ b/shared/checkout/handleCheckout.ts
@@ -1,9 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { supabase, testMarker } from '../supabase/serverClient';
-import { findOrCreateCustomer } from '../lib/findOrCreateCustomer';
+import { supabase, testMarker } from '../supabase/serverClient.js';
+import { findOrCreateCustomer } from '../lib/findOrCreateCustomer.js';
 import crypto from 'crypto';
-import { validateCheckoutPayload } from './utils/validateCheckoutPayload';
-import { dedupeOrders } from './utils/dedupeOrders';
+import { validateCheckoutPayload } from './utils/validateCheckoutPayload.js';
+import { dedupeOrders } from './utils/dedupeOrders.js';
 
 interface CheckoutPayload {
   order_number?: string;

--- a/shared/checkout/providers/authorizeNet.ts
+++ b/shared/checkout/providers/authorizeNet.ts
@@ -1,4 +1,4 @@
-import { getStoreIntegration } from '../getStoreIntegration';
+import { getStoreIntegration } from '../getStoreIntegration.js';
 
 const env = process.env.AUTHNET_ENV === 'production' ? 'production' : 'sandbox';
 const baseUrl =

--- a/shared/checkout/providers/nmi.ts
+++ b/shared/checkout/providers/nmi.ts
@@ -4,7 +4,7 @@ const debug = process.env.SMOOTHR_DEBUG === 'true';
 const log = (...args: any[]) => debug && console.log('[Checkout NMI]', ...args);
 const err = (...args: any[]) => debug && console.error('[Checkout NMI]', ...args);
 
-import { getStoreIntegration } from '../getStoreIntegration';
+import { getStoreIntegration } from '../getStoreIntegration.js';
 
 interface NmiPayload {
   payment_token?: string;

--- a/shared/checkout/providers/paypal.ts
+++ b/shared/checkout/providers/paypal.ts
@@ -1,4 +1,4 @@
-import { getStoreIntegration } from '../getStoreIntegration';
+import { getStoreIntegration } from '../getStoreIntegration.js';
 
 const env = process.env.PAYPAL_ENV === 'live' ? 'live' : 'sandbox';
 const baseUrl =

--- a/shared/checkout/providers/stripeProvider.ts
+++ b/shared/checkout/providers/stripeProvider.ts
@@ -1,7 +1,7 @@
 import Stripe from 'stripe';
 import crypto from 'crypto';
-import { getStoreIntegration } from '../getStoreIntegration';
-import { createServerSupabaseClient } from '../../supabase/serverClient';
+import { getStoreIntegration } from '../getStoreIntegration.js';
+import { createServerSupabaseClient } from '../../supabase/serverClient.js';
 
 const debug = process.env.SMOOTHR_DEBUG === 'true';
 const log = (...args: any[]) => debug && console.log('[Checkout Stripe]', ...args);

--- a/shared/init.ts
+++ b/shared/init.ts
@@ -1,4 +1,4 @@
-import { createServerSupabaseClient } from './supabase/serverClient';
+import { createServerSupabaseClient } from './supabase/serverClient.js';
 
 const debug = process.env.SMOOTHR_DEBUG === 'true';
 const log = (...args: any[]) => debug && console.log('[generateOrderNumber]', ...args);

--- a/smoothr/pages/api/checkout/[provider].ts
+++ b/smoothr/pages/api/checkout/[provider].ts
@@ -1,8 +1,8 @@
 // For example `/api/checkout/nmi` resolves to this dynamic route.
 import type { NextApiRequest, NextApiResponse } from 'next';
 import '../../../../shared/init';
-import { handleCheckout } from 'shared/checkout/handleCheckout';
-import { applyCors } from '../../../../shared/utils/applyCors';
+import { handleCheckout } from '../../../../shared/checkout/handleCheckout.js';
+import { applyCors } from '../../../../shared/utils/applyCors.js';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const origin = process.env.CORS_ORIGIN || '*';

--- a/smoothr/pages/api/checkout/paypal/capture-order.ts
+++ b/smoothr/pages/api/checkout/paypal/capture-order.ts
@@ -1,8 +1,8 @@
 
 import type { NextApiRequest, NextApiResponse } from 'next';
 import PayPal from '@paypal/checkout-server-sdk';
-import { handleCheckout } from 'shared/checkout/handleCheckout';
-import { getStoreIntegration } from 'shared/checkout/getStoreIntegration';
+import { handleCheckout } from '../../../../../shared/checkout/handleCheckout.js';
+import { getStoreIntegration } from '../../../../../shared/checkout/getStoreIntegration.js';
 
 export default async function handler(
   req: NextApiRequest,

--- a/smoothr/pages/api/checkout/paypal/createPayPalOrder.ts
+++ b/smoothr/pages/api/checkout/paypal/createPayPalOrder.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import PayPal from '@paypal/checkout-server-sdk';
-import { getStoreIntegration } from 'shared/checkout/getStoreIntegration';
+import { getStoreIntegration } from '../../../../../shared/checkout/getStoreIntegration.js';
 
 
 

--- a/smoothr/pages/api/create-checkout-session.ts
+++ b/smoothr/pages/api/create-checkout-session.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import Stripe from 'stripe';
-import { createServerSupabaseClient } from 'shared/supabase/serverClient';
-import { getStoreIntegration } from 'shared/checkout/getStoreIntegration';
-import { applyCors } from '../../../shared/utils/applyCors';
+import { createServerSupabaseClient } from '../../../shared/supabase/serverClient.js';
+import { getStoreIntegration } from '../../../shared/checkout/getStoreIntegration.js';
+import { applyCors } from '../../../shared/utils/applyCors.js';
 
 const debug = process.env.SMOOTHR_DEBUG === 'true';
 const log = (...args: any[]) => debug && console.log('[create-checkout]', ...args);

--- a/smoothr/pages/api/createOrder.ts
+++ b/smoothr/pages/api/createOrder.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import 'shared/init';
-import { createServerSupabaseClient } from 'shared/supabase/serverClient';
-import { createOrder } from 'shared/checkout/createOrder';
-import { applyCors } from '../../../shared/utils/applyCors';
+import { createServerSupabaseClient } from '../../../shared/supabase/serverClient.js';
+import { createOrder } from '../../../shared/checkout/createOrder.js';
+import { applyCors } from '../../../shared/utils/applyCors.js';
 
 export default async function handler(
   req: NextApiRequest,

--- a/smoothr/pages/api/get-payment-key.js
+++ b/smoothr/pages/api/get-payment-key.js
@@ -1,6 +1,6 @@
 // pages/api/get-payment-key.js
 import { createClient } from '@supabase/supabase-js';
-import { applyCors } from '../../../shared/utils/applyCors';
+import { applyCors } from '../../../shared/utils/applyCors.js';
 
 export default async function handler(req, res) {
   const origin = process.env.CORS_ORIGIN || '*';

--- a/smoothr/pages/api/webhooks/stripeWebhook.ts
+++ b/smoothr/pages/api/webhooks/stripeWebhook.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import Stripe from "stripe";
-import { supabase } from "shared/supabase/serverClient";
+import { supabase } from "../../../../shared/supabase/serverClient.js";
 
 const debug = process.env.SMOOTHR_DEBUG === "true";
 const log = (...args: any[]) => debug && console.log("[Stripe Webhook]", ...args);

--- a/supabase/functions/proxy-live-rates/handler.test.ts
+++ b/supabase/functions/proxy-live-rates/handler.test.ts
@@ -5,7 +5,7 @@ let handleRequest: (req: Request, fetchFn?: typeof fetch) => Promise<Response>;
 describe.skip('handleRequest', () => {
   beforeEach(async () => {
     (globalThis as any).Deno = { env: { get: () => 'token' } };
-    ({ handleRequest } = await import('./handler'));
+    ({ handleRequest } = await import('./handler.js'));
   });
 
   afterEach(() => {
@@ -85,7 +85,7 @@ describe.skip('token missing', () => {
   it('returns 500 when token is absent', async () => {
     (globalThis as any).Deno = { env: { get: () => undefined } };
     const fetchFn = vi.fn();
-    ({ handleRequest } = await import('./handler'));
+    ({ handleRequest } = await import('./handler.js'));
     global.fetch = fetchFn as any;
     const res = await handleRequest(new Request('https://example.com'));
     expect(fetchFn).not.toHaveBeenCalled();

--- a/supabase/functions/store-tables.test.ts
+++ b/supabase/functions/store-tables.test.ts
@@ -7,7 +7,7 @@ let integrationsBuilder: any
 
 async function loadClient() {
 
-  supabase = (await import('../../shared/supabase/serverClient')).supabase
+  supabase = (await import('../../shared/supabase/serverClient.js')).supabase
 
 }
 

--- a/supabase/functions/supabaseClientHeaders.test.ts
+++ b/supabase/functions/supabaseClientHeaders.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { supabase } from '../../shared/supabase/serverClient'
+import { supabase } from '../../shared/supabase/serverClient.js'
 
 describe('supabase client headers', () => {
   it('includes default authorization headers', () => {


### PR DESCRIPTION
## Summary
- add `scripts/check-imports.mjs` to verify and auto-fix local imports
- normalize local imports to explicit `.js` specifiers across shared and API modules

## Testing
- `npm ci`
- `npm run build --workspaces=false` *(fails: Missing script "build")*
- `npm test` *(fails: 2 failing tests in storefronts)*

------
https://chatgpt.com/codex/tasks/task_e_6898c32ce91c8325bcad0f36468a6671