### PR TITLE
feat(auth): polyfill CustomEvent and adjust event dispatch

### DIFF
--- a/storefronts/tests/sdk/account-access.test.js
+++ b/storefronts/tests/sdk/account-access.test.js
@@ -112,8 +112,8 @@ describe("account access trigger", () => {
       await clickHandler({ target: btn, preventDefault: () => {} });
       await flushPromises();
 
-      expect(global.window.dispatchEvent).toHaveBeenCalled();
-      const evt = global.window.dispatchEvent.mock.calls[0][0];
+      expect(global.document.dispatchEvent).toHaveBeenCalled();
+      const evt = global.document.dispatchEvent.mock.calls[0][0];
       expect(evt.type).toBe("smoothr:open-auth");
       expect(evt.detail.targetSelector).toBe('[data-smoothr="auth-wrapper"]');
     });

--- a/storefronts/tests/sdk/dom-mutation.test.js
+++ b/storefronts/tests/sdk/dom-mutation.test.js
@@ -401,8 +401,8 @@ describe("dynamic DOM bindings", () => {
 
     await docClickHandler({ target: btn, preventDefault: () => {} });
     await flushPromises();
-    expect(win.dispatchEvent).toHaveBeenCalled();
-    const evt = win.dispatchEvent.mock.calls[0][0];
+    expect(global.document.dispatchEvent).toHaveBeenCalled();
+    const evt = global.document.dispatchEvent.mock.calls[0][0];
     expect(evt.type).toBe("smoothr:open-auth");
     expect(evt.detail.targetSelector).toBe('[data-smoothr="auth-wrapper"]');
   });


### PR DESCRIPTION
## Summary
- add a minimal CustomEvent polyfill
- dispatch auth modal events via `document` instead of `window`
- emit login event when initial auth state includes a user

## Testing
- `npm test` *(fails: dom-mutation, password-reset)*


------
https://chatgpt.com/codex/tasks/task_e_689f051dba88832581a4bdd8ceead60a