### PR TITLE
feat: make browser supabase client lazy

### DIFF
--- a/storefronts/core/credentials.js
+++ b/storefronts/core/credentials.js
@@ -1,4 +1,4 @@
-import supabase, { ensureSupabaseSessionAuth } from '../../supabase/browserClient.js';
+import { getSupabaseClient, ensureSupabaseSessionAuth } from '../../supabase/browserClient.js';
 import { getConfig } from '../features/config/globalConfig.js';
 
 export async function getGatewayCredential(gateway) {
@@ -6,6 +6,10 @@ export async function getGatewayCredential(gateway) {
     typeof window !== 'undefined' &&
     new URLSearchParams(window.location.search).has('smoothr-debug');
   try {
+    const supabase = await getSupabaseClient();
+    if (!supabase) {
+      return { publishable_key: null, tokenization_key: null, api_login_id: null };
+    }
     await ensureSupabaseSessionAuth();
     const { storeId: store_id } = getConfig();
 

--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -123,14 +123,17 @@ export const resolveSupabase = async () => {
 };
 
 /** @internal test-only helper to avoid bundling legacy deps */
-async function tryImportClient() {
-  try {
-    const mod = await import('../../../supabase/browserClient.js');
-    return mod.supabase ?? mod.default ?? null;
-  } catch {
-    return null;
+  async function tryImportClient() {
+    try {
+      const mod = await import('../../../supabase/browserClient.js');
+      if (mod.getSupabaseClient) {
+        return await mod.getSupabaseClient();
+      }
+      return mod.default ?? null;
+    } catch {
+      return null;
+    }
   }
-}
 export { tryImportClient as __test_tryImportClient };
 
 export { lookupRedirectUrl, lookupDashboardHomeUrl };

--- a/storefronts/tests/adapters/checkout.test.js
+++ b/storefronts/tests/adapters/checkout.test.js
@@ -18,8 +18,7 @@ vi.mock('../../../supabase/browserClient.js', () => {
   const from = vi.fn(() => ({ select }));
   const client = { from };
   return {
-    supabase: client,
-    default: client,
+    getSupabaseClient: () => Promise.resolve(client),
     ensureSupabaseSessionAuth: vi.fn()
   };
 });

--- a/storefronts/tests/core/credential-helper.test.js
+++ b/storefronts/tests/core/credential-helper.test.js
@@ -4,7 +4,7 @@ const invokeMock = vi.fn();
 const ensureMock = vi.fn();
 
 vi.mock('../../../supabase/browserClient.js', () => ({
-  default: { functions: { invoke: invokeMock } },
+  getSupabaseClient: () => Promise.resolve({ functions: { invoke: invokeMock } }),
   ensureSupabaseSessionAuth: ensureMock
 }));
 

--- a/storefronts/tests/features/auth.test.js
+++ b/storefronts/tests/features/auth.test.js
@@ -33,10 +33,10 @@ describe('auth feature init', () => {
       }
     };
     globalThis.xc = supabaseMock;
-    vi.doMock('../../../supabase/browserClient.js', () => ({
-      supabase: supabaseMock,
-      ensureSupabaseSessionAuth: vi.fn().mockResolvedValue()
-    }));
+      vi.doMock('../../../supabase/browserClient.js', () => ({
+        getSupabaseClient: () => Promise.resolve(supabaseMock),
+        ensureSupabaseSessionAuth: vi.fn().mockResolvedValue()
+      }));
     vi.doMock('../../features/currency/index.js', () => ({
       setBaseCurrency: vi.fn(),
       updateRates: vi.fn(),

--- a/storefronts/tests/sdk/auth-idempotent.test.js
+++ b/storefronts/tests/sdk/auth-idempotent.test.js
@@ -25,13 +25,14 @@ const getSessionMock = vi.fn().mockResolvedValue({
 let client;
 
 vi.mock('../../../supabase/browserClient.js', () => ({
-  supabase: {
-    auth: { getSession: getSessionMock },
-    from: vi.fn(() => ({
-      select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue({ data: null }) })) })),
-    })),
-    supabaseUrl: process.env.SUPABASE_URL,
-  },
+  getSupabaseClient: () =>
+    Promise.resolve({
+      auth: { getSession: getSessionMock },
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue({ data: null }) })) })),
+      })),
+      supabaseUrl: process.env.SUPABASE_URL,
+    }),
   ensureSupabaseSessionAuth: vi.fn().mockResolvedValue(),
 }));
 

