### PR TITLE
fix(cart): forward init from barrel and add default export to cart/init

### DIFF
--- a/storefronts/features/cart/index.js
+++ b/storefronts/features/cart/index.js
@@ -1,3 +1,8 @@
+// Forward the cart initializer for callers that import the barrel
+export { init } from './init.js';
+export { init as default } from './init.js';
+export { init as initCart } from './init.js';
+
 const STORAGE_KEY = 'smoothr_cart';
 
 const getDebug = () => window.Smoothr?.config?.debug;

--- a/storefronts/features/cart/init.js
+++ b/storefronts/features/cart/init.js
@@ -50,3 +50,5 @@ export async function init({ config, supabase, adapter } = {}) {
   return typeof window !== 'undefined' ? window.Smoothr.cart : undefined;
 }
 
+export default init;
+export { init };


### PR DESCRIPTION
## Summary
- forward cart init through the barrel and add default and compat exports
- expose cart/init's init function as both default and named exports

## Testing
- `npm test` *(fails: AssertionError and TypeError across multiple suites)*

------
https://chatgpt.com/codex/tasks/task_e_689dd3be8fcc8325baa725af4b80faf8