### PR TITLE
admin: fix ESLint errors and config for Next.js build

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,24 +5,37 @@ import next from '@next/eslint-plugin-next';
 
 export default [
   {
-    files: ['smoothr/**/*.{ts,tsx,js,jsx}'],
+    files: ['smoothr/**/*.{ts,js}'],
     languageOptions: {
       parser,
       sourceType: 'module',
       ecmaVersion: 2021,
+      globals: {
+        process: 'readonly',
+        fetch: 'readonly',
+        Buffer: 'readonly',
+        NodeJS: 'readonly',
+      },
     },
   },
   js.configs.recommended,
+  next.flatConfig.recommended,
   {
+    settings: {
+      next: {
+        rootDir: 'smoothr',
+      },
+    },
     plugins: {
       '@typescript-eslint': ts,
-      next,
     },
     rules: {
       ...ts.configs.recommended.rules,
       'no-console': 'off',
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-unused-vars': 'warn',
+      'next/no-html-link-for-pages': 'off',
+      'no-undef': 'off',
     },
   },
 ];

--- a/smoothr/pages/api/webhooks/stripeWebhook.ts
+++ b/smoothr/pages/api/webhooks/stripeWebhook.ts
@@ -102,7 +102,7 @@ export default async function handler(
       if (!data || data.length === 0) {
         // Order not found for payment_intent
       }
-    } catch (error: unknown) {
+    } catch {
       res.status(400).send("Webhook processing error");
       return;
     }


### PR DESCRIPTION
## Summary
- configure ESLint for Next.js with relaxed rules
- drop unused variable in Stripe webhook handler

## Testing
- `npx eslint "smoothr/pages/api/**/*.{ts,tsx,js,jsx}"`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689c376861c88325aa2854cd5ed9f093