### PR TITLE
test(storefronts): add Supabase mock helper + setup; adapt auth specs to lazy client

### DIFF
--- a/storefronts/tests/sdk/account-access.test.js
+++ b/storefronts/tests/sdk/account-access.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createClientMock, currentSupabaseMocks } from "../utils/supabase-mock";
 
 var getUserMock;
 var createClientMock;
@@ -77,6 +78,8 @@ describe("account access trigger", () => {
 
     beforeEach(async () => {
       vi.resetModules();
+      createClientMock();
+      const { getUserMock } = currentSupabaseMocks();
       authHelpers = await import("../../../supabase/authHelpers.js");
       vi
         .spyOn(authHelpers, "lookupDashboardHomeUrl")
@@ -101,6 +104,8 @@ describe("account access trigger", () => {
   describe("dispatches open-auth event for anonymous users", () => {
     beforeEach(async () => {
       vi.resetModules();
+      createClientMock();
+      const { getUserMock } = currentSupabaseMocks();
       getUserMock.mockResolvedValueOnce({ data: { user: null } });
       authHelpers = await import("../../../supabase/authHelpers.js");
       const { init } = await import("../../features/auth/index.js");

--- a/storefronts/tests/sdk/dom-mutation.test.js
+++ b/storefronts/tests/sdk/dom-mutation.test.js
@@ -1,5 +1,6 @@
 // [Codex Fix] Updated for ESM/Vitest/Node 20 compatibility
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createClientMock, currentSupabaseMocks } from "../utils/supabase-mock";
 let auth;
 
 var signInMock;
@@ -7,7 +8,7 @@ var signUpMock;
 var signInWithOAuthMock;
 var resetPasswordMock;
 var getUserMock;
-var createClientMock;
+var legacyCreateClientMock;
 
 const STORE_ID = "test-store";
 
@@ -17,7 +18,7 @@ vi.mock("@supabase/supabase-js", () => {
   signInWithOAuthMock = vi.fn();
   resetPasswordMock = vi.fn();
   getUserMock = vi.fn(() => Promise.resolve({ data: { user: null } }));
-  createClientMock = vi.fn(() => ({
+  legacyCreateClientMock = vi.fn(() => ({
     auth: {
       getUser: getUserMock,
       signOut: vi.fn(),
@@ -35,7 +36,7 @@ vi.mock("@supabase/supabase-js", () => {
       })),
     })),
   }));
-  return { createClient: createClientMock };
+  return { createClient: legacyCreateClientMock };
 });
 
 
@@ -57,13 +58,17 @@ describe("dynamic DOM bindings", () => {
   let docClickHandler;
 
     beforeEach(async () => {
-      signInMock?.mockClear?.();
-      signUpMock?.mockClear?.();
-      signInWithOAuthMock?.mockClear?.();
-      resetPasswordMock?.mockClear?.();
-      getUserMock?.mockClear?.();
       vi.resetModules();
       document?.dispatchEvent?.mockClear?.();
+      createClientMock();
+      ({
+        signInMock,
+        signUpMock,
+        signInWithOAuthMock,
+        resetPasswordMock,
+        getUserMock,
+      } = currentSupabaseMocks());
+      getUserMock.mockResolvedValue({ data: { user: null } });
       elements = [];
       forms = [];
       mutationCallback = undefined;

--- a/storefronts/tests/sdk/google-login.test.js
+++ b/storefronts/tests/sdk/google-login.test.js
@@ -1,14 +1,15 @@
 // [Codex Fix] Updated for ESM/Vitest/Node 20 compatibility
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createClientMock, currentSupabaseMocks } from "../utils/supabase-mock";
 
   var getUserMock;
   var signInWithOAuthMock;
-  var createClientMock;
+  var legacyCreateClientMock;
 
 vi.mock("@supabase/supabase-js", () => {
   getUserMock = vi.fn(() => Promise.resolve({ data: { user: null } }));
   signInWithOAuthMock = vi.fn(() => Promise.resolve());
-  createClientMock = vi.fn(() => ({
+  legacyCreateClientMock = vi.fn(() => ({
     auth: {
       getUser: getUserMock,
       signOut: vi.fn(),
@@ -23,7 +24,7 @@ vi.mock("@supabase/supabase-js", () => {
       })),
     })),
   }));
-  return { createClient: createClientMock };
+  return { createClient: legacyCreateClientMock };
 });
 
 let init;
@@ -39,6 +40,8 @@ describe("OAuth login buttons", () => {
 
   beforeEach(async () => {
     vi.resetModules();
+    createClientMock();
+    ({ signInWithOAuthMock } = currentSupabaseMocks());
     googleClickHandler = undefined;
     appleClickHandler = undefined;
     store = null;

--- a/storefronts/tests/sdk/login-dataset-immutable.test.js
+++ b/storefronts/tests/sdk/login-dataset-immutable.test.js
@@ -1,5 +1,6 @@
 // [Codex Fix] New test for immutable dataset
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createClientMock, currentSupabaseMocks } from "../utils/supabase-mock";
 
 var signInMock;
 var getUserMock;
@@ -40,6 +41,9 @@ describe("login with immutable dataset", () => {
 
   beforeEach(async () => {
     vi.resetModules();
+    createClientMock();
+    ({ signInMock, getUserMock } = currentSupabaseMocks());
+    getUserMock.mockResolvedValue({ data: { user: null } });
     clickHandler = undefined;
     emailValue = "user@example.com";
     passwordValue = "Password1";

--- a/storefronts/tests/sdk/login.test.js
+++ b/storefronts/tests/sdk/login.test.js
@@ -1,5 +1,6 @@
 // [Codex Fix] Updated for ESM/Vitest/Node 20 compatibility
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createClientMock, currentSupabaseMocks } from "../utils/supabase-mock";
 
 var signInMock;
 var getUserMock;
@@ -42,6 +43,9 @@ describe("login form", () => {
 
   beforeEach(async () => {
     vi.resetModules();
+    createClientMock();
+    ({ signInMock, getUserMock, getSessionMock } = currentSupabaseMocks());
+    getUserMock.mockResolvedValue({ data: { user: null } });
     clickHandler = undefined;
     emailValue = "user@example.com";
     passwordValue = "Password1";

--- a/storefronts/tests/sdk/password-reset.test.js
+++ b/storefronts/tests/sdk/password-reset.test.js
@@ -1,5 +1,6 @@
 // [Codex Fix] Updated for ESM/Vitest/Node 20 compatibility
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createClientMock, currentSupabaseMocks } from "../utils/supabase-mock";
 
 var resetPasswordMock;
 var updateUserMock;
@@ -46,6 +47,9 @@ describe("password reset request", () => {
 
   beforeEach(async () => {
     vi.resetModules();
+    createClientMock();
+    ({ resetPasswordMock, getUserMock } = currentSupabaseMocks());
+    getUserMock.mockResolvedValue({ data: { user: null } });
     emailValue = "user@example.com";
     clickHandler = undefined;
     let btn;
@@ -122,6 +126,10 @@ describe("password reset confirmation", () => {
 
   beforeEach(async () => {
     vi.resetModules();
+    createClientMock();
+    const { updateUserMock: uMock, setSessionMock: sMock } = currentSupabaseMocks();
+    updateUserMock = uMock;
+    setSessionMock = sMock;
     updateUserMock.mockClear();
     setSessionMock.mockClear();
     passwordValue = "newpass123";

--- a/storefronts/tests/setup.ts
+++ b/storefronts/tests/setup.ts
@@ -1,0 +1,13 @@
+import { beforeEach } from "vitest";
+import { buildSupabaseMock, useWindowSupabaseMock } from "./utils/supabase-mock";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __smoothrTest: { supabase?: any; mocks?: any } | undefined;
+}
+
+beforeEach(() => {
+  const { client, mocks } = buildSupabaseMock();
+  (globalThis as any).__smoothrTest = { supabase: client, mocks };
+  useWindowSupabaseMock(client, mocks);
+});

--- a/storefronts/tests/utils/supabase-mock.ts
+++ b/storefronts/tests/utils/supabase-mock.ts
@@ -1,0 +1,81 @@
+import { vi } from "vitest";
+
+export type SupabaseClientMock = ReturnType<typeof buildSupabaseMock>["client"];
+export type SupabaseClientMocks = ReturnType<typeof buildSupabaseMock>["mocks"];
+
+export function buildSupabaseMock(overrides: Partial<SupabaseClientMock> = {}) {
+  // Auth mocks commonly used across tests
+  const getUserMock = vi.fn(); // resolve null user by default at call site
+  const getSessionMock = vi.fn().mockResolvedValue({ data: { session: {} }, error: null });
+  const signInMock = vi.fn().mockResolvedValue({ data: { user: null }, error: null });
+  const signUpMock = vi.fn().mockResolvedValue({ data: { user: null }, error: null });
+  const signInWithOAuthMock = vi.fn().mockResolvedValue({});
+  const resetPasswordMock = vi.fn().mockResolvedValue({ data: {}, error: null });
+  const updateUserMock = vi.fn().mockResolvedValue({ data: {}, error: null });
+  const setSessionMock = vi.fn().mockResolvedValue({ data: {}, error: null });
+  const signOutMock = vi.fn();
+  const onAuthStateChangeMock = vi.fn(() => ({
+    data: { subscription: { unsubscribe: vi.fn() } },
+  }));
+
+  // Data/functions mocks
+  const fromSelectMock = vi.fn().mockResolvedValue({ data: null, error: null });
+  const fromMock = vi.fn(() => ({ select: fromSelectMock }));
+  const functionsInvokeMock = vi.fn().mockResolvedValue({ data: null, error: null });
+
+  const client: any = {
+    auth: {
+      getUser: getUserMock,
+      getSession: getSessionMock,
+      signInWithPassword: signInMock,
+      signUp: signUpMock,
+      signInWithOAuth: signInWithOAuthMock,
+      resetPasswordForEmail: resetPasswordMock,
+      updateUser: updateUserMock,
+      setSession: setSessionMock,
+      signOut: signOutMock,
+      onAuthStateChange: onAuthStateChangeMock,
+    },
+    from: fromMock,
+    functions: { invoke: functionsInvokeMock },
+    ...overrides,
+  };
+
+  const mocks = {
+    getUserMock,
+    getSessionMock,
+    signInMock,
+    signUpMock,
+    signInWithOAuthMock,
+    resetPasswordMock,
+    updateUserMock,
+    setSessionMock,
+    signOutMock,
+    onAuthStateChangeMock,
+    fromMock,
+    fromSelectMock,
+    functionsInvokeMock,
+  };
+
+  return { client, mocks };
+}
+
+export function useWindowSupabaseMock(client: SupabaseClientMock, mocks?: SupabaseClientMocks) {
+  const w: any = (globalThis as any).window || (globalThis as any);
+  w.Smoothr = w.Smoothr || {};
+  w.Smoothr.__supabase = client;
+  w.Smoothr.supabaseReady = Promise.resolve(client);
+  // stash mocks for easy access in specs
+  (globalThis as any).__smoothrTest = { ...(globalThis as any).__smoothrTest, supabase: client, mocks };
+}
+
+export function currentSupabaseMocks(): SupabaseClientMocks {
+  return ((globalThis as any).__smoothrTest || {}).mocks;
+}
+
+// Back-compat for specs that expect to call createClientMock()
+export function createClientMock() {
+  const { client, mocks } = buildSupabaseMock();
+  useWindowSupabaseMock(client, mocks);
+  return client;
+}

--- a/storefronts/vitest.config.js
+++ b/storefronts/vitest.config.js
@@ -10,7 +10,7 @@ export default defineConfig(({ mode }) => {
   return {
     test: {
       environment: 'jsdom',
-      setupFiles: './vitest.setup.js'
+      setupFiles: ['./vitest.setup.js', './tests/setup.ts']
     },
     resolve: {
       alias: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   test: {
     // Use jsdom so that browser globals like `window` are available in tests
     environment: 'jsdom',
-    setupFiles: './vitest.setup.ts',
+    setupFiles: ['./vitest.setup.ts', './storefronts/tests/setup.ts'],
     testTimeout: 10000,
     deps: {
       inline: ['@supabase/supabase-js'], // Enable npm imports


### PR DESCRIPTION
## Summary
- add reusable Supabase test mock and window helper
- run Supabase mock before each storefront test
- refactor auth-related specs to use centralized mock

## Testing
- `npm test` *(fails: assertion errors and missing spy calls)*

------
https://chatgpt.com/codex/tasks/task_e_68a0925561e883259794976cd6814cc8