### PR TITLE
sdk: deploy /api/config and fix SDK/test issues

### DIFF
--- a/smoothr/pages/api/config.js
+++ b/smoothr/pages/api/config.js
@@ -1,20 +1,21 @@
 import { createClient } from '@supabase/supabase-js';
 
-export default async function handler(req, res) {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-  const supabase = createClient(url, anonKey);
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const supabase = createClient(url, anonKey);
 
-  const { data, error } = await supabase
+export default async function handler(req, res) {
+  const response = await supabase
     .from('v_public_store')
-    .select('store_id,active_payment_gateway,publishable_key,base_currency,public_settings')
+    .select(
+      'store_id,active_payment_gateway,publishable_key,base_currency,public_settings'
+    )
     .eq('store_id', req.query.store_id)
     .maybeSingle();
 
-  if (error || !data) {
-    res.status(200).json({ public_settings: {}, active_payment_gateway: null });
-    return;
-  }
-
-  res.status(200).json(data);
+  res
+    .status(200)
+    .json(
+      response.data || { public_settings: {}, active_payment_gateway: null }
+    );
 }

--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -10,10 +10,12 @@ import { getConfig, mergeConfig } from '../config/globalConfig.js';
 const { lookupRedirectUrl, lookupDashboardHomeUrl } = authExports;
 export const storeRedirects = { lookupRedirectUrl, lookupDashboardHomeUrl };
 
-// Some build environments reference a minified global `Tc` or `Cc` for the
-// Supabase client. Fall back to the imported client if those globals are
-// unavailable.
-const authClient = globalThis.Tc || globalThis.Cc || importedSupabase;
+// Some build environments reference a minified global `xc`, `Tc` or `Cc` for the
+// Supabase client. Ensure `xc` exists and fall back to the imported client when
+// these globals are unavailable.
+const xc = globalThis.xc || importedSupabase;
+globalThis.xc = xc;
+const authClient = globalThis.Tc || globalThis.Cc || xc;
 
 if (typeof globalThis.setSelectedCurrency !== 'function') {
   globalThis.setSelectedCurrency = () => {};

--- a/storefronts/features/cart/index.js
+++ b/storefronts/features/cart/index.js
@@ -9,28 +9,32 @@ const log = (...args) => getConfig().debug && console.log('[Smoothr Cart]', ...a
 const warn = (...args) => getConfig().debug && console.warn('[Smoothr Cart]', ...args);
 const err = (...args) => getConfig().debug && console.error('[Smoothr Cart]', ...args);
 
-// Some builds reference a minified `cl` variable for localStorage access.
+// Some builds reference a minified `il` variable for localStorage access.
 // Define it safely here so imports never throw in environments without
 // localStorage (e.g. server-side rendering or tests).
-let cl =
-  globalThis.cl ||
+let il =
+  globalThis.il ||
   (typeof window !== 'undefined'
     ? window.localStorage
     : typeof globalThis !== 'undefined'
     ? globalThis.localStorage
     : undefined);
+globalThis.il = il;
 
 // Ensure the cart storage key exists so JSON.parse does not throw later.
 try {
-  if (cl && cl.getItem(STORAGE_KEY) == null) {
-    cl.setItem(STORAGE_KEY, JSON.stringify({ items: [] }));
+  if (il && il.getItem(STORAGE_KEY) == null) {
+    il.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ items: [], meta: { lastModified: Date.now() } })
+    );
   }
 } catch {
   // ignore storage errors
 }
 
 function getStorage() {
-  return cl || null;
+  return il || null;
 }
 
 export function readCart() {
@@ -170,7 +174,10 @@ export async function initCart() {
 
     try {
       if (window.localStorage.getItem(STORAGE_KEY) == null) {
-        window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ items: [] }));
+        window.localStorage.setItem(
+          STORAGE_KEY,
+          JSON.stringify({ items: [], meta: { lastModified: Date.now() } })
+        );
       }
     } catch (e) {
       if (debug) {
@@ -180,7 +187,7 @@ export async function initCart() {
       }
     }
 
-    cl = window.localStorage;
+    il = window.localStorage;
 
     Smoothr.cart = {
       readCart,

--- a/storefronts/features/checkout/init.js
+++ b/storefronts/features/checkout/init.js
@@ -52,7 +52,7 @@ export async function init(config = {}) {
     // Allow tests or embedders to provide a minified global Supabase client
     mergeConfig({
       ...config,
-      supabase: config.supabase || globalThis.Kc || globalThis.Hc
+      supabase: config.supabase || globalThis.Zc || globalThis.Kc || globalThis.Hc
     });
     await platformReady();
 

--- a/storefronts/tests/features/auth.test.js
+++ b/storefronts/tests/features/auth.test.js
@@ -26,10 +26,12 @@ describe('auth feature init', () => {
         getSession: vi.fn().mockResolvedValue({ data: { session: {} } }),
         getSessionFromUrl: vi.fn().mockResolvedValue({}),
         signOut: vi.fn(),
-        onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } }))
+        onAuthStateChange: vi.fn(() => ({
+          data: { subscription: { unsubscribe: vi.fn() } }
+        }))
       }
     };
