### PR TITLE
refactor: lazy load cart and checkout utilities

### DIFF
--- a/storefronts/features/cart/init.js
+++ b/storefronts/features/cart/init.js
@@ -40,11 +40,6 @@ async function bindCartButtons() {
       _bound.add(el);
     }
   });
-
-  try {
-    const { bindAddToCartButtons } = await import('./addToCart.js');
-    bindAddToCartButtons();
-  } catch {}
 }
 
 export async function init() {
@@ -63,7 +58,11 @@ export async function init() {
     };
 
     w.Smoothr.cart = api;
-    try { await bindCartButtons(); } catch {}
+    try {
+      await bindCartButtons();
+      const { bindAddToCartButtons } = await import('./addToCart.js');
+      bindAddToCartButtons();
+    } catch {}
     return api;
   })();
   return _initPromise;


### PR DESCRIPTION
## Summary
- move addToCart binding import into cart init and keep file-scope isolated
- lazily import checkout utilities and gateway modules inside init

## Testing
- `npm test` *(fails: Test Files 2 failed | 67 passed)*
- `npm run test:supabase` *(fails: Test Files 3 failed | 3 passed | 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_689f3fbbfc588325903f2996a6eebebe