### PR TITLE
refactor: flatten auth barrel exports

### DIFF
--- a/storefronts/features/auth/index.js
+++ b/storefronts/features/auth/index.js
@@ -1,24 +1,24 @@
-// Stable barrel for the auth feature — no DOM work at import time.
-// Simply re-export everything from init.js and provide a callable default.
-
+// Auth barrel: side-effect-free, stable export shapes.
+// Re-export everything from init.js so tests can spy on these symbols here.
 export {
-  default as init,
-  initPasswordResetConfirmation,
-  setSupabaseClient,
-  resolveSupabase,
+  // lifecycle
+  init as init,
+  default as default,
+  // hooks
   onAuthStateChangeHandler,
   mutationCallback,
   clickHandler,
   googleClickHandler,
   appleClickHandler,
   passwordResetClickHandler,
-  normalizeDomain,
+  // client plumbing
+  setSupabaseClient,
+  resolveSupabase,
+  // utils spied in tests
   lookupRedirectUrl,
   lookupDashboardHomeUrl,
+  normalizeDomain,
+  // optional flow
+  initPasswordResetConfirmation,
 } from './init.js';
-
-// Barrel default is a callable init
-import init from './init.js';
-const callable = (opts) => init(opts);
-export default callable;
 


### PR DESCRIPTION
## Summary
- simplify auth barrel by re-exporting lifecycle hooks and utilities directly from init.js

## Testing
- `npm test` *(fails: 39 failed, 123 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689ecd7afc6c8325abb71eaf4f6bac65