### PR TITLE
sdk: fix CORS, /api/config, SDK, and test issues

### DIFF
--- a/smoothr/pages/api/config.js
+++ b/smoothr/pages/api/config.js
@@ -14,20 +14,21 @@ export default async function handler(req, res) {
     .eq('store_id', req.query.store_id)
     .maybeSingle();
 
-  if (response.error) {
-    const { status, code, message } = response.error;
-    console.error('[api/config] Supabase query failed', {
-      status,
-      code,
-      message
+    if (response.error) {
+      const { status, code, message } = response.error;
+      console.error('[api/config] Supabase query failed', {
+        status,
+        code,
+        message
+      });
+    }
+
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET');
+
+    res.status(200).json({
+      data:
+        response.data || { public_settings: {}, active_payment_gateway: null }
     });
   }
-
-  res.setHeader('Access-Control-Allow-Origin', '*');
-
-  res.status(200).json({
-    data:
-      response.data || { public_settings: {}, active_payment_gateway: null }
-  });
-}
 

--- a/smoothr/vercel.json
+++ b/smoothr/vercel.json
@@ -4,7 +4,8 @@
       "src": "/api/config",
       "dest": "/pages/api/config.js",
       "headers": {
-        "Access-Control-Allow-Origin": "*"
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET"
       }
     }
   ]

--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -19,16 +19,12 @@ globalThis.Lc = Lc;
 const { lookupRedirectUrl, lookupDashboardHomeUrl } = authExports;
 export const storeRedirects = { lookupRedirectUrl, lookupDashboardHomeUrl };
 
-// Some build environments reference a minified global `xc`, `Tc` or `Cc` for the
-// Supabase client. Ensure these placeholders exist and fall back to the imported
-// client when unavailable.
+// Some build environments reference a minified global `Tc` for the Supabase
+// client. Ensure this placeholder exists and fall back to the imported client
+// when unavailable.
 let authClient;
 try {
-  const xc = globalThis.xc || importedSupabase;
-  globalThis.xc = xc;
-  const Cc = globalThis.Cc || xc;
-  globalThis.Cc = Cc;
-  authClient = globalThis.Tc || Cc;
+  authClient = globalThis.Tc || importedSupabase;
   globalThis.Tc = authClient;
 } catch {
   authClient = null;

--- a/storefronts/features/cart/index.js
+++ b/storefronts/features/cart/index.js
@@ -9,23 +9,28 @@ const log = (...args) => getConfig().debug && console.log('[Smoothr Cart]', ...a
 const warn = (...args) => getConfig().debug && console.warn('[Smoothr Cart]', ...args);
 const err = (...args) => getConfig().debug && console.error('[Smoothr Cart]', ...args);
 
-// Ensure a minified global placeholder `Zc` exists and initialize cart storage
-// if it hasn't been created yet.
+// Ensure legacy globals exist and cart storage is initialized.
 try {
+  const el =
+    globalThis.el ||
+    (sel => (typeof document !== 'undefined' ? document.querySelector(sel) : null));
+  globalThis.el = el;
+
   const Zc = globalThis.Zc || {};
   globalThis.Zc = Zc;
+
   if (
     typeof window !== 'undefined' &&
     window.localStorage &&
     window.localStorage.getItem(STORAGE_KEY) == null
   ) {
-    window.localStorage[STORAGE_KEY] = JSON.stringify({
-      items: [],
-      meta: { lastModified: Date.now() }
-    });
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ items: [], meta: { lastModified: Date.now() } })
+    );
   }
 } catch {
-  // ignore storage errors
+  // ignore DOM/storage errors
 }
 
 // Some builds reference a minified `al` variable for localStorage access.

--- a/storefronts/features/checkout/init.js
+++ b/storefronts/features/checkout/init.js
@@ -39,6 +39,15 @@ try {
   Jc = {};
 }
 
