### PR TITLE
edge: standardize on v_public_store for public config/creds

### DIFF
--- a/supabase/functions/get_public_store_settings/index.ts
+++ b/supabase/functions/get_public_store_settings/index.ts
@@ -257,31 +257,14 @@ Deno.serve(async (req: Request) => {
       }
     }
 
-    // Create a custom header for RLS policy
-    const customHeaders = {
-      "x-store-id": storeId,
-      "Content-Type": "application/json"
-    };
+    // Query public store configuration
+    log("Querying store settings from v_public_store for:", storeId);
 
-    // Set up the client with the headers
-    const supabaseWithHeaders = createClient(
-      supabaseUrl, 
-      supabaseAnonKey, 
-      {
-        global: {
-          headers: customHeaders
-        }
-      }
-    );
-
-    // Query public_store_settings with RLS headers
-    log("Querying store settings with RLS headers:", customHeaders);
-    
-    const { data, error } = await supabaseWithHeaders
-      .from("public_store_settings")
-      .select("*")
+    const { data, error } = await supabase
+      .from("v_public_store")
+      .select("base_currency, public_settings")
       .eq("store_id", storeId)
-      .maybeSingle();
+      .single();
 
     if (error) {
       log("Query error:", error);

--- a/supabase/functions/store-tables.test.ts
+++ b/supabase/functions/store-tables.test.ts
@@ -16,7 +16,7 @@ describe('store tables queries', () => {
     settingsBuilder = {
       select: vi.fn(() => settingsBuilder),
       eq: vi.fn(() => settingsBuilder),
-      maybeSingle: vi.fn(),
+      single: vi.fn(),
     }
     integrationsBuilder = {
       select: vi.fn(() => integrationsBuilder),
@@ -25,7 +25,7 @@ describe('store tables queries', () => {
     }
     createClientMock = vi.fn(() => ({
       from: (table: string) =>
-        table === 'public_store_settings' ? settingsBuilder : integrationsBuilder,
+        table === 'v_public_store' ? settingsBuilder : integrationsBuilder,
     }))
     vi.mock('@supabase/supabase-js', () => ({ createClient: createClientMock }))
     await loadClient()
@@ -38,17 +38,17 @@ describe('store tables queries', () => {
 
   it('returns settings and integrations data', async () => {
     const storeId = 'store-123'
-    const settingsRow = { store_id: storeId }
+    const settingsRow = { base_currency: 'USD', public_settings: { mode: 'test' } }
     const integrationRow = { id: 'i1', store_id: storeId }
 
-    settingsBuilder.maybeSingle.mockResolvedValue({ data: settingsRow, error: null })
+    settingsBuilder.single.mockResolvedValue({ data: settingsRow, error: null })
     integrationsBuilder.maybeSingle.mockResolvedValue({ data: integrationRow, error: null })
 
     const { data: settings, error: settingsError } = await supabase
-      .from('public_store_settings')
-      .select('*')
+      .from('v_public_store')
+      .select('base_currency, public_settings')
       .eq('store_id', storeId)
-      .maybeSingle()
+      .single()
 
     const { data: integration, error: integrationError } = await supabase
       .from('store_integrations')


### PR DESCRIPTION
## Summary
- use `v_public_store` view for settings fetch with store ID filter
- query `v_public_store` for gateway credentials and expose only browser-safe fields
- adjust tests to reflect `v_public_store`

## Testing
- `npm run test:supabase`
- `npm run supabase:lint-fx` *(fails: deno: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c28231b588325948c73ca54da63bc