### PR TITLE
feat(cart): bind add to cart once

### DIFF
--- a/storefronts/features/cart/addToCart.js
+++ b/storefronts/features/cart/addToCart.js
@@ -5,6 +5,7 @@ let noButtonsWarned = false;
 let foundLogShown = false;
 const MAX_POLL_ATTEMPTS = 10;
 let pollAttempts = 0;
+const _bound = new WeakSet();
 
 const { debug } = getConfig();
 const log = (...args) => debug && console.log('[Smoothr Cart]', ...args);
@@ -23,7 +24,23 @@ export function bindAddToCartButtons() {
     return;
   }
 
-  const buttons = document.querySelectorAll('[data-smoothr="add-to-cart"]');
+  const selectors = [
+    '[data-smoothr="add-to-cart"]',
+    '#smoothr-add-to-cart',
+    '.smoothr-add-to-cart',
+    '[data-smoothr-add-to-cart]',
+    '[data-smoothr-add]'
+  ];
+  const seen = new Set();
+  const buttons = [];
+  selectors.forEach((sel) => {
+    document.querySelectorAll(sel).forEach((btn) => {
+      if (!seen.has(btn)) {
+        seen.add(btn);
+        buttons.push(btn);
+      }
+    });
+  });
   if (debug && !foundLogShown)
     log(`found ${buttons.length} [data-smoothr="add-to-cart"] elements`);
   foundLogShown = true;
@@ -53,8 +70,8 @@ export function bindAddToCartButtons() {
 
     buttons.forEach(btn => {
       if (debug) log('🔗 binding [data-smoothr="add-to-cart"] button', btn);
-      if (btn.__smoothrBound) return;
-      btn.__smoothrBound = true;
+      if (_bound.has(btn)) return;
+      _bound.add(btn);
 
     btn.addEventListener('click', e => {
       e?.preventDefault?.();

--- a/storefronts/features/cart/init.js
+++ b/storefronts/features/cart/init.js
@@ -1,3 +1,5 @@
+import { bindAddToCartButtons } from './addToCart.js';
+
 let _initPromise;
 const _bound = new WeakSet();
 const _state = { items: [] };
@@ -26,7 +28,7 @@ export function __test_resetCart() {
 }
 function bindCartButtons() {
   const w = globalThis.window || globalThis;
-  const d = w.document;
+  const d = w.document || globalThis.document;
   if (!d?.querySelectorAll) return;
   const sel = [
     '#smoothr-cart-toggle',
@@ -40,6 +42,8 @@ function bindCartButtons() {
       _bound.add(el);
     }
   });
+
+  try { bindAddToCartButtons(); } catch {}
 }
 
 export async function init() {
@@ -57,8 +61,8 @@ export async function init() {
       clear: () => { _state.items.length = 0; },
     };
 
-    try { bindCartButtons(); } catch {}
     w.Smoothr.cart = api;
+    try { bindCartButtons(); } catch {}
     return api;
   })();
   return _initPromise;


### PR DESCRIPTION
## Summary
- ensure cart init binds `[data-smoothr="add-to-cart"]` buttons
- dedupe add-to-cart listeners with a WeakSet

## Testing
- `npm test` *(fails: 25 failed, 137 passed)*
- `npm --workspace storefronts test -- tests/sdk/cart-idempotency.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689ee58ed62c8325b93f4fa47ee35b22