### PR TITLE
fix(checkout): standardize gateway failure message and settle mounts

### DIFF
--- a/storefronts/features/checkout/init.js
+++ b/storefronts/features/checkout/init.js
@@ -190,15 +190,13 @@ async function init(opts = {}) {
           globalVar: sdkGlobals[provider]
         });
       } catch (e) {
-        if (getConfig().debug) {
-          const msg =
-            provider === 'stripe'
-              ? '[Smoothr Checkout] Failed to load Stripe SDK'
-              : '[Smoothr Checkout] Failed to load gateway script';
-          console.error(msg, e);
-        }
+        const msg =
+          provider === 'stripe'
+            ? '[Smoothr Checkout] Failed to load Stripe SDK'
+            : '[Smoothr Checkout] Failed to load gateway script';
+        console.error(msg, e);
         warn('Failed to load gateway SDK:', e?.message || e);
-        return;
+        throw e;
       }
     }
 
@@ -430,9 +428,10 @@ async function init(opts = {}) {
   });
   log('pay button handlers attached');
   } catch (error) {
-    const debug = getConfig().debug;
-    if (debug) console.warn('[Smoothr Checkout] Initialization failed', error);
-    return {};
+    if (typeof getConfig === 'function' && getConfig().debug) {
+      console.warn('[Smoothr Checkout] Initialization failed', error);
+    }
+    throw error;
   }
 }
 

--- a/storefronts/tests/adapters/checkout.test.js
+++ b/storefronts/tests/adapters/checkout.test.js
@@ -213,8 +213,12 @@ afterEach(() => {
 });
 
 async function loadCheckout() {
+  const cfg = global.window.SMOOTHR_CONFIG || {};
+  const originalGateway = cfg.active_payment_gateway;
+  cfg.active_payment_gateway = undefined;
   const mod = await import('../../adapters/webflow/initCheckoutWebflow.js');
   window.Smoothr.checkout.submit = submitCheckout;
+  cfg.active_payment_gateway = originalGateway;
   return mod.init;
 }
 
@@ -294,7 +298,7 @@ describe('checkout', () => {
   it('logs warning when gateway script fails to load', async () => {
     loadScriptOnceMock.mockRejectedValueOnce(new Error('load failed'));
     const init = await loadCheckout();
-    await init();
+    await expect(init()).rejects.toThrow('load failed');
     expect(console.error).toHaveBeenCalledWith(
       '[Smoothr Checkout] Failed to load Stripe SDK',
       expect.any(Error)


### PR DESCRIPTION
## Summary
- log standardized message when Stripe SDK fails to load and reject init
- ensure checkout adapter mocks settle and script loader errors surface
- stub checkout payload test script loading for Node environment

## Testing
- `npm --workspace storefronts test`

------
https://chatgpt.com/codex/tasks/task_e_689f4d28b6c48325bb114488ce36ac2d