### PR TITLE
feat: expose named cart init

### DIFF
--- a/storefronts/features/cart/init.js
+++ b/storefronts/features/cart/init.js
@@ -1,5 +1,5 @@
 let _initPromise;
-export default async function init() {
+export async function init() {
   if (_initPromise) return _initPromise;
   _initPromise = (async () => {
     const w = globalThis.window || globalThis;
@@ -35,4 +35,5 @@ export default async function init() {
   })();
   return _initPromise;
 }
+export default init;
 


### PR DESCRIPTION
## Summary
- export named cart `init` alongside default
- maintain idempotent initialization and expose cart API

## Testing
- `npm test` *(fails: Test Files 16 failed | 52 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689ecedbb79c832598a2b1b47d0758cb