--- a/storefronts/tests/utils/supabase-singleton.test.js
+++ b/storefronts/tests/utils/supabase-singleton.test.js
@@ -1,24 +1,25 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 let createClient;
-const globalKey = '__supabaseAuthClientsmoothr-browser-client';
 
 describe('supabase browser client singleton', () => {
   beforeEach(() => {
     vi.resetModules();
     createClient = vi.fn(() => ({ auth: {} }));
     vi.mock('@supabase/supabase-js', () => ({ createClient }));
-    delete globalThis[globalKey];
+    if (globalThis.Smoothr) {
+      delete globalThis.Smoothr.__supabase;
+    }
   });
 
-  it('creates client only once across imports', async () => {
-    const mod1 = await import('../../../supabase/browserClient.js');
-    const client1 = mod1.default;
-    vi.resetModules();
-    vi.mock('@supabase/supabase-js', () => ({ createClient }));
-    const mod2 = await import('../../../supabase/browserClient.js');
-    const client2 = mod2.default;
-    expect(createClient).toHaveBeenCalledTimes(1);
-    expect(client1).toBe(client2);
-  });
+    it('creates client only once across calls', async () => {
+      const mod1 = await import('../../../supabase/browserClient.js');
+      const client1 = await mod1.getSupabaseClient();
+      vi.resetModules();
+      vi.mock('@supabase/supabase-js', () => ({ createClient }));
+      const mod2 = await import('../../../supabase/browserClient.js');
+      const client2 = await mod2.getSupabaseClient();
+      expect(createClient).toHaveBeenCalledTimes(1);
+      expect(client1).toBe(client2);
+    });
 });

--- a/supabase/client/browserClient.js
+++ b/supabase/client/browserClient.js
@@ -1,35 +1,73 @@
 import { createClient } from '@supabase/supabase-js';
 
-const storageKey = 'smoothr-browser-client';
-const globalKey = `__supabaseAuthClient${storageKey}`;
+let _supabasePromise = null;
 
-const supabase =
-  globalThis[globalKey] ||
-  (globalThis[globalKey] = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-  ));
+/** Resolve/create a singleton Supabase client after loader config. */
+export async function getSupabaseClient() {
+  const w = typeof window !== 'undefined' ? window : globalThis;
 
-async function ensureSupabaseSessionAuth() {
-  try {
-    if (typeof process !== 'undefined' && process.env.NODE_ENV === 'test') return;
+  // If loader already created it, reuse.
+  if (w.Smoothr?.__supabase) return w.Smoothr.__supabase;
 
-    const {
-      data: { session }
-    } = await supabase.auth.getSession();
+  if (!_supabasePromise) {
+    _supabasePromise = (async () => {
+      // Preferred path: wait for loader-provided supabaseReady.
+      if (w.Smoothr?.supabaseReady) {
+        const c = await w.Smoothr.supabaseReady;
+        if (c) return (w.Smoothr.__supabase = c);
+      }
 
-    const access_token = session?.access_token;
-    const refresh_token = session?.refresh_token;
+      // Fallback for tests/dev: pull from env or preloaded config.
+      const cfg = (w.Smoothr && w.Smoothr.config) || {};
+      const url =
+        cfg.supabaseUrl ||
+        (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_SUPABASE_URL);
+      const key =
+        cfg.supabaseAnonKey ||
+        (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_SUPABASE_ANON_KEY);
 
-    if (access_token && refresh_token) {
-      await supabase.auth.setSession({ access_token, refresh_token });
-    } else {
-      console.warn('[Smoothr] Missing access or refresh token — skipping session restore');
-    }
-  } catch {
-    // ignore errors
+      if (!url || !key) return null;
+
+      const client = createClient(url, key, {
+        auth: {
+          persistSession: true,
+          storageKey: `smoothr_${cfg.storeId || 'default'}`,
+        },
+      });
+      w.Smoothr = w.Smoothr || {};
+      w.Smoothr.__supabase = client;
+      return client;
+    })();
   }
+  return _supabasePromise;
 }
 
-export { supabase, ensureSupabaseSessionAuth };
-export default supabase;
+export async function ensureSupabaseSessionAuth() {
+  try {
+    const w = typeof window !== 'undefined' ? window : globalThis;
+    const client = await getSupabaseClient();
+    if (!client) return;
+
+    const storage = w.localStorage;
+    if (!storage?.getItem) return;
+
+    const candidates = ['smoothr.auth.session', 'supabase.auth.token'];
+    for (const key of candidates) {
+      try {
+        const raw = storage.getItem(key);
+        if (!raw) continue;
+        const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+        const s = parsed?.currentSession || parsed?.session || parsed || null;
+        const access_token = s?.access_token || s?.access?.token;
+        const refresh_token = s?.refresh_token || s?.refresh?.token;
+        if (access_token && refresh_token) {
+          await client.auth.setSession({ access_token, refresh_token });
+          break;
+        }
+      } catch {}
+    }
+  } catch {}
+}
+
+// Do NOT export a default client (prevents eager init).
+export default undefined;


### PR DESCRIPTION
## Summary
- lazily create Supabase browser client with getSupabaseClient and session restoration helper
- update auth helpers and credential helper to resolve client at runtime
- adjust tests for new client API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a081dbf1148325aeaa5a818fdfd416