### PR TITLE
feat(checkout): accept top-level config in init

### DIFF
--- a/storefronts/features/checkout/init.js
+++ b/storefronts/features/checkout/init.js
@@ -113,14 +113,18 @@ const gatewayModules = {
   segpay: () => import('./gateways/segpay.js')
 };
 
-async function init({ config, supabase, adapter } = {}) {
+async function init(opts = {}) {
   if (typeof process !== 'undefined' && process.env?.NODE_ENV === 'test') {
     __checkoutInitialized = false;
   }
   if (__checkoutInitialized) return window.Smoothr?.checkout;
 
-  const Sc = (globalThis.Sc = config || {});
-  const globalConfig = config || {};
+  if (typeof opts !== 'object' || Array.isArray(opts)) opts = {};
+  const { config: nested = {}, supabase, adapter, ...topLevel } = opts;
+  const config = { ...nested, ...topLevel };
+
+  const Sc = (globalThis.Sc = config);
+  const globalConfig = config;
 
   const resolvedSupabase =
     supabase ??


### PR DESCRIPTION
## Summary
- allow checkout `init` to accept top-level config options and merge them

## Testing
- `npm --workspace storefronts test tests/sdk/gateway-loader.test.js tests/sdk/gateway-dispatch.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689ee492c3e883258fa1410d445734a3