### PR TITLE
fix(auth): close init() before exports to satisfy ESM parser

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -225,5 +225,7 @@ async function init({ config, supabase, adapter } = {}) {
     };
   }
 
+}
+
 export { init };
 export default init;


### PR DESCRIPTION
## Summary
- close `init` function before exports so ESM parser no longer errors

## Testing
- `npm test` *(fails: AssertionError expected "spy" to be called with arguments: [ 'v_public_store' ], and other failures; 40 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_689dd1b4bfbc83258fc21c868b8c3cc1