### PR TITLE
fix(api): handle OPTIONS in pages/api and set precise CORS + caching; remove wildcard headers in vercel.json

### DIFF
--- a/smoothr/pages/api/config.js
+++ b/smoothr/pages/api/config.js
@@ -1,17 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
 
-export async function OPTIONS() {
-  return new Response(null, {
-    status: 200,
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type',
-      Vary: 'Origin'
-    }
-  });
-}
-
 export default async function handler(req, res) {
   const supabase = createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL,
@@ -44,6 +32,18 @@ export default async function handler(req, res) {
     }
   }
 
+  if (req.method === 'OPTIONS') {
+    res.setHeader('Access-Control-Allow-Origin', allowOrigin);
+    res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+    res.setHeader('Vary', 'Origin');
+    return res.status(204).end();
+  }
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET, OPTIONS');
+    return res.status(405).end();
+  }
+
   // Fetch public store config
   const response = await supabase
     .from('v_public_store')
@@ -66,6 +66,8 @@ export default async function handler(req, res) {
   res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
   res.setHeader('Vary', 'Origin');
+  res.setHeader('Cache-Control', 'public, max-age=60, s-maxage=300');
+  res.setHeader('X-Smoothr-Store', String(req.query.store_id || ''));
 
   const data = response.data || {};
   const {

--- a/smoothr/vercel.json
+++ b/smoothr/vercel.json
@@ -1,15 +1,5 @@
 {
   "routes": [
-      {
-        "src": "/api/config",
-        "dest": "/pages/api/config.js",
-        "headers": {
-          "Access-Control-Allow-Origin": "*",
-          "Access-Control-Allow-Methods": "GET, OPTIONS",
-          "Access-Control-Allow-Headers": "Content-Type",
-          "Vary": "Origin"
-        }
-      }
-    ]
-  }
-
+    { "src": "/api/config", "dest": "/pages/api/config.js" }
+  ]
+}

--- a/storefronts/smoothr-sdk.js
+++ b/storefronts/smoothr-sdk.js
@@ -90,6 +90,10 @@ if (!scriptEl || !storeId) {
 
   Smoothr.ready = (async () => {
     const res = await fetchFirstOk(candidateUrls);
+    const chosenUrl = res?.url ? new URL(res.url) : null;
+    if (chosenUrl) {
+      console.info('[Smoothr SDK] Using config URL:', chosenUrl.toString());
+    }
     if (!res) return null;
     try {
       return await res.json();


### PR DESCRIPTION
## Summary
- Handle CORS preflight and non-GET requests directly in `pages/api/config.js`, set precise CORS, cache, and store headers.
- Remove wildcard CORS headers from `vercel.json` so API handler is the source of truth.
- Log the resolved config URL in `smoothr-sdk.js` for easier debugging.

## Testing
- `npm test` *(fails: Failed to resolve import "../../shared/supabase/client.ts"...)*

------
https://chatgpt.com/codex/tasks/task_e_689dc432bfa48325b226e07061703907