### PR TITLE
Defang get-payment-key route and mark deprecated

### DIFF
--- a/storefronts/tests/api/get-payment-key.test.ts
+++ b/storefronts/tests/api/get-payment-key.test.ts
@@ -4,7 +4,8 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 let handler;
 let fromFn;
 let createClientMock;
-const originalEnv = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const originalUrl = process.env.SUPABASE_URL;
+const originalAnon = process.env.SUPABASE_ANON_KEY;
 
 vi.mock('@supabase/supabase-js', () => {
   createClientMock = vi.fn(() => ({ from: fromFn }));
@@ -19,32 +20,46 @@ async function loadModule() {
 beforeEach(async () => {
   vi.resetModules();
   fromFn = vi.fn();
-  process.env.SUPABASE_SERVICE_ROLE_KEY = 'srv';
+  process.env.SUPABASE_URL = 'https://example.supabase.co';
+  process.env.SUPABASE_ANON_KEY = 'anon';
   await loadModule();
 });
 
 afterEach(() => {
-  process.env.SUPABASE_SERVICE_ROLE_KEY = originalEnv;
+  process.env.SUPABASE_URL = originalUrl;
+  process.env.SUPABASE_ANON_KEY = originalAnon;
 });
 
 describe('get-payment-key handler', () => {
   it('returns key on success', async () => {
-    fromFn.mockReturnValue({
-      select: vi.fn(() => ({
-        eq: vi.fn(() => ({
+      fromFn.mockReturnValue({
+        select: vi.fn(() => ({
           eq: vi.fn(() => ({
-            single: vi.fn(async () => ({ data: { api_key: 'k1' }, error: null }))
+            eq: vi.fn(() => ({
+              single: vi.fn(async () => ({
+                data: {
+                  publishable_key: 'pk1',
+                  tokenization_key: 'tk1',
+                  api_login_id: 'api1',
+                },
+                error: null,
+              }))
+            }))
           }))
         }))
-      }))
-    });
+      });
 
     const req = { method: 'GET', query: { storeId: 's1', provider: 'nmi' } } as Partial<NextApiRequest>;
     const res: Partial<NextApiResponse> = { status: vi.fn(() => res as any), json: vi.fn(() => res as any), setHeader: vi.fn() };
 
     await handler(req as NextApiRequest, res as NextApiResponse);
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({ tokenization_key: 'k1' });
+    expect(res.json).toHaveBeenCalledWith({
+      publishable_key: 'pk1',
+      tokenization_key: 'tk1',
+      api_login_id: 'api1',
+      message: 'Deprecated - use get_gateway_credentials edge function',
+    });
   });
 
   it('returns error when query fails', async () => {


### PR DESCRIPTION
## Summary
- use env-based Supabase client with anon key
- fetch browser-safe credentials from v_public_store
- respond with deprecation notice and update tests

## Testing
- `npm test` *(fails: TypeError fetch failed in get-payment-key tests)*

------
https://chatgpt.com/codex/tasks/task_e_689c00bf8c4c83259d148ebdd67863af