### PR TITLE
chore: add import verification scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
   "scripts": {
     "test": "npm --workspace storefronts test && npm run test:supabase",
     "test:supabase": "vitest run supabase/functions",
-    "postinstall": "node scripts/postinstall.js"
+    "postinstall": "node scripts/postinstall.js",
+    "verify:server-imports": "node scripts/verify-server-imports.mjs",
+    "verify:sdk-imports": "node scripts/verify-sdk-imports.mjs",
+    "prebuild": "npm run verify:server-imports && npm run verify:sdk-imports",
+    "build": "npm -ws run build"
   },
   "devDependencies": {
     "@supabase/supabase-js": "^2.52.1",

--- a/scripts/verify-sdk-imports.mjs
+++ b/scripts/verify-sdk-imports.mjs
@@ -1,0 +1,53 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const repoRoot = path.resolve(fileURLToPath(import.meta.url), '..', '..');
+const rootDir = path.join(repoRoot, 'storefronts');
+const exts = ['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs'];
+const warnings = [];
+
+function isUrl(spec) {
+  return spec.startsWith('http://') || spec.startsWith('https://');
+}
+
+function isExternal(spec) {
+  return !isUrl(spec) && /^[a-zA-Z@][^:]*$/.test(spec);
+}
+
+function isLocal(spec) {
+  return spec.startsWith('./') || spec.startsWith('../') || spec.startsWith('/');
+}
+
+function scanFile(file) {
+  const lines = fs.readFileSync(file, 'utf8').split('\n');
+  lines.forEach((line, idx) => {
+    const match = line.match(/import\s+(?:[^'"\n]+?from\s*)?['"]([^'"\n]+)['"]/);
+    if (!match) return;
+    const spec = match[1];
+    if (isExternal(spec) || !isLocal(spec) || spec.endsWith('.js')) return;
+    warnings.push(`${path.relative(repoRoot, file)}:${idx + 1}: ${spec}`);
+  });
+}
+
+function walk(dir) {
+  if (!fs.existsSync(dir)) return;
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full);
+    } else if (exts.includes(path.extname(entry.name))) {
+      scanFile(full);
+    }
+  }
+}
+
+walk(rootDir);
+
+if (warnings.length) {
+  warnings.forEach(w => console.warn(w));
+  console.warn(`Found ${warnings.length} local import(s) without .js extension`);
+} else {
+  console.log('All SDK local imports use .js extension');
+}

--- a/scripts/verify-server-imports.mjs
+++ b/scripts/verify-server-imports.mjs
@@ -1,0 +1,56 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const repoRoot = path.resolve(fileURLToPath(import.meta.url), '..', '..');
+const dirs = ['shared', 'smoothr'];
+const exts = ['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs'];
+const offenders = [];
+
+function isUrl(spec) {
+  return spec.startsWith('http://') || spec.startsWith('https://');
+}
+
+function isExternal(spec) {
+  return !isUrl(spec) && /^[a-zA-Z@][^:]*$/.test(spec);
+}
+
+function isLocal(spec) {
+  return spec.startsWith('./') || spec.startsWith('../') || spec.startsWith('/') || spec.startsWith('shared/') || spec.startsWith('smoothr/');
+}
+
+function scanFile(file) {
+  const lines = fs.readFileSync(file, 'utf8').split('\n');
+  lines.forEach((line, idx) => {
+    const match = line.match(/import\s+(?:[^'"\n]+?from\s*)?['"]([^'"\n]+)['"]/);
+    if (!match) return;
+    const spec = match[1];
+    if (isExternal(spec) || !isLocal(spec) || !spec.endsWith('.js')) return;
+    offenders.push(`${path.relative(repoRoot, file)}:${idx + 1}: ${spec}`);
+  });
+}
+
+function walk(dir) {
+  if (!fs.existsSync(dir)) return;
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full);
+    } else if (exts.includes(path.extname(entry.name))) {
+      scanFile(full);
+    }
+  }
+}
+
+for (const d of dirs) {
+  walk(path.join(repoRoot, d));
+}
+
+if (offenders.length) {
+  offenders.forEach(o => console.error(o));
+  console.error(`Found ${offenders.length} local import(s) ending in .js`);
+  process.exit(1);
+}
+
+console.log('No local .js imports found in server code');

--- a/smoothr/pages/api/checkout/[provider].ts
+++ b/smoothr/pages/api/checkout/[provider].ts
@@ -1,8 +1,8 @@
 // For example `/api/checkout/nmi` resolves to this dynamic route.
 import type { NextApiRequest, NextApiResponse } from 'next';
