### PR TITLE
test: add auth trigger dynamic import tests

### DIFF
--- a/storefronts/tests/sdk/auth-trigger.test.js
+++ b/storefronts/tests/sdk/auth-trigger.test.js
@@ -1,0 +1,47 @@
+import { vi, expect, test, beforeEach, afterEach } from 'vitest';
+import { __test_bootstrap } from 'storefronts/smoothr-sdk.js';
+
+const authInitMock = vi.fn();
+vi.mock('storefronts/features/auth/init.js', () => ({
+  default: authInitMock,
+  init: authInitMock,
+}));
+
+beforeEach(() => {
+  authInitMock.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('loads auth feature when auth trigger is present', async () => {
+  const authEl = document.createElement('div');
+  authEl.setAttribute('data-smoothr', 'auth');
+
+  vi.spyOn(document, 'querySelector')
+    .mockReturnValueOnce(authEl)
+    .mockReturnValue(null);
+
+  await __test_bootstrap({
+    storeId: 'test-store',
+    supabaseUrl: 'x',
+    supabaseAnonKey: 'y',
+    activePaymentGateway: 'stripe',
+  });
+
+  expect(authInitMock).toHaveBeenCalled();
+});
+
+test('does not load auth feature when trigger is absent', async () => {
+  vi.spyOn(document, 'querySelector').mockReturnValue(null);
+
+  await __test_bootstrap({
+    storeId: 'test-store',
+    supabaseUrl: 'x',
+    supabaseAnonKey: 'y',
+    activePaymentGateway: 'stripe',
+  });
+
+  expect(authInitMock).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add tests for auth trigger to ensure auth module is loaded when data-smoothr="auth" element is present
- assert auth module not loaded when trigger is absent

## Testing
- `npm test` *(fails: Failed to resolve import "../../shared/supabase/client.ts" from "supabase/functions/get_gateway_credentials/index.ts")*


------
https://chatgpt.com/codex/tasks/task_e_689f2c53fee08325936dae441f0f6e9f