### PR TITLE
feat: add auth reset helper for tests

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -367,3 +367,20 @@ export async function initPasswordResetConfirmation(opts = {}) {
   try { mutationCallback(); } catch {}
 }
 
+// Exported test helper to reset private module state between specs.
+export function __test_resetAuth() {
+  _initPromise = undefined;
+  _restoredOnce = false;
+  _seededUserOnce = false;
+  _prSession = null;
+  _prRedirect = '';
+  _injectedClient = null;
+  onAuthStateChangeHandler = () => {};
+  mutationCallback = () => {};
+  clickHandler = () => {};
+  googleClickHandler = () => {};
+  appleClickHandler = () => {};
+  signOutHandler = () => {};
+  docClickHandler = () => {};
+}
+

--- a/storefronts/tests/features/auth.test.js
+++ b/storefronts/tests/features/auth.test.js
@@ -4,7 +4,7 @@ let fromMock;
 let supabaseMock;
 
 describe('auth feature init', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.resetModules();
     fromMock = vi.fn(() => ({
       select: vi.fn(() => ({
@@ -54,6 +54,8 @@ describe('auth feature init', () => {
       currentScript: { getAttribute: vi.fn(), dataset: {} },
       querySelectorAll: vi.fn(() => [])
     };
+    const mod = await import('../../features/auth/init.js');
+    mod.__test_resetAuth();
   });
 
   it('loads v_public_store during init', async () => {

--- a/storefronts/tests/sdk/auth-idempotent.test.js
+++ b/storefronts/tests/sdk/auth-idempotent.test.js
@@ -33,7 +33,7 @@ vi.mock('../../../supabase/browserClient.js', () => ({
   ensureSupabaseSessionAuth: vi.fn().mockResolvedValue(),
 }));
 
-beforeEach(() => {
+beforeEach(async () => {
   vi.resetModules();
   process.env.NODE_ENV = 'production';
   global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }));
@@ -64,6 +64,8 @@ beforeEach(() => {
       }))
     }))
   };
+  const mod = await import('../../features/auth/init.js');
+  mod.__test_resetAuth();
 });
 
 describe('auth init session restoration', () => {

--- a/storefronts/tests/sdk/auth-state-change.test.js
+++ b/storefronts/tests/sdk/auth-state-change.test.js
@@ -32,6 +32,7 @@ vi.mock("@supabase/supabase-js", () => {
 });
 
 import * as auth from "../../features/auth/index.js";
+import { __test_resetAuth } from "../../features/auth/init.js";
 
 function flushPromises() {
   return new Promise(setImmediate);
@@ -39,6 +40,7 @@ function flushPromises() {
 
 describe("auth state change", () => {
   beforeEach(() => {
+    __test_resetAuth();
     global.window = {
       location: { origin: "", href: "", hostname: "" },
       addEventListener: vi.fn(),


### PR DESCRIPTION
## Summary
- add `__test_resetAuth` helper to reset auth module state
- use helper in auth-related tests to ensure clean module state

## Testing
- `npm test` *(fails: Failed to resolve import "../../shared/supabase/client.ts" from "supabase/functions/get_gateway_credentials/index.ts" and other Supabase function tests)*

------
https://chatgpt.com/codex/tasks/task_e_689f270fca4083258ee77d2b45bf16d0