### PR TITLE
fix(sdk): robust config URL resolution, call feature init, correct cart import and log strings

### DIFF
--- a/storefronts/smoothr-sdk.js
+++ b/storefronts/smoothr-sdk.js
@@ -12,26 +12,58 @@ if (!scriptEl || !storeId) {
     '[Smoothr SDK] initialization aborted: #smoothr-sdk script element not found or data-store-id missing'
   );
 } else {
-  const base = document.currentScript
-    ? new URL(document.currentScript.src).origin
-    : 'https://smoothr-admin.vercel.app';
-  const configUrl =
-    document.currentScript?.dataset?.configUrl || new URL('/api/config', base);
+  const scriptOrigin = scriptEl?.src ? new URL(scriptEl.src).origin : location.origin;
+  const candidateUrls = [
+    scriptEl?.dataset?.configUrl,
+    `${scriptOrigin}/api/config`,
+    'https://smoothr-admin.vercel.app/api/config'
+  ].filter(Boolean);
+
+  async function fetchFirstOk(urls) {
+    for (const url of urls) {
+      try {
+        const u = new URL(url);
+        u.searchParams.set('store_id', storeId);
+        const res = await fetch(u.toString());
+        const ok =
+          res.ok ??
+          (typeof res.status === 'undefined' || (res.status >= 200 && res.status < 300));
+        if (ok) return res;
+      } catch {
+        // ignore errors
+      }
+    }
+    return null;
+  }
 
   const Smoothr = (window.Smoothr = window.Smoothr || {});
   window.smoothr = window.smoothr || Smoothr;
 
-  Smoothr.ready = fetch(`${configUrl}?store_id=${storeId}`)
-    .then(res => res.json())
-    .catch(() => ({ public_settings: {}, active_payment_gateway: null }));
+  Smoothr.ready = (async () => {
+    const res = await fetchFirstOk(candidateUrls);
+    if (!res) return null;
+    try {
+      return await res.json();
+    } catch {
+      return null;
+    }
+  })();
 
   (async () => {
     const fetched = await Smoothr.ready;
+    if (!fetched) {
+      console.warn(
+        '[Smoothr SDK] Config fetch failed; aborting feature initialization'
+      );
+      return;
+    }
+
     const existing = Smoothr.config || {};
     Smoothr.config = { ...existing, ...fetched };
 
     try {
-      await import('storefronts/features/auth/init.js');
+      const m = await import('./features/auth/init.js');
+      (m.default || m.init)?.(Smoothr.config);
     } catch (err) {
       console.warn('[Smoothr SDK] Auth init failed', err);
     }
@@ -39,7 +71,8 @@ if (!scriptEl || !storeId) {
     const hasCheckoutTrigger = document.querySelector('[data-smoothr="pay"]');
     if (hasCheckoutTrigger) {
       try {
-        await import('storefronts/features/checkout/init.js');
+        const m = await import('./features/checkout/init.js');
+        (m.default || m.init)?.(Smoothr.config);
       } catch (err) {
         console.warn('[Smoothr SDK] Checkout init failed', err);
       }
@@ -56,12 +89,13 @@ if (!scriptEl || !storeId) {
 
     if (hasCartTrigger) {
       try {
-        await import('storefronts/features/cart/index.js');
+        const m = await import('./features/cart/init.js');
+        (m.default || m.init)?.(Smoothr.config);
       } catch (err) {
         console.warn('[Smoothr SDK] Cart init failed', err);
       }
     } else {
-      console.warn(
+      console.log(
         '[Smoothr SDK] No cart triggers found, skipping cart initialization'
       );
     }


### PR DESCRIPTION
## Summary
- resolve config URL with script origin fallback and helper `fetchFirstOk`
- merge fetched config before loading features and invoke each feature's `init`
- import cart init directly and log cart trigger absence via `console.log`

## Testing
- `npm test` *(fails: spy expectations for feature init)*

------
https://chatgpt.com/codex/tasks/task_e_689db57942208325b2ce5b7079804e0d