### PR TITLE
sdk: enhance v_public_store query handling and error logging

### DIFF
--- a/storefronts/features/config/sdkConfig.js
+++ b/storefronts/features/config/sdkConfig.js
@@ -1,4 +1,4 @@
-import supabase from '../../../supabase/browserClient.js';
+import { supabase } from '../../../shared/supabase/client.ts';
 import { getConfig } from './globalConfig.js';
 
 const debug = typeof window !== 'undefined' && getConfig().debug;
@@ -11,25 +11,37 @@ export async function loadPublicConfig(storeId) {
   try {
     const { data, error } = await supabase
       .from('v_public_store')
-      .select('store_id,active_payment_gateway,publishable_key,base_currency')
+      .select(
+        'store_id,active_payment_gateway,publishable_key,base_currency,public_settings'
+      )
       .eq('store_id', storeId)
       .maybeSingle();
 
-    if (error) {
+    if (error || !data) {
       warn('Store settings lookup failed:', {
-        status: error.status,
-        message: error.message,
+        status: error?.status,
+        code: error?.code,
+        message: error?.message,
+        data,
       });
-      return null;
+      return { public_settings: {}, active_payment_gateway: null };
     }
 
+    const settings = {
+      ...data,
+      public_settings: data.public_settings || {},
+      active_payment_gateway: data.active_payment_gateway ?? null,
+    };
+
     log('Config fetched');
-    return data || null;
+    return settings;
   } catch (e) {
     warn('Store settings fetch error:', {
       status: e?.status,
+      code: e?.code,
       message: e?.message || e,
+      data: e?.response?.data,
     });
-    return null;
+    return { public_settings: {}, active_payment_gateway: null };
   }
 }

--- a/storefronts/tests/v_public_store.test.ts
+++ b/storefronts/tests/v_public_store.test.ts
@@ -1,14 +1,16 @@
 import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 
 let supabase: any;
+let loadPublicConfig: any;
 let createClientMock: any;
 let builder: any;
 
-async function loadClient() {
+async function loadModules() {
   supabase = (await import('../../shared/supabase/client.ts')).supabase;
+  ({ loadPublicConfig } = await import('../features/config/sdkConfig.js'));
 }
 
-describe('v_public_store view', () => {
+describe('loadPublicConfig', () => {
   beforeEach(async () => {
     builder = {
       select: vi.fn(() => builder),
@@ -24,7 +26,7 @@ describe('v_public_store view', () => {
     }));
 
     vi.mock('@supabase/supabase-js', () => ({ createClient: createClientMock }));
-    await loadClient();
+    await loadModules();
   });
 
   afterEach(() => {
@@ -33,28 +35,52 @@ describe('v_public_store view', () => {
   });
 
   it('returns one row per store with public fields', async () => {
-    const storeId = 'store-123';
+    const storeId = 'a3fea30b-8a63-4a72-9040-6049d88545d0';
     const row = {
       store_id: storeId,
       active_payment_gateway: 'stripe',
-      publishable_key: 'pk_test_123',
-      base_currency: 'USD',
+      publishable_key: 'pk_live_123',
+      base_currency: 'GBP',
+      public_settings: {},
     };
     builder.maybeSingle.mockResolvedValue({ data: row, error: null });
 
-    const { data, error } = await supabase
-      .from('v_public_store')
-      .select('store_id,active_payment_gateway,publishable_key,base_currency')
-      .eq('store_id', storeId)
-      .maybeSingle();
+    const config = await loadPublicConfig(storeId);
 
-    expect(error).toBeNull();
-    expect(data).toEqual(row);
+    expect(config).toEqual(row);
     expect(builder.select).toHaveBeenCalledWith(
-      'store_id,active_payment_gateway,publishable_key,base_currency'
+      'store_id,active_payment_gateway,publishable_key,base_currency,public_settings'
     );
     expect(builder.eq).toHaveBeenCalledWith('store_id', storeId);
     expect(builder.maybeSingle).toHaveBeenCalledTimes(1);
+  });
+
+  it('defaults missing active_payment_gateway to null', async () => {
+    const storeId = 'a3fea30b-8a63-4a72-9040-6049d88545d0';
+    const row = {
+      store_id: storeId,
+      publishable_key: 'pk_live_123',
+      base_currency: 'GBP',
+      public_settings: {},
+    };
+    builder.maybeSingle.mockResolvedValue({ data: row, error: null });
+
+    const config = await loadPublicConfig(storeId);
+
+    expect(config.active_payment_gateway).toBeNull();
+    expect(config.public_settings).toEqual({});
+  });
+
+  it('returns fallback settings on query error', async () => {
+    const storeId = 'a3fea30b-8a63-4a72-9040-6049d88545d0';
+    builder.maybeSingle.mockResolvedValue({
+      data: {},
+      error: { status: 500, code: 'PGRST500', message: 'failed' },
+    });
+
+    const config = await loadPublicConfig(storeId);
+
+    expect(config).toEqual({ public_settings: {}, active_payment_gateway: null });
   });
 });
 


### PR DESCRIPTION
## Summary
- use shared Supabase client and request public_settings
- validate query response and default missing fields
- cover config fallback and query failures in tests

## Testing
- `npm test` (failed: checkout tests, load-config tests)
- `npm run build`
- `curl -I https://smoothr-cms.webflow.io/?smoothr-debug=true`

------
https://chatgpt.com/codex/tasks/task_e_689d289d8b4c8325bacc8ed8f4239a37