### PR TITLE
chore: alias supabase for vitest

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     alias: {
       '@': path.resolve(repoRoot, 'smoothr'),
       '@/lib/findOrCreateCustomer': path.resolve(repoRoot, 'shared/lib/findOrCreateCustomer.ts'),
+      'npm:@supabase/supabase-js@2.38.4': '@supabase/supabase-js',
       shared: path.resolve(repoRoot, 'shared'),
       'shared/*': path.resolve(repoRoot, 'shared'),
       smoothr: path.resolve(repoRoot, 'smoothr'),


### PR DESCRIPTION
## Summary
- map `npm:@supabase/supabase-js@2.38.4` to the existing `@supabase/supabase-js` alias in Vitest config
- ensure Supabase client remains in inline deps for Vitest

## Testing
- `npm test` *(fails: Deno.serve is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689a7d3ee95483258217531980fd2f4c