+// Some environments expect a minified helper `Vc`. Provide a safe fallback.
+let Vc;
+try {
+  Vc = globalThis.Vc || {};
+  globalThis.Vc = Vc;
+} catch {
+  Vc = {};
+}
+
 let initialized = false;
 
 function forEachPayButton(fn) {

--- a/storefronts/smoothr-sdk.js
+++ b/storefronts/smoothr-sdk.js
@@ -81,7 +81,7 @@ if (!scriptEl || !storeId) {
 
     try {
       log('Initializing auth feature');
-      await import('./features/auth/init.js');
+      await import('storefronts/features/auth/init.js');
     } catch (err) {
       debug && console.warn('[Smoothr SDK] Auth init failed', err);
     }
@@ -102,7 +102,7 @@ if (!scriptEl || !storeId) {
     if (hasCheckoutTrigger) {
       try {
         log('Initializing checkout feature');
-        await import('./features/checkout/init.js');
+        await import('storefronts/features/checkout/init.js');
       } catch (err) {
         debug && console.warn('[Smoothr SDK] Checkout init failed', err);
       }
@@ -113,7 +113,7 @@ if (!scriptEl || !storeId) {
     if (hasCartTrigger) {
       try {
         log('Initializing cart feature');
-        await import('./features/cart/index.js');
+        await import('storefronts/features/cart/index.js');
       } catch (err) {
         debug && console.warn('[Smoothr SDK] Cart init failed', err);
       }

--- a/storefronts/tests/sdk/cart-dom-trigger.test.js
+++ b/storefronts/tests/sdk/cart-dom-trigger.test.js
@@ -14,18 +14,18 @@ describe("cart DOM trigger", () => {
     );
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "warn").mockImplementation(() => {});
-    vi.doMock("../../features/auth/init.js", () => ({ default: vi.fn() }));
-    vi.doMock("../../features/currency/index.js", () => ({ init: vi.fn().mockResolvedValue() }));
-    vi.doMock("../../features/cart/index.js", () => {
+    vi.mock("storefronts/features/auth/init.js", () => ({ default: vi.fn() }));
+    vi.mock("storefronts/features/currency/index.js", () => ({ init: vi.fn().mockResolvedValue() }));
+    vi.mock("storefronts/features/cart/index.js", () => {
       cartInitMock();
       return { __esModule: true };
     });
   });
 
   afterEach(() => {
-    vi.doUnmock("../../features/auth/init.js");
-    vi.doUnmock("../../features/currency/index.js");
-    vi.doUnmock("../../features/cart/index.js");
+    vi.unmock("storefronts/features/auth/init.js");
+    vi.unmock("storefronts/features/currency/index.js");
+    vi.unmock("storefronts/features/cart/index.js");
     delete globalThis[globalKey];
     vi.restoreAllMocks();
   });

--- a/storefronts/tests/sdk/cart-feature-loading.test.js
+++ b/storefronts/tests/sdk/cart-feature-loading.test.js
@@ -12,18 +12,18 @@ describe("cart feature loading", () => {
       Promise.resolve({ ok: true, json: () => Promise.resolve({ data: {} }) })
     );
     vi.spyOn(console, "warn").mockImplementation(() => {});
-    vi.doMock("../../features/auth/init.js", () => ({ default: vi.fn() }));
-    vi.doMock("../../features/currency/index.js", () => ({ init: vi.fn().mockResolvedValue() }));
-    vi.doMock("../../features/cart/index.js", () => {
+    vi.mock("storefronts/features/auth/init.js", () => ({ default: vi.fn() }));
+    vi.mock("storefronts/features/currency/index.js", () => ({ init: vi.fn().mockResolvedValue() }));
+    vi.mock("storefronts/features/cart/index.js", () => {
       cartInitMock();
       return { __esModule: true };
     });
   });
 
   afterEach(() => {
-    vi.doUnmock("../../features/auth/init.js");
-    vi.doUnmock("../../features/currency/index.js");
-    vi.doUnmock("../../features/cart/index.js");
+    vi.unmock("storefronts/features/auth/init.js");
+    vi.unmock("storefronts/features/currency/index.js");
+    vi.unmock("storefronts/features/cart/index.js");
     document.body.innerHTML = '';
     vi.restoreAllMocks();
   });

--- a/storefronts/tests/sdk/checkout-trigger.test.js
+++ b/storefronts/tests/sdk/checkout-trigger.test.js
@@ -16,10 +16,10 @@ describe("checkout DOM trigger", () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    vi.doMock("../../features/auth/init.js", () => ({ default: vi.fn() }));
-    vi.doMock("../../features/currency/index.js", () => ({ init: vi.fn().mockResolvedValue() }));
-    vi.doMock("../../features/cart/index.js", () => ({ __esModule: true }));
-    vi.doMock("../../features/checkout/init.js", () => {
+    vi.mock("storefronts/features/auth/init.js", () => ({ default: vi.fn() }));
+    vi.mock("storefronts/features/currency/index.js", () => ({ init: vi.fn().mockResolvedValue() }));
+    vi.mock("storefronts/features/cart/index.js", () => ({ __esModule: true }));
+    vi.mock("storefronts/features/checkout/init.js", () => {
       checkoutInitMock();
       return { __esModule: true };
     });
@@ -28,16 +28,17 @@ describe("checkout DOM trigger", () => {
   });
 
   afterEach(() => {
-    vi.doUnmock("../../features/auth/init.js");
-    vi.doUnmock("../../features/currency/index.js");
-    vi.doUnmock("../../features/cart/index.js");
-    vi.doUnmock("../../features/checkout/init.js");
+    vi.unmock("storefronts/features/auth/init.js");
+    vi.unmock("storefronts/features/currency/index.js");
+    vi.unmock("storefronts/features/cart/index.js");
+    vi.unmock("storefronts/features/checkout/init.js");
     vi.restoreAllMocks();
   });
 
-  it("initializes checkout when trigger exists", async () => {
-    const scriptEl = document.createElement('script');
-    scriptEl.dataset.storeId = '1';
+    it("initializes checkout when trigger exists", async () => {
+      const scriptEl = document.createElement('script');
+      scriptEl.dataset.storeId = '1';
+      scriptEl.id = 'smoothr-sdk';
     Object.defineProperty(window, 'location', { value: { search: '' }, configurable: true });
     window.addEventListener = vi.fn();
     window.removeEventListener = vi.fn();
@@ -46,15 +47,18 @@ describe("checkout DOM trigger", () => {
     vi.spyOn(document, 'querySelector').mockImplementation(sel => (sel === '[data-smoothr="pay"]' ? {} : null));
     vi.spyOn(document, 'getElementById').mockReturnValue(scriptEl);
 
-    await import("../../smoothr-sdk.js");
-    await flushPromises();
-    await flushPromises();
-    expect(checkoutInitMock).toHaveBeenCalled();
-  });
+      await import("../../smoothr-sdk.js");
+      await flushPromises();
+      await flushPromises();
+      await flushPromises();
+      await flushPromises();
+      expect(checkoutInitMock).toHaveBeenCalled();
+    });
 
-  it("skips checkout when trigger absent", async () => {
-    const scriptEl = document.createElement('script');
-    scriptEl.dataset.storeId = '1';
+    it("skips checkout when trigger absent", async () => {
+      const scriptEl = document.createElement('script');
+      scriptEl.dataset.storeId = '1';
+      scriptEl.id = 'smoothr-sdk';
     Object.defineProperty(window, 'location', { value: { search: '' }, configurable: true });
     window.addEventListener = vi.fn();
     window.removeEventListener = vi.fn();
@@ -63,9 +67,11 @@ describe("checkout DOM trigger", () => {
     vi.spyOn(document, 'querySelector').mockReturnValue(null);
     vi.spyOn(document, 'getElementById').mockReturnValue(scriptEl);
 
-    await import("../../smoothr-sdk.js");
-    await flushPromises();
-    await flushPromises();
-    expect(checkoutInitMock).not.toHaveBeenCalled();
-  });
+      await import("../../smoothr-sdk.js");
+      await flushPromises();
+      await flushPromises();
+      await flushPromises();
+      await flushPromises();
+      expect(checkoutInitMock).not.toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
## Summary
- handle CORS and defaults in `/api/config`
- expose /api/config on vercel with GET headers
- load store config via admin API in SDK and gate feature imports
- harden auth, checkout, and cart modules for legacy globals
- update tests for new SDK and checkout behaviors

## Testing
- `npm test` *(fails: expected spy to be called at least once)*
- `npm run build` (storefronts)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689d8dd640448325897c7522784a9eff