### PR TITLE
Ensure CORS headers on error responses

### DIFF
--- a/supabase/functions/get_gateway_credentials/index.ts
+++ b/supabase/functions/get_gateway_credentials/index.ts
@@ -1,11 +1,11 @@
 import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import {
+  getAllowedHostsForStore,
+  hostFromOrigin,
+  isAllowedOrigin,
   preflight,
   withCors,
-  hostFromOrigin,
-  getAllowedHostsForStore,
-  isAllowedOrigin,
 } from "../_shared/cors.ts";
 
 serve(async (req) => {
@@ -27,7 +27,10 @@ serve(async (req) => {
   try {
     if (req.method === "OPTIONS") {
       if (!wildcard && (!originHost || !allowlist.includes(originHost))) {
-        return new Response("origin not allowed", { status: 403 });
+        return withCors(
+          new Response("origin not allowed", { status: 403 }),
+          origin || "*",
+        );
       }
       return preflight(origin || "*");
     }
@@ -42,9 +45,9 @@ serve(async (req) => {
           {
             status: 400,
             headers: { "Content-Type": "application/json" },
-          }
+          },
         ),
-        origin || "*"
+        origin || "*",
       );
     }
 
@@ -62,9 +65,9 @@ serve(async (req) => {
           {
             status: 400,
             headers: { "Content-Type": "application/json" },
-          }
+          },
         ),
-        origin || "*"
+        origin || "*",
       );
     }
 
@@ -86,9 +89,9 @@ serve(async (req) => {
           {
             status: 400,
             headers: { "Content-Type": "application/json" },
-          }
+          },
         ),
-        origin || "*"
+        origin || "*",
       );
     }
 
@@ -102,9 +105,9 @@ serve(async (req) => {
           {
             status: 400,
             headers: { "Content-Type": "application/json" },
-          }
+          },
         ),
-        origin || "*"
+        origin || "*",
       );
     }
 
@@ -114,7 +117,7 @@ serve(async (req) => {
       Deno.env.get("SUPABASE_ANON_KEY")!,
       authHeader
         ? { global: { headers: { Authorization: authHeader } } }
-        : undefined
+        : undefined,
     );
 
     if (authHeader) {
@@ -129,7 +132,7 @@ serve(async (req) => {
             {
               status: 401,
               headers: { "Content-Type": "application/json" },
-            }
+            },
           ),
           origin || "*",
         );
@@ -145,8 +148,8 @@ serve(async (req) => {
             {
               status: 400,
               headers: { "Content-Type": "application/json" },
-            }
-            ),
+            },
+          ),
           origin || "*",
         );
       }
@@ -155,7 +158,10 @@ serve(async (req) => {
     if (!wildcard && (!originHost || !allowlist.includes(originHost))) {
       const allowed = await getAllowedHostsForStore(store_id, supabase);
       if (allowed.size === 0 || !isAllowedOrigin(originHost, allowed)) {
-        return new Response("Origin not allowed", { status: 403 });
+        return withCors(
+          new Response("Origin not allowed", { status: 403 }),
+          origin || "*",
+        );
       }
     }
 

--- a/supabase/functions/get_public_store_settings/index.ts
+++ b/supabase/functions/get_public_store_settings/index.ts
@@ -1,6 +1,6 @@
 import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { preflight, withCors, hostFromOrigin } from "../_shared/cors.ts";
+import { hostFromOrigin, preflight, withCors } from "../_shared/cors.ts";
 
 serve(async (req) => {
   const origin = req.headers.get("Origin") || "";
@@ -14,8 +14,8 @@ serve(async (req) => {
 
   try {
     if (req.method === "OPTIONS") {
-      const storeId =
-        url.searchParams.get("store_id") || req.headers.get("X-Store-Id");
+      const storeId = url.searchParams.get("store_id") ||
+        req.headers.get("X-Store-Id");
       if (typeof storeId !== "string" || !storeId) {
         return withCors(
           new Response(
@@ -28,7 +28,7 @@ serve(async (req) => {
               headers: { "Content-Type": "application/json" },
             },
           ),
-          origin,
+          origin || "*",
         );
       }
       const supabase = createClient(
@@ -47,10 +47,10 @@ serve(async (req) => {
       if (!originHost || !allowedHosts.has(originHost)) {
         return withCors(
           new Response("Origin not allowed", { status: 403 }),
-          origin,
+          origin || "*",
         );
       }
-      return preflight(origin);
+      return preflight(origin || "*");
     }
 
     if (req.method !== "POST") {
@@ -65,7 +65,7 @@ serve(async (req) => {
             headers: { "Content-Type": "application/json" },
           },
         ),
-        origin,
+        origin || "*",
       );
     }
 
@@ -85,7 +85,7 @@ serve(async (req) => {
             headers: { "Content-Type": "application/json" },
           },
         ),
-        origin,
+        origin || "*",
       );
     }
 
@@ -103,7 +103,7 @@ serve(async (req) => {
             headers: { "Content-Type": "application/json" },
           },
         ),
-        origin,
+        origin || "*",
       );
     }
 
@@ -130,7 +130,7 @@ serve(async (req) => {
               headers: { "Content-Type": "application/json" },
             },
           ),
-          origin,
+          origin || "*",
         );
       }
       const claimStoreId = user.user.user_metadata?.store_id;
@@ -146,7 +146,7 @@ serve(async (req) => {
               headers: { "Content-Type": "application/json" },
             },
           ),
-          origin,
+          origin || "*",
         );
       }
     }
@@ -163,7 +163,7 @@ serve(async (req) => {
     if (!originHost || !allowedHosts.has(originHost)) {
       return withCors(
         new Response("Origin not allowed", { status: 403 }),
-        origin,
+        origin || "*",
       );
     }
 
@@ -183,7 +183,7 @@ serve(async (req) => {
             headers: { "Content-Type": "application/json" },
           },
         ),
-        origin,
+        origin || "*",
       );
     }
 
@@ -197,7 +197,7 @@ serve(async (req) => {
       new Response(JSON.stringify(sanitized), {
         headers: { "Content-Type": "application/json" },
       }),
-      origin,
+      origin || "*",
     );
   } catch (err) {
     errorLog("Unexpected error", err);
@@ -207,8 +207,7 @@ serve(async (req) => {
         status: 500,
         headers: { "Content-Type": "application/json" },
       }),
-      origin,
+      origin || "*",
     );
   }
 });
-


### PR DESCRIPTION
## Summary
- Default CORS headers to `*` when no Origin is provided in `get_public_store_settings`
- Wrap gateway credential errors with `withCors` and allow wildcard origins

## Testing
- `npm run supabase:fmt`
- `npm test` *(fails: AssertionError expected "spy" to be called...)*

------
https://chatgpt.com/codex/tasks/task_e_689a2e3e39588325a487cc361f9fd24e