### PR TITLE
feat: include Supabase anon key in SDK requests

### DIFF
--- a/storefronts/features/config/sdkConfig.js
+++ b/storefronts/features/config/sdkConfig.js
@@ -1,6 +1,17 @@
 import supabase from '../../../supabase/browserClient.js';
 import { getConfig } from './globalConfig.js';
 
+export const SUPABASE_URL = 'https://lpuqrzvokroazwlricgn.supabase.co';
+export const SUPABASE_ANON_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImxwdXFyenZva3JvYXp3bHJpY2duIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk3MTM2MzQsImV4cCI6MjA2NTI4OTYzNH0.bIItSJMzdx9BgXm5jOtTFI03yq94CLVHepiPQ0Xl_lU';
+
+const sdkConfig = {
+  supabaseUrl: SUPABASE_URL,
+  anonKey: SUPABASE_ANON_KEY
+};
+
+Object.assign(getConfig(), sdkConfig);
+
 const debug = typeof window !== 'undefined' && getConfig().debug;
 const log = (...args) => debug && console.log('[Smoothr Config]', ...args);
 const warn = (...args) => console.warn('[Smoothr Config]', ...args);
@@ -13,9 +24,13 @@ export async function loadPublicConfig(storeId) {
       data: { session }
     } = await supabase.auth.getSession();
     const access_token = session?.access_token;
+    const cfg = getConfig();
     const supabaseUrl =
-      supabase.supabaseUrl || process.env.NEXT_PUBLIC_SUPABASE_URL;
-    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+      cfg.supabaseUrl ||
+      supabase.supabaseUrl ||
+      process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const anonKey =
+      cfg.anonKey || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
     const headers = {
       'Content-Type': 'application/json',
@@ -62,3 +77,5 @@ export async function loadPublicConfig(storeId) {
     return null;
   }
 }
+
+export default sdkConfig;

--- a/storefronts/features/currency/fetchLiveRates.js
+++ b/storefronts/features/currency/fetchLiveRates.js
@@ -1,13 +1,15 @@
 import { getConfig } from '../config/globalConfig.js';
+import sdkConfig from '../config/sdkConfig.js';
 
 const debug = typeof window !== 'undefined' && getConfig().debug;
 const log = (...args) => debug && console.log('[Smoothr Rates]', ...args);
 
 function getSupabaseUrl() {
   return (
-    (typeof window !== 'undefined' && window.SMOOTHR_CONFIG?.supabaseUrl) ||
     (typeof import.meta !== 'undefined' && import.meta.env?.VITE_SUPABASE_URL) ||
-    (typeof process !== 'undefined' && process.env.SUPABASE_URL)
+    (typeof process !== 'undefined' && process.env.SUPABASE_URL) ||
+    getConfig().supabaseUrl ||
+    sdkConfig?.supabaseUrl
   );
 }
 
@@ -22,7 +24,7 @@ function resolveDefaultSource() {
   if (envRate) return envRate;
   const supabase = getSupabaseUrl();
   return supabase
-    ? `${supabase.replace('.co', '.co/functions')}/proxy-live-rates`
+    ? `${supabase.replace('.supabase.co', '.functions.supabase.co')}/proxy-live-rates`
     : null;
 }
 
@@ -70,7 +72,10 @@ export async function fetchExchangeRates(
     }
     try {
       const proxyEndpoint = getSupabaseUrl()
-        ? `${getSupabaseUrl().replace('.co', '.co/functions')}/proxy-live-rates`
+        ? `${getSupabaseUrl().replace(
+            '.supabase.co',
+            '.functions.supabase.co'
+          )}/proxy-live-rates`
         : null;
       const { hostname, pathname } = new URL(url);
       if (proxyEndpoint) {
@@ -80,7 +85,9 @@ export async function fetchExchangeRates(
             (typeof import.meta !== 'undefined' &&
               import.meta.env?.VITE_SUPABASE_ANON_KEY) ||
             (typeof process !== 'undefined' &&
-              process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY);
+              process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) ||
+            getConfig().anonKey ||
+            sdkConfig?.anonKey;
           if (anonKey) {
             headers.Authorization = `Bearer ${anonKey}`;
           }


### PR DESCRIPTION
## Summary
- add Supabase URL and anon key to SDK config
- authorize gateway credential requests with anon key
- send anon key when fetching live currency rates

## Testing
- `npm test` *(fails: 14)*

------
https://chatgpt.com/codex/tasks/task_e_689a20a0e57083258d0f304239feac56