### PR TITLE
fix(sdk): lazily create Supabase client after config fetch

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -78,6 +78,17 @@ export const resolveSupabase = async () => {
   const w = g.window || g;
   if (_injectedClient) return _injectedClient;
   if (w?.Smoothr?.__supabase) return w.Smoothr.__supabase;
+  const maybeReady = w?.Smoothr?.supabaseReady;
+  if (maybeReady) {
+    try {
+      const client = await maybeReady;
+      if (client) {
+        w.Smoothr = w.Smoothr || {};
+        w.Smoothr.__supabase = client;
+        return client;
+      }
+    } catch {}
+  }
   const existing = w?.Smoothr?.auth?.client || w?.supabase;
   if (existing) {
     w.Smoothr = w.Smoothr || {};


### PR DESCRIPTION
## Summary
- lazily create Supabase client via `Smoothr.supabaseReady` promise after config fetch
- ensure auth feature awaits `supabaseReady` when resolving client

## Testing
- `npm --workspace storefronts test`
- `npm run test:supabase` *(fails: Failed to resolve import "../../shared/supabase/client.ts" from "supabase/functions/get_gateway_credentials/index.ts")*

------
https://chatgpt.com/codex/tasks/task_e_689f545254508325957e96b4ec05dba8