### PR TITLE
Add v_public_store tests and unscoped query linter

### DIFF
--- a/scripts/ci.yml
+++ b/scripts/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts --loglevel verbose
+
+      - name: Verify unscoped queries
+        run: node scripts/verify-unscoped-queries.mjs
+
+      - name: Run tests
+        working-directory: storefronts
+        run: npm test
+
+      - name: Build packages
+        run: npm run build

--- a/scripts/verify-unscoped-queries.mjs
+++ b/scripts/verify-unscoped-queries.mjs
@@ -1,0 +1,56 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const repoRoot = path.resolve(fileURLToPath(import.meta.url), '..', '..');
+const rootDir = path.join(repoRoot, 'storefronts');
+const exts = ['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs'];
+const tables = ['orders', 'discounts', 'discount_usages', 'integrations', 'store_settings'];
+const offenders = [];
+
+function scanFile(file) {
+  const lines = fs.readFileSync(file, 'utf8').split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const fromMatch = line.match(/\.from\(['"](orders|discounts|discount_usages|integrations|store_settings)['"]\)/);
+    if (fromMatch) {
+      let hasEq = false;
+      for (let j = i; j < Math.min(lines.length, i + 10); j++) {
+        const checkLine = lines[j];
+        if (/\.eq\(['"]store_id['"]/.test(checkLine)) {
+          hasEq = true;
+          break;
+        }
+        if (j > i && /\.from\(/.test(checkLine)) break;
+        if (/;/.test(checkLine)) break;
+      }
+      if (!hasEq) {
+        offenders.push(`${path.relative(repoRoot, file)}:${i + 1}: ${line.trim()}`);
+      }
+    }
+  }
+}
+
+function walk(dir) {
+  if (!fs.existsSync(dir)) return;
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full);
+    } else if (exts.includes(path.extname(entry.name))) {
+      scanFile(full);
+    }
+  }
+}
+
+walk(rootDir);
+
+if (offenders.length) {
+  offenders.forEach(o => console.error(o));
+  console.error(`Found ${offenders.length} unscoped quer${offenders.length === 1 ? 'y' : 'ies'}`);
+  process.exit(1);
+}
+
+console.log('No unscoped queries found');
+

--- a/storefronts/tests/v_public_store.test.ts
+++ b/storefronts/tests/v_public_store.test.ts
@@ -1,0 +1,61 @@
+import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
+
+let supabase: any;
+let createClientMock: any;
+let builder: any;
+
+async function loadClient() {
+  supabase = (await import('../../shared/supabase/client.ts')).supabase;
+}
+
+describe('v_public_store view', () => {
+  beforeEach(async () => {
+    builder = {
+      select: vi.fn(() => builder),
+      eq: vi.fn(() => builder),
+      single: vi.fn(),
+    };
+
+    createClientMock = vi.fn(() => ({
+      from: (table: string) => {
+        if (table === 'v_public_store') return builder;
+        throw new Error(`Unexpected table ${table}`);
+      },
+    }));
+
+    vi.mock('@supabase/supabase-js', () => ({ createClient: createClientMock }));
+    await loadClient();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it('returns one row per store with public fields', async () => {
+    const storeId = 'store-123';
+    const row = {
+      store_id: storeId,
+      base_currency: 'USD',
+      active_payment_gateway: 'stripe',
+      publishable_key: 'pk_test_123',
+      safe: { theme: 'dark' },
+    };
+    builder.single.mockResolvedValue({ data: row, error: null });
+
+    const { data, error } = await supabase
+      .from('v_public_store')
+      .select('store_id, base_currency, active_payment_gateway, publishable_key, safe')
+      .eq('store_id', storeId)
+      .single();
+
+    expect(error).toBeNull();
+    expect(data).toEqual(row);
+    expect(builder.select).toHaveBeenCalledWith(
+      'store_id, base_currency, active_payment_gateway, publishable_key, safe'
+    );
+    expect(builder.eq).toHaveBeenCalledWith('store_id', storeId);
+    expect(builder.single).toHaveBeenCalledTimes(1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- test v_public_store view returns expected public fields and single row
- lint storefronts for unscoped Supabase queries
- run unscoped query linter in CI on pull requests

## Testing
- `node scripts/verify-unscoped-queries.mjs`
- `npm test` (from `storefronts`)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c6e674754832596a8c5aa2b68c5f1