### PR TITLE
sdk: fix v_public_store query to use store_id instead of id

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -34,8 +34,10 @@ export async function loadConfig(storeId) {
   try {
     const { data, error } = await authClient
       .from('v_public_store')
-      .select('*')
-      .eq('id', storeId)
+      .select(
+        'store_id, active_payment_gateway, publishable_key, base_currency'
+      )
+      .eq('store_id', storeId)
       .maybeSingle();
     if (error) throw error;
     const record = data ?? {};

--- a/storefronts/features/config/sdkConfig.js
+++ b/storefronts/features/config/sdkConfig.js
@@ -11,8 +11,10 @@ export async function loadPublicConfig(storeId) {
   try {
     const { data, error } = await supabase
       .from('v_public_store')
-      .select('*')
-      .eq('id', storeId)
+      .select(
+        'store_id, active_payment_gateway, publishable_key, base_currency'
+      )
+      .eq('store_id', storeId)
       .maybeSingle();
 
     if (error) {

--- a/storefronts/tests/v_public_store.test.ts
+++ b/storefronts/tests/v_public_store.test.ts
@@ -36,23 +36,24 @@ describe('v_public_store view', () => {
     const storeId = 'store-123';
     const row = {
       store_id: storeId,
-      base_currency: 'USD',
       active_payment_gateway: 'stripe',
       publishable_key: 'pk_test_123',
-      safe: { theme: 'dark' },
+      base_currency: 'USD',
     };
     builder.single.mockResolvedValue({ data: row, error: null });
 
     const { data, error } = await supabase
       .from('v_public_store')
-      .select('store_id, base_currency, active_payment_gateway, publishable_key, safe')
+      .select(
+        'store_id, active_payment_gateway, publishable_key, base_currency'
+      )
       .eq('store_id', storeId)
       .single();
 
     expect(error).toBeNull();
     expect(data).toEqual(row);
     expect(builder.select).toHaveBeenCalledWith(
-      'store_id, base_currency, active_payment_gateway, publishable_key, safe'
+      'store_id, active_payment_gateway, publishable_key, base_currency'
     );
     expect(builder.eq).toHaveBeenCalledWith('store_id', storeId);
     expect(builder.single).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- query `v_public_store` by `store_id` instead of `id`
- load `store_id`, `active_payment_gateway`, `publishable_key`, `base_currency`
- adjust tests to reflect `store_id` usage

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c757d7dd48325802937c3869d25df