-    globalThis.Tc = supabaseMock;
+    globalThis.xc = supabaseMock;
     vi.doMock('../../../supabase/browserClient.js', () => ({
       supabase: supabaseMock,
       ensureSupabaseSessionAuth: vi.fn().mockResolvedValue()

--- a/storefronts/tests/features/checkout.test.js
+++ b/storefronts/tests/features/checkout.test.js
@@ -7,7 +7,7 @@ describe('checkout feature init', () => {
   beforeEach(() => {
     vi.resetModules();
     supabaseMock = { from: vi.fn() };
-    globalThis.Kc = supabaseMock;
+    globalThis.Zc = supabaseMock;
     loadPublicConfigMock = vi.fn().mockResolvedValue({});
     vi.doMock('../../features/config/sdkConfig.js', () => ({
       loadPublicConfig: loadPublicConfigMock

--- a/storefronts/tests/sdk/auth-idempotent.test.js
+++ b/storefronts/tests/sdk/auth-idempotent.test.js
@@ -51,12 +51,19 @@ beforeEach(() => {
     dispatchEvent: vi.fn(),
     currentScript: { getAttribute: vi.fn(), dataset: { storeId: 's1' } },
   };
-  globalThis.Tc = {
-    auth: { getSession: getSessionMock, onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })) },
+  globalThis.xc = {
+    auth: {
+      getSession: getSessionMock,
+      onAuthStateChange: vi.fn(() => ({
+        data: { subscription: { unsubscribe: vi.fn() } }
+      }))
+    },
     from: vi.fn(() => ({
-      select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue({ data: null }) })) })),
-    })),
-  } as any;
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue({ data: null }) }))
+      }))
+    }))
+  };
 });
 
 describe('auth init session restoration', () => {

--- a/storefronts/tests/sdk/cart-dom-trigger.test.js
+++ b/storefronts/tests/sdk/cart-dom-trigger.test.js
@@ -25,6 +25,7 @@ describe("cart DOM trigger", () => {
     vi.doUnmock("../../features/currency/index.js");
     vi.doUnmock("../../features/cart/init.js");
     delete globalThis[globalKey];
+    vi.restoreAllMocks();
   });
 
   it.each([
@@ -32,44 +33,38 @@ describe("cart DOM trigger", () => {
     '[data-smoothr-total]',
     '[data-smoothr-cart]'
   ])("imports cart when %s is present", async selector => {
-    const scriptEl = { dataset: { storeId: "1" } };
-    global.window = {
-      location: { search: "" },
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      Smoothr: {},
-      smoothr: {},
-    };
-    global.document = {
-      readyState: "complete",
-      addEventListener: vi.fn(),
-      querySelectorAll: vi.fn(() => []),
-      querySelector: vi.fn(sel => (sel === selector ? {} : null)),
-      getElementById: vi.fn(() => scriptEl),
-    };
+    const scriptEl = document.createElement('script');
+    scriptEl.dataset.storeId = '1';
+    Object.defineProperty(window, 'location', { value: { search: '' }, configurable: true });
+    window.addEventListener = vi.fn();
+    window.removeEventListener = vi.fn();
+    window.Smoothr = {};
+    window.smoothr = {};
+    Object.defineProperty(document, 'readyState', { value: 'complete', configurable: true });
+    vi.spyOn(document, 'querySelectorAll').mockReturnValue([]);
+    vi.spyOn(document, 'querySelector').mockImplementation(sel => (sel === selector ? {} : null));
+    vi.spyOn(document, 'getElementById').mockReturnValue(scriptEl);
     await import("../../smoothr-sdk.js");
+    await flushPromises();
     await flushPromises();
     await flushPromises();
     expect(cartInitMock).toHaveBeenCalled();
   });
 
   it("skips cart when no triggers present", async () => {
-    const scriptEl = { dataset: { storeId: "1" } };
-    global.window = {
-      location: { search: "" },
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      Smoothr: {},
-      smoothr: {},
-    };
-    global.document = {
-      readyState: "complete",
-      addEventListener: vi.fn(),
-      querySelectorAll: vi.fn(() => []),
-      querySelector: vi.fn(() => null),
-      getElementById: vi.fn(() => scriptEl),
-    };
+    const scriptEl = document.createElement('script');
+    scriptEl.dataset.storeId = '1';
+    Object.defineProperty(window, 'location', { value: { search: '' }, configurable: true });
+    window.addEventListener = vi.fn();
+    window.removeEventListener = vi.fn();
+    window.Smoothr = {};
+    window.smoothr = {};
+    Object.defineProperty(document, 'readyState', { value: 'complete', configurable: true });
+    vi.spyOn(document, 'querySelectorAll').mockReturnValue([]);
+    vi.spyOn(document, 'querySelector').mockReturnValue(null);
+    vi.spyOn(document, 'getElementById').mockReturnValue(scriptEl);
     await import("../../smoothr-sdk.js");
+    await flushPromises();
     await flushPromises();
     await flushPromises();
     expect(cartInitMock).not.toHaveBeenCalled();

--- a/storefronts/tests/sdk/cart-feature-loading.test.js
+++ b/storefronts/tests/sdk/cart-feature-loading.test.js
@@ -23,6 +23,7 @@ describe("cart feature loading", () => {
     vi.doUnmock("../../features/currency/index.js");
     vi.doUnmock("../../features/cart/init.js");
     delete globalThis[globalKey];
+    vi.restoreAllMocks();
   });
 
   it.each([
@@ -30,49 +31,41 @@ describe("cart feature loading", () => {
     '[data-smoothr-total]',
     '[data-smoothr-cart]'
   ])("initializes cart when trigger %s exists", async selector => {
-    const scriptEl = { dataset: { storeId: "1" } };
-    global.location = { search: "" };
-    global.window = {
-      location: { search: "" },
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      Smoothr: {},
-      smoothr: {},
-    };
-    global.document = {
-      readyState: "complete",
-      addEventListener: vi.fn(),
-      querySelectorAll: vi.fn(() => []),
-      querySelector: vi.fn(sel => (sel === selector ? {} : null)),
-      getElementById: vi.fn(() => scriptEl),
-    };
+    const scriptEl = document.createElement('script');
+    scriptEl.dataset.storeId = '1';
+    Object.defineProperty(window, 'location', { value: { search: '' }, configurable: true });
+    window.addEventListener = vi.fn();
+    window.removeEventListener = vi.fn();
+    window.Smoothr = {};
+    window.smoothr = {};
+    Object.defineProperty(document, 'readyState', { value: 'complete', configurable: true });
+    vi.spyOn(document, 'querySelectorAll').mockReturnValue([]);
+    vi.spyOn(document, 'querySelector').mockImplementation(sel => (sel === selector ? {} : null));
+    vi.spyOn(document, 'getElementById').mockReturnValue(scriptEl);
 
     await import("../../smoothr-sdk.js");
+    await flushPromises();
     await flushPromises();
     await flushPromises();
     expect(cartInitMock).toHaveBeenCalled();
   });
 
   it("logs when cart triggers are absent", async () => {
-    const scriptEl = { dataset: { storeId: "1" } };
-    global.location = { search: "?smoothr-debug=true" };
-    global.window = {
-      location: { search: "?smoothr-debug=true" },
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      Smoothr: {},
-      smoothr: {},
-    };
+    const scriptEl = document.createElement('script');
+    scriptEl.dataset.storeId = '1';
+    Object.defineProperty(window, 'location', { value: { search: '?smoothr-debug=true' }, configurable: true });
+    window.addEventListener = vi.fn();
+    window.removeEventListener = vi.fn();
+    window.Smoothr = {};
+    window.smoothr = {};
     const logSpy = console.log;
-    global.document = {
-      readyState: "complete",
-      addEventListener: vi.fn(),
-      querySelectorAll: vi.fn(() => []),
-      querySelector: vi.fn(() => null),
-      getElementById: vi.fn(() => scriptEl),
-    };
+    Object.defineProperty(document, 'readyState', { value: 'complete', configurable: true });
+    vi.spyOn(document, 'querySelectorAll').mockReturnValue([]);
+    vi.spyOn(document, 'querySelector').mockReturnValue(null);
+    vi.spyOn(document, 'getElementById').mockReturnValue(scriptEl);
 
     await import("../../smoothr-sdk.js");
+    await flushPromises();
     await flushPromises();
     await flushPromises();
     expect(cartInitMock).not.toHaveBeenCalled();

--- a/storefronts/tests/sdk/cart.test.js
+++ b/storefronts/tests/sdk/cart.test.js
@@ -22,15 +22,15 @@ beforeEach(async () => {
     Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
   );
   global.localStorage = {
-    getItem: vi.fn((key) => store[key] ?? null),
+    getItem: vi.fn(key => store[key] ?? null),
     setItem: vi.fn((key, val) => {
       store[key] = val;
     }),
-    removeItem: vi.fn((key) => {
+    removeItem: vi.fn(key => {
       delete store[key];
-    }),
+    })
   };
-  globalThis.cl = global.localStorage;
+  globalThis.il = global.localStorage;
   global.window = {
     dispatchEvent: vi.fn((ev) => events.push(ev)),
     addEventListener: vi.fn(),
@@ -61,7 +61,7 @@ beforeEach(async () => {
       dataset: { storeId: "00000000-0000-0000-0000-000000000000" },
     })),
   };
-  store["smoothr_cart"] = JSON.stringify({ items: [] });
+  store["smoothr_cart"] = JSON.stringify({ items: [], meta: { lastModified: Date.now() } });
   await import("../../features/auth/init.js");
   await auth.init({
     storeId: "00000000-0000-0000-0000-000000000000",
@@ -79,6 +79,7 @@ describe("cart module", () => {
     const stored = JSON.parse(store["smoothr_cart"]);
     expect(stored.items[0].quantity).toBe(2);
     expect(cart.getSubtotal()).toBe(200);
+    expect(stored.meta).toHaveProperty("lastModified");
     expect(events.length).toBe(2);
   });
 
@@ -104,5 +105,7 @@ describe("cart module", () => {
     cart.addItem({ product_id: "1", name: "A", price: 100, quantity: 1 });
     cart.clearCart();
     expect(cart.getCart().items.length).toBe(0);
+    const stored = JSON.parse(store["smoothr_cart"]);
+    expect(stored).toEqual({ items: [], meta: { lastModified: expect.any(Number) } });
   });
 });

--- a/storefronts/tests/sdk/checkout-trigger.test.js
+++ b/storefronts/tests/sdk/checkout-trigger.test.js
@@ -25,52 +25,43 @@ describe("checkout DOM trigger", () => {
     vi.doUnmock("../../features/cart/init.js");
     vi.doUnmock("../../features/checkout/init.js");
     delete globalThis[globalKey];
-    delete global.window;
-    delete global.document;
+    vi.restoreAllMocks();
   });
 
   it("initializes checkout when trigger exists", async () => {
-    const scriptEl = { dataset: { storeId: "1" } };
-    global.location = { search: "" };
-    global.window = {
-      location: { search: "" },
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      Smoothr: {},
-      smoothr: {},
-    };
-    global.document = {
-      readyState: "complete",
-      addEventListener: vi.fn(),
-      querySelectorAll: vi.fn(() => []),
-      querySelector: vi.fn(sel => (sel === '[data-smoothr="pay"]' ? {} : null)),
-      getElementById: vi.fn(() => scriptEl),
-    };
+    const scriptEl = document.createElement('script');
+    scriptEl.dataset.storeId = '1';
+    Object.defineProperty(window, 'location', { value: { search: '' }, configurable: true });
+    window.addEventListener = vi.fn();
+    window.removeEventListener = vi.fn();
+    window.Smoothr = {};
+    window.smoothr = {};
+    Object.defineProperty(document, 'readyState', { value: 'complete', configurable: true });
+    vi.spyOn(document, 'querySelectorAll').mockReturnValue([]);
+    vi.spyOn(document, 'querySelector').mockImplementation(sel => (sel === '[data-smoothr="pay"]' ? {} : null));
+    vi.spyOn(document, 'getElementById').mockReturnValue(scriptEl);
 
     await import("../../smoothr-sdk.js");
+    await flushPromises();
     await flushPromises();
     expect(checkoutInitMock).toHaveBeenCalled();
   });
 
   it("skips checkout when trigger absent", async () => {
-    const scriptEl = { dataset: { storeId: "1" } };
-    global.location = { search: "" };
-    global.window = {
-      location: { search: "" },
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      Smoothr: {},
-      smoothr: {},
-    };
-    global.document = {
-      readyState: "complete",
-      addEventListener: vi.fn(),
-      querySelectorAll: vi.fn(() => []),
-      querySelector: vi.fn(() => null),
-      getElementById: vi.fn(() => scriptEl),
-    };
+    const scriptEl = document.createElement('script');
+    scriptEl.dataset.storeId = '1';
+    Object.defineProperty(window, 'location', { value: { search: '' }, configurable: true });
+    window.addEventListener = vi.fn();
+    window.removeEventListener = vi.fn();
+    window.Smoothr = {};
+    window.smoothr = {};
+    Object.defineProperty(document, 'readyState', { value: 'complete', configurable: true });
+    vi.spyOn(document, 'querySelectorAll').mockReturnValue([]);
+    vi.spyOn(document, 'querySelector').mockReturnValue(null);
+    vi.spyOn(document, 'getElementById').mockReturnValue(scriptEl);
 
     await import("../../smoothr-sdk.js");
+    await flushPromises();
     await flushPromises();
     expect(checkoutInitMock).not.toHaveBeenCalled();
   });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,6 @@
 import { defineConfig } from 'vitest/config';
 import path from 'node:path';
 
-if (typeof (globalThis as any).window === 'undefined') {
-  ;(globalThis as any).window = {};
-}
-
 const repoRoot = __dirname;
 
 export default defineConfig({

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,4 +1,16 @@
 // vitest.setup.ts
+import { vi } from 'vitest';
+
+// Ensure minimal browser globals exist for tests
+if (typeof (globalThis as any).window === 'undefined') {
+  ;(globalThis as any).window = {};
+}
+if (typeof (globalThis as any).localStorage === 'undefined') {
+  ;(globalThis as any).localStorage = {
+    getItem: vi.fn(),
+    setItem: vi.fn()
+  } as any;
+}
 
 // ————————————————————————————————————————————————————————————————
 // JSDOM shims for things Vitest needs


### PR DESCRIPTION
## Summary
- deploy `/api/config` endpoint via Supabase `v_public_store`
- support minified globals `xc`, `Zc`, and `il` across SDK features
- update SDK/cart tests and Vitest setup for browser-like environment

## Testing
- `npm test` (failed: cart feature loading and DOM trigger tests)
- `npm run build`
- `(cd smoothr && npm run build)`


------
https://chatgpt.com/codex/tasks/task_e_689d65f82474832589223df1e5cabdc8