### PR TITLE
refactor(sdk features): config-first features; remove top-level side-effects

### DIFF
--- a/storefronts/features/auth/index.js
+++ b/storefronts/features/auth/index.js
@@ -1,4 +1,3 @@
-import { supabase, ensureSupabaseSessionAuth } from '../../../supabase/browserClient.js';
 import { getConfig, mergeConfig } from '../config/globalConfig.js';
 import {
   initAuth as initAuthHelper,
@@ -54,6 +53,14 @@ function showLoginPopup() {
       })
     );
   }
+}
+
+let supabase;
+let ensureSupabaseSessionAuth = async () => {};
+
+export function setSupabaseClient(client, ensureFn = async () => {}) {
+  supabase = client;
+  ensureSupabaseSessionAuth = ensureFn;
 }
 
 async function login(email, password) {

--- a/storefronts/features/cart/init.js
+++ b/storefronts/features/cart/init.js
@@ -5,8 +5,30 @@ import { renderCart, bindRemoveFromCartButtons } from './renderCart.js';
 
 let initialized = false;
 
-export async function init(config = {}) {
+export async function init({ config, supabase, adapter } = {}) {
   if (initialized) return typeof window !== 'undefined' ? window.Smoothr?.cart : undefined;
+
+  if (typeof window !== 'undefined') {
+    globalThis.el =
+      globalThis.el || (sel => document.querySelector(sel));
+    globalThis.Zc = globalThis.Zc || {};
+    globalThis.tl = globalThis.tl || {};
+    globalThis.ol = globalThis.ol || {};
+    globalThis.Cc = globalThis.Cc || {};
+    globalThis.Xc = globalThis.Xc || {};
+    globalThis.ll = globalThis.ll || {};
+    globalThis.Pc = config || {};
+    try {
+      const initValue = JSON.stringify({
+        items: [],
+        meta: { lastModified: Date.now() }
+      });
+      localStorage.setItem('smoothr_cart', initValue);
+    } catch {}
+    const storage = window.localStorage;
+    globalThis.al = globalThis.al || storage;
+    globalThis.il = globalThis.il || storage;
+  }
 
   mergeConfig(config);
 


### PR DESCRIPTION
## Summary
- create and inject single Supabase client in SDK loader
- rework feature init files to accept `{ config, supabase, adapter }`
- move cart storage and legacy globals into `cart/init`

## Testing
- `npm test` *(fails: TypeError: init is not a function, 18 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_689dc6463088832586758e39ff8413a1