### PR TITLE
Handle anonymous config & credential requests in SDK

### DIFF
--- a/storefronts/features/config/sdkConfig.js
+++ b/storefronts/features/config/sdkConfig.js
@@ -3,34 +3,55 @@ import { getConfig } from './globalConfig.js';
 
 const debug = typeof window !== 'undefined' && getConfig().debug;
 const log = (...args) => debug && console.log('[Smoothr Config]', ...args);
-const warn = (...args) => debug && console.warn('[Smoothr Config]', ...args);
+const warn = (...args) => console.warn('[Smoothr Config]', ...args);
 
 export async function loadPublicConfig(storeId) {
   if (!storeId) return null;
 
   try {
     const {
-      data: { session },
+      data: { session }
     } = await supabase.auth.getSession();
     const access_token = session?.access_token;
-    const supabaseUrl = supabase.supabaseUrl || process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const supabaseUrl =
+      supabase.supabaseUrl || process.env.NEXT_PUBLIC_SUPABASE_URL;
 
     const headers = {
       'Content-Type': 'application/json',
-      apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+      apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
     };
     if (access_token) {
       headers.Authorization = `Bearer ${access_token}`;
     }
 
-    const res = await fetch(`${supabaseUrl}/functions/v1/get_public_store_settings`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({ store_id: storeId }),
-    });
+    const body = JSON.stringify({ store_id: storeId });
+    let res = await fetch(
+      `${supabaseUrl}/functions/v1/get_public_store_settings`,
+      {
+        method: 'POST',
+        headers,
+        body
+      }
+    );
+
+    if ((res.status === 401 || res.status === 403) && headers.Authorization) {
+      warn(
+        'Store settings lookup failed with auth header:',
+        res.status
+      );
+      delete headers.Authorization;
+      res = await fetch(
+        `${supabaseUrl}/functions/v1/get_public_store_settings`,
+        { method: 'POST', headers, body }
+      );
+    }
 
     if (!res.ok) {
-      warn('Store settings lookup failed:', res.status);
+      let msg = '';
+      try {
+        msg = await res.text();
+      } catch {}
+      warn('Store settings lookup failed:', res.status, msg);
       return null;
     }
 


### PR DESCRIPTION
## Summary
- Retry public config and gateway credential lookups without auth when initial call fails
- Abort checkout init if config fetch fails and log auth state during gateway mount
- Harden config loader to throw on missing data

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68991197f3688325ae3a1ea6d781cf79