### PR TITLE
Refactor CORS handling for get_public_store_settings

### DIFF
--- a/storefronts/tests/functions/get_public_store_settings.cors.test.ts
+++ b/storefronts/tests/functions/get_public_store_settings.cors.test.ts
@@ -21,10 +21,9 @@ function expectCors(res: Response) {
 
 beforeEach(() => {
   handler = undefined as any;
-  (globalThis as any).Deno = {
-    env: { get: (k: string) => (k === "ALLOWED_ORIGINS" ? testOrigin : "") },
-  };
+  (globalThis as any).Deno = { env: { get: () => "" } };
   createClientMock = vi.fn(() => ({
+    rpc: vi.fn(async () => ({ data: [testOrigin], error: null })),
     from: () => ({
       select: () => ({
         eq: () => ({
@@ -56,7 +55,10 @@ describe("get_public_store_settings CORS", () => {
       "../../../supabase/functions/get_public_store_settings/index.ts"
     );
     const res = await handler(
-      new Request("http://localhost", { method: "OPTIONS", headers: { Origin: testOrigin } }),
+      new Request("http://localhost?store_id=s1", {
+        method: "OPTIONS",
+        headers: { Origin: testOrigin },
+      }),
     );
     expect(res.status).toBe(204);
     expectCors(res);


### PR DESCRIPTION
## Summary
- resolve allowed origins per store via `get_allowed_hosts`
- read `store_id` from query, header, or body and enforce CORS
- update CORS tests for per-store origin checks

## Testing
- `npm test` *(fails: many tests failing)*
- `npm run test:supabase` *(fails: Missing Supabase credentials, CORS expectations)*
- `npx vitest run storefronts/tests/functions/get_public_store_settings.cors.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689a2c5683788325993558f6b0c4db1b