### PR TITLE
fix cart checkout init order

### DIFF
--- a/storefronts/features/cart/init.js
+++ b/storefronts/features/cart/init.js
@@ -58,9 +58,9 @@ export async function init() {
 
     try {
       await bindCartButtons();
-      const { bindAddToCartButtons } = await import('./addToCart.js');
       w.Smoothr = w.Smoothr || {};
       w.Smoothr.cart = api;
+      const { bindAddToCartButtons } = await import('./addToCart.js');
       bindAddToCartButtons();
     } catch {
       w.Smoothr = w.Smoothr || {};

--- a/storefronts/features/checkout/init.js
+++ b/storefronts/features/checkout/init.js
@@ -86,6 +86,18 @@ async function init(opts = {}) {
 
       mergeConfig({ ...config, supabase: resolvedSupabase });
       await platformReady();
+
+    let isSubmitting = false;
+    const { log, warn, err, select, q } = checkoutLogger();
+
+    const publicConfig = await loadPublicConfig(
+      getConfig().storeId,
+      resolvedSupabase
+    );
+    if (publicConfig) {
+      mergeConfig(publicConfig);
+    }
+
     const [
       { default: resolveGateway },
       { default: collectFormFields },
@@ -102,17 +114,6 @@ async function init(opts = {}) {
 
     const debug = getConfig().debug;
     if (debug) console.log('[Smoothr] init', config);
-
-    let isSubmitting = false;
-    const { log, warn, err, select, q } = checkoutLogger();
-
-    const publicConfig = await loadPublicConfig(
-      getConfig().storeId,
-      resolvedSupabase
-    );
-    if (publicConfig) {
-      mergeConfig(publicConfig);
-    }
 
     log('SDK initialized');
     log('SMOOTHR_CONFIG', JSON.stringify(getConfig()));


### PR DESCRIPTION
## Summary
- avoid referencing Smoothr.cart during add-to-cart module evaluation by assigning global cart before dynamic import
- load checkout gateway helpers only after configuration merges complete

## Testing
- `npm test` *(fails: dom-mutation, signup)*

------
https://chatgpt.com/codex/tasks/task_e_689f6339c0c8832586986debc9975abd