### PR TITLE
Ensure auth init always triggers login event

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -121,10 +121,9 @@ export async function init(options = {}) {
 
     // Idempotent global
     w.Smoothr = w.Smoothr || {};
-    if (w.Smoothr.auth) return w.Smoothr.auth;
 
     // Minimal API shape some tests reach for
-    const api = {
+    const api = w.Smoothr.auth || {
       client: client || null,
       user: { value: null },
       init,


### PR DESCRIPTION
## Summary
- Remove early return when `w.Smoothr.auth` already exists
- Always initialize auth API and dispatch `smoothr:login` when `getUser` returns a user

## Testing
- `npm test` *(fails: Failed to resolve import "../../shared/supabase/client.ts" and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_689f1dbe86408325bdb55e60491de062