### PR TITLE
test: add shared alias for vitest

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig } from 'vitest/config';
-import { resolve } from 'path';
+import path from 'node:path';
+
+// Resolve repo root based on this config file location
+const repoRoot = __dirname;
 
 export default defineConfig({
   test: {
@@ -9,11 +12,17 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@': resolve(__dirname, 'smoothr'),
-      '@/lib/findOrCreateCustomer': resolve(
-        __dirname,
+      '@': path.resolve(repoRoot, 'smoothr'),
+      '@/lib/findOrCreateCustomer': path.resolve(
+        repoRoot,
         'shared/lib/findOrCreateCustomer.ts'
       ),
+      // Admin/server shared code referenced by storefront tests
+      shared: path.resolve(repoRoot, 'shared'),
+      'shared/*': path.resolve(repoRoot, 'shared'),
+      // Optional: if any tests import admin app files by alias later
+      smoothr: path.resolve(repoRoot, 'smoothr'),
+      'smoothr/*': path.resolve(repoRoot, 'smoothr'),
     },
   },
 });


### PR DESCRIPTION
## Summary
- map `shared/*` to the repo's shared directory in `vitest.config.ts`
- add optional `smoothr/*` alias for future imports

## Testing
- `npm --workspace=storefronts run test --silent -- tests/api/get-payment-key.test.ts`
- `npm --workspace=storefronts run test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6898de06eda883258f2b27a84dd0b85d