### PR TITLE
Dispatch login event after OAuth

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -278,19 +278,37 @@ export async function init(options = {}) {
     googleClickHandler = async (e) => {
       try { e?.preventDefault?.(); } catch {}
       globalThis.localStorage?.setItem?.('smoothr_oauth', '1');
-      await resolveSupabase()?.auth?.signInWithOAuth?.({
+      const c = resolveSupabase();
+      await c?.auth?.signInWithOAuth?.({
         provider: 'google',
         options: { redirectTo: w.location?.origin || '' },
       });
+      try {
+        const res = await c?.auth?.getUser?.();
+        w.Smoothr.auth.user.value = res?.data?.user ?? null;
+      } catch {}
+      const ev = typeof w.CustomEvent === 'function'
+        ? new w.CustomEvent('smoothr:login')
+        : { type: 'smoothr:login' };
+      (w.document || globalThis.document)?.dispatchEvent?.(ev);
     };
 
     appleClickHandler = async (e) => {
       try { e?.preventDefault?.(); } catch {}
       globalThis.localStorage?.setItem?.('smoothr_oauth', '1');
-      await resolveSupabase()?.auth?.signInWithOAuth?.({
+      const c = resolveSupabase();
+      await c?.auth?.signInWithOAuth?.({
         provider: 'apple',
         options: { redirectTo: w.location?.origin || '' },
       });
+      try {
+        const res = await c?.auth?.getUser?.();
+        w.Smoothr.auth.user.value = res?.data?.user ?? null;
+      } catch {}
+      const ev = typeof w.CustomEvent === 'function'
+        ? new w.CustomEvent('smoothr:login')
+        : { type: 'smoothr:login' };
+      (w.document || globalThis.document)?.dispatchEvent?.(ev);
     };
 
     signOutHandler = async (e) => {


### PR DESCRIPTION
## Summary
- dispatch `smoothr:login` event after Google and Apple OAuth flows
- refresh cached auth user after OAuth sign-in

## Testing
- `npm --workspace storefronts test`
- `npm run test:supabase` *(fails: Failed to resolve import "../../shared/supabase/client.ts"; expected { Object (X-Client-Info) } to deeply equal ObjectContaining...)*

------
https://chatgpt.com/codex/tasks/task_e_689f22cdcef08325894f8f04a08fe738