-import '../../../../shared/init';
-import { handleCheckout } from '../../../../shared/checkout/handleCheckout';
-import { applyCors } from '../../../../shared/utils/applyCors.js';
+import 'shared/init';
+import { handleCheckout } from 'shared/checkout/handleCheckout';
+import { applyCors } from 'shared/utils/applyCors';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const origin = process.env.CORS_ORIGIN || '*';

--- a/smoothr/pages/api/checkout/paypal/capture-order.ts
+++ b/smoothr/pages/api/checkout/paypal/capture-order.ts
@@ -1,8 +1,8 @@
 
 import type { NextApiRequest, NextApiResponse } from 'next';
 import PayPal from '@paypal/checkout-server-sdk';
-import { handleCheckout } from '../../../../../shared/checkout/handleCheckout';
-import { getStoreIntegration } from '../../../../../shared/checkout/getStoreIntegration';
+import { handleCheckout } from 'shared/checkout/handleCheckout';
+import { getStoreIntegration } from 'shared/checkout/getStoreIntegration';
 
 export default async function handler(
   req: NextApiRequest,

--- a/smoothr/pages/api/createOrder.ts
+++ b/smoothr/pages/api/createOrder.ts
@@ -2,7 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import 'shared/init';
 import { createServerSupabaseClient } from 'shared/supabase/serverClient';
 import { createOrder } from 'shared/checkout/createOrder';
-import { applyCors } from '../../../shared/utils/applyCors.js';
+import { applyCors } from 'shared/utils/applyCors';
 
 export default async function handler(
   req: NextApiRequest,

--- a/smoothr/pages/api/get-payment-key.js
+++ b/smoothr/pages/api/get-payment-key.js
@@ -1,6 +1,6 @@
 // pages/api/get-payment-key.js
 import { createClient } from '@supabase/supabase-js';
-import { applyCors } from '../../../shared/utils/applyCors.js';
+import { applyCors } from 'shared/utils/applyCors';
 
 export default async function handler(req, res) {
   const origin = process.env.CORS_ORIGIN || '*';

--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -3,7 +3,7 @@ import {
   ensureSupabaseSessionAuth
 } from '../../../supabase/browserClient.js';
 import * as authExports from './index.js';
-import { loadPublicConfig } from '../config/sdkConfig.ts';
+import { loadPublicConfig } from '../config/sdkConfig.js';
 import * as currency from '../currency/index.js';
 import { getConfig, mergeConfig } from '../config/globalConfig.js';
 

--- a/storefronts/features/checkout/init.js
+++ b/storefronts/features/checkout/init.js
@@ -11,7 +11,7 @@ import {
   disableButton,
   enableButton
 } from './utils/cartHash.js';
-import { loadPublicConfig } from '../config/sdkConfig.ts';
+import { loadPublicConfig } from '../config/sdkConfig.js';
 import { getConfig, mergeConfig } from '../config/globalConfig.js';
 import { platformReady } from '../../utils/platformReady.js';
 import loadScriptOnce from '../../utils/loadScriptOnce.js';

--- a/storefronts/features/config/sdkConfig.js
+++ b/storefronts/features/config/sdkConfig.js
@@ -2,10 +2,10 @@ import supabase from '../../../supabase/browserClient.js';
 import { getConfig } from './globalConfig.js';
 
 const debug = typeof window !== 'undefined' && getConfig().debug;
-const log = (...args: any[]) => debug && console.log('[Smoothr Config]', ...args);
-const warn = (...args: any[]) => debug && console.warn('[Smoothr Config]', ...args);
+const log = (...args) => debug && console.log('[Smoothr Config]', ...args);
+const warn = (...args) => debug && console.warn('[Smoothr Config]', ...args);
 
-export async function loadPublicConfig(storeId: string) {
+export async function loadPublicConfig(storeId) {
   if (!storeId) return null;
 
   try {
@@ -15,7 +15,7 @@ export async function loadPublicConfig(storeId: string) {
     const access_token = session?.access_token;
     const supabaseUrl = supabase.supabaseUrl || process.env.NEXT_PUBLIC_SUPABASE_URL;
 
-    const headers: Record<string, string> = {
+    const headers = {
       'Content-Type': 'application/json',
       apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
     };
@@ -37,7 +37,7 @@ export async function loadPublicConfig(storeId: string) {
     const data = await res.json();
     log('Config fetched');
     return data || null;
-  } catch (e: any) {
+  } catch (e) {
     warn('Store settings fetch error:', e?.message || e);
     return null;
   }

--- a/storefronts/smoothr-sdk.js
+++ b/storefronts/smoothr-sdk.js
@@ -1,5 +1,5 @@
 import { mergeConfig } from './features/config/globalConfig.js';
-import { loadPublicConfig } from './features/config/sdkConfig.ts';
+import { loadPublicConfig } from './features/config/sdkConfig.js';
 
 // Ensure legacy global currency helper exists
 if (typeof globalThis.setSelectedCurrency !== 'function') {

--- a/storefronts/tests/sdk/auth-idempotent.test.js
+++ b/storefronts/tests/sdk/auth-idempotent.test.js
@@ -14,7 +14,7 @@ vi.mock('../../features/auth/index.js', () => {
   return { default: authMock, ...authMock };
 });
 
-vi.mock('../../features/config/sdkConfig.ts', () => ({
+vi.mock('../../features/config/sdkConfig.js', () => ({
   loadPublicConfig: vi.fn().mockResolvedValue({}),
 }));
 

--- a/storefronts/tests/sdk/gateway-dispatch.test.js
+++ b/storefronts/tests/sdk/gateway-dispatch.test.js
@@ -34,7 +34,7 @@ function setupEnv(modulePath) {
   trackMock("../../features/checkout/utils/inputFormatters.js", () => ({
     default: vi.fn()
   }));
-  trackMock("../../features/config/sdkConfig.ts", () => ({
+  trackMock("../../features/config/sdkConfig.js", () => ({
     loadPublicConfig: vi.fn(async () => null)
   }));
   trackMock("../../features/config/globalConfig.js", () => {

--- a/storefronts/tests/sdk/gateway-loader.test.js
+++ b/storefronts/tests/sdk/gateway-loader.test.js
@@ -35,7 +35,7 @@ function setupEnv(provider, modulePath) {
   trackMock("../../features/checkout/utils/inputFormatters.js", () => ({
     default: vi.fn()
   }));
-  trackMock("../../features/config/sdkConfig.ts", () => ({
+  trackMock("../../features/config/sdkConfig.js", () => ({
     loadPublicConfig: vi.fn(async () => null)
   }));
   trackMock("../../features/config/globalConfig.js", () => {

--- a/storefronts/tests/sdk/load-config-api-base.test.js
+++ b/storefronts/tests/sdk/load-config-api-base.test.js
@@ -87,7 +87,7 @@ describe('loadConfig api_base mapping', () => {
   it('sets apiBase from supabase config', async () => {
     console.log('Starting test: loadConfig api_base mapping');
     const { loadPublicConfig } = await import(
-      '../../features/config/sdkConfig.ts'
+      '../../features/config/sdkConfig.js'
     );
     const { mergeConfig } = await import(
       '../../features/config/globalConfig.js'

--- a/storefronts/tests/sdk/load-config-merge.test.js
+++ b/storefronts/tests/sdk/load-config-merge.test.js
@@ -86,7 +86,7 @@ describe('loadConfig merge', () => {
   it('preserves existing config values', async () => {
     console.log('Starting test: loadConfig merge');
     const { loadPublicConfig } = await import(
-      '../../features/config/sdkConfig.ts'
+      '../../features/config/sdkConfig.js'
     );
     const { mergeConfig } = await import(
       '../../features/config/globalConfig.js'

--- a/supabase/authHelpers.js
+++ b/supabase/authHelpers.js
@@ -1,5 +1,5 @@
 import { supabase } from './browserClient.js';
-import { loadPublicConfig } from '../storefronts/features/config/sdkConfig.ts';
+import { loadPublicConfig } from '../storefronts/features/config/sdkConfig.js';
 
 const globalScope = typeof window !== 'undefined' ? window : globalThis;
 const SMOOTHR_CONFIG = globalScope.SMOOTHR_CONFIG || {};


### PR DESCRIPTION
## Summary
- guard server code from local .js imports
- warn when SDK local imports omit .js extension
- convert storefront SDK config to .js and align imports

## Testing
- `npm run verify:server-imports`
- `npm run verify:sdk-imports`
- `npm --workspace=storefronts run build`
- `npm --workspace=smoothr run build`
- `npm --workspace=storefronts test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6898d7597a708325a0e19cd92281b115