### PR TITLE
sdk: migrate legacy table names to integrations and v_public_store

### DIFF
--- a/shared/checkout/getStoreIntegration.ts
+++ b/shared/checkout/getStoreIntegration.ts
@@ -8,16 +8,52 @@ const debug =
 export async function getStoreIntegration(storeId: string, integrationId: string) {
   if (!storeId || !integrationId) return null;
   const supabase = createServerSupabaseClient();
-  if (debug) console.log('[STEP] Fetching store_integrations...');
+  if (debug) console.log('[STEP] Fetching integrations...');
   const { data, error } = await supabase
-    .from('store_integrations')
-    .select('api_key, settings')
+    .from('integrations')
+    .select('provider_key, publishable_key')
     .eq('store_id', storeId)
-    .eq('gateway', integrationId)
+    .eq('provider_key', integrationId)
     .maybeSingle();
+
   if (error) {
     if (debug) console.warn('[getStoreIntegration]', error.message || error);
     return null;
   }
-  return data as { api_key?: string; settings?: any } | null;
+
+  let secretKey: string | null = null;
+  try {
+    const { data: secretData, error: secretError } = await supabase
+      .from('vault.decrypted_secrets')
+      .select('secret')
+      .eq('name', `${integrationId}_secret_key_${storeId}`)
+      .maybeSingle();
+    if (secretError) {
+      if (debug)
+        console.warn('[getStoreIntegration] secret lookup error', secretError.message);
+    } else {
+      secretKey = (secretData as any)?.secret || null;
+    }
+  } catch (e: any) {
+    if (debug) console.warn('[getStoreIntegration] secret lookup failed', e);
+  }
+
+  return {
+    provider_key: data?.provider_key,
+    publishable_key: (data as any)?.publishable_key ?? null,
+    secret_key: secretKey,
+    api_key: (data as any)?.publishable_key ?? null,
+    settings: {
+      api_key: (data as any)?.publishable_key ?? null,
+      secret_key: secretKey,
+      client_id: (data as any)?.publishable_key ?? null,
+      secret: secretKey,
+    } as any,
+  } as {
+    provider_key?: string;
+    publishable_key?: string | null;
+    secret_key?: string | null;
+    api_key?: string | null;
+    settings?: any;
+  } | null;
 }

--- a/shared/checkout/providers/authorizeNet.ts
+++ b/shared/checkout/providers/authorizeNet.ts
@@ -62,7 +62,7 @@ export default async function handleAuthorizeNet(payload: AuthorizeNetPayload) {
 
     try {
       creds = await getStoreIntegration(payload.store_id, 'authorizeNet');
-      log('🧩 Raw store_integrations:', creds);
+      log('🧩 Raw integrations:', creds);
     } catch (e) {
       err('❌ getStoreIntegration() threw:', e);
       return {
@@ -77,23 +77,23 @@ export default async function handleAuthorizeNet(payload: AuthorizeNetPayload) {
     let loginIdSource = '';
     if (typeof settings.api_login_id === 'string' && settings.api_login_id.trim()) {
       loginId = settings.api_login_id.trim();
-      loginIdSource = 'store_integrations.settings';
+      loginIdSource = 'integrations.settings';
     } else if (typeof creds?.api_login_id === 'string' && creds.api_login_id.trim()) {
       loginId = creds.api_login_id.trim();
-      loginIdSource = 'store_integrations';
+      loginIdSource = 'integrations';
     } else if (typeof (creds as any)?.api_key === 'string' && (creds as any).api_key.trim()) {
       loginId = (creds as any).api_key.trim();
-      loginIdSource = 'store_integrations.api_key';
+      loginIdSource = 'integrations.publishable_key';
     }
 
     let transactionKey = '';
     let transactionKeySource = '';
     if (typeof settings.transaction_key === 'string' && settings.transaction_key.trim()) {
       transactionKey = settings.transaction_key.trim();
-      transactionKeySource = 'store_integrations.settings';
+      transactionKeySource = 'integrations.settings';
     } else if (typeof creds?.transaction_key === 'string' && creds.transaction_key.trim()) {
       transactionKey = creds.transaction_key.trim();
-      transactionKeySource = 'store_integrations';
+      transactionKeySource = 'integrations';
     }
 
     log('🧾 Final credentials used:', {

--- a/shared/checkout/providers/paypal.ts
+++ b/shared/checkout/providers/paypal.ts
@@ -24,8 +24,15 @@ export default async function handlePayPal(payload: PayPalPayload) {
   try {
     const integration = await getStoreIntegration(payload.store_id, 'paypal');
     if (integration) {
-      clientId = integration.settings?.client_id || integration.api_key || clientId;
-      clientSecret = integration.settings?.secret || clientSecret;
+      clientId =
+        integration.publishable_key ||
+        integration.api_key ||
+        integration.settings?.client_id ||
+        clientId;
+      clientSecret =
+        integration.secret_key ||
+        integration.settings?.secret ||
+        clientSecret;
     }
   } catch (e) {
     err('Credential lookup failed:', e);

--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -3,7 +3,6 @@ import {
   ensureSupabaseSessionAuth
 } from '../../../supabase/browserClient.js';
 import * as authExports from './index.js';
-import { loadPublicConfig } from '../config/sdkConfig.js';
 import * as currency from '../currency/index.js';
 import { getConfig, mergeConfig } from '../config/globalConfig.js';
 
@@ -33,18 +32,12 @@ let initialized = false;
 export async function loadConfig(storeId) {
   console.log('[Smoothr SDK] loadConfig called with storeId:', storeId);
   try {
-    let record;
-    if (typeof process !== 'undefined' && process.env.NODE_ENV === 'test') {
-      const { data, error } = await authClient
-        .from('public_store_settings')
-        .select('*')
-        .eq('store_id', storeId)
-        .single();
-      if (error) throw error;
-      record = data ?? {};
-    } else {
-      record = (await loadPublicConfig(storeId)) ?? {};
-    }
+    const { data, error } = await authClient.functions.invoke(
+      'get_public_store_settings',
+      { body: { store_id: storeId } }
+    );
+    if (error) throw error;
+    const record = data ?? {};
     console.debug('[Smoothr Config] Loaded config:', record);
     if (record.active_payment_gateway == null) {
       console.debug(


### PR DESCRIPTION
## Summary
- use new `integrations` table and Supabase Vault in checkout integration lookups
- load public store settings via `get_public_store_settings` edge function
- update payment providers and Stripe webhook to align with canonical tables

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c4d38c48883259228cb9720f830c8