### PR TITLE
Add __test_reset hooks and test env auto-reset for storefront features

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -12,6 +12,20 @@ let authClient;
 let initialized = false;
 let sessionReadyPromise;
 
+export function __test_resetAuth() {
+  initialized = false;
+  try {
+    if (typeof window !== 'undefined') {
+      if (window.Smoothr) delete window.Smoothr.auth;
+      if (window.smoothr) {
+        delete window.smoothr.auth;
+        delete window.smoothr.supabaseAuth;
+      }
+      delete window.supabaseAuth;
+    }
+  } catch {}
+}
+
 export async function loadConfig(storeId) {
   console.log('[Smoothr SDK] loadConfig called with storeId:', storeId);
   try {
@@ -100,6 +114,9 @@ export function waitForSessionReady() {
 }
 
 async function init({ config, supabase, adapter } = {}) {
+  if (typeof process !== 'undefined' && process.env?.NODE_ENV === 'test') {
+    initialized = false;
+  }
   if (initialized) return window.Smoothr?.auth;
   authClient = supabase;
 
@@ -227,5 +244,5 @@ async function init({ config, supabase, adapter } = {}) {
 
 }
 
-export { init };
 export default init;
+export { init };

--- a/storefronts/features/cart/index.js
+++ b/storefronts/features/cart/index.js
@@ -2,6 +2,7 @@
 export { init } from './init.js';
 export { init as default } from './init.js';
 export { init as initCart } from './init.js';
+export { __test_resetCart } from './init.js';
 
 const STORAGE_KEY = 'smoothr_cart';
 

--- a/storefronts/features/cart/init.js
+++ b/storefronts/features/cart/init.js
@@ -5,7 +5,25 @@ import { renderCart, bindRemoveFromCartButtons } from './renderCart.js';
 
 let initialized = false;
 
+export function __test_resetCart() {
+  try {
+    if (typeof window !== 'undefined') {
+      if (window.Smoothr) {
+        delete window.Smoothr.cart;
+      }
+      if (window.smoothr) {
+        delete window.smoothr.cart;
+      }
+      try { localStorage.removeItem('smoothr_cart'); } catch {}
+    }
+  } catch {}
+  initialized = false;
+}
+
 export async function init({ config, supabase, adapter } = {}) {
+  if (typeof process !== 'undefined' && process.env?.NODE_ENV === 'test') {
+    initialized = false;
+  }
   if (initialized) return typeof window !== 'undefined' ? window.Smoothr?.cart : undefined;
 
   if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary
- add `__test_resetCart` with automatic reset in cart initializer and re-export from barrel
- introduce `__test_resetCheckout` and `__checkoutInitialized` tracking with test-mode reset
- expose `__test_resetAuth` and auto-reset logic for auth feature

## Testing
- `npm test` *(fails: Test Files 18 failed | 50 passed)*
- `npm run test:supabase` *(fails: Test Files 3 failed | 3 passed | 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_689dd6adf8e483259b2670c0ce1f701b