### PR TITLE
ci: wire client secret guard script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "supabase:validate-config": "node scripts/supabase/validate-config.mjs",
     "supabase:check-imports": "node scripts/supabase/check-imports.mjs",
     "supabase:lint-fx": "eslint supabase/functions/**/*.{ts,js}",
-    "supabase:fmt": "deno fmt supabase/functions"
+    "supabase:fmt": "deno fmt supabase/functions",
+    "check:client-secrets": "node scripts/check-no-service-role-in-client.mjs"
   },
   "devDependencies": {
     "@iarna/toml": "^2.2.5",


### PR DESCRIPTION
## Summary
- add `check:client-secrets` npm script to invoke storefront guard for service-role keys

## Testing
- `npm run check:client-secrets`
- `npm test` *(fails: get_public_store_settings.cors.test.ts expected 500 to be 200)*

------
https://chatgpt.com/codex/tasks/task_e_689c3a902ca0832583563b061f4ba330