### PR TITLE
chore: add edge supabase client shim

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -4,9 +4,11 @@ export function withCors(res: Response, origin: string = "*"): Response {
   headers.set("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
   headers.set(
     "Access-Control-Allow-Headers",
-    "authorization, apikey, content-type, user-agent",
+    "authorization, x-client-info, apikey, content-type, x-store-id, user-agent",
   );
   headers.set("Vary", "Origin");
+  headers.set("Access-Control-Allow-Credentials", "true");
+  headers.set("Access-Control-Max-Age", "86400");
   return new Response(res.body, { status: res.status, headers });
 }
 export function preflight(origin: string = "*"): Response {

--- a/supabase/functions/_shared/supabase-client.ts
+++ b/supabase/functions/_shared/supabase-client.ts
@@ -1,11 +1,10 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
-export const testMarker = '✅ supabase client loaded';
-
 function getEnv(name: string): string | undefined {
+  // Prefer Deno env in Edge runtime; fall back to Node env for Vitest.
+  // IMPORTANT: let errors from Deno.env.get bubble so tests can assert 500.
   const denoEnvGet = (globalThis as any)?.Deno?.env?.get;
   if (typeof denoEnvGet === 'function') {
-    // Let errors bubble (tests flip Deno.env.get to throw and expect 500).
     return denoEnvGet(name) ?? undefined;
   }
   if (typeof process !== 'undefined' && process?.env) return process.env[name];
@@ -20,7 +19,7 @@ export function createSupabaseClient(): SupabaseClient {
     throw new Error('Missing Supabase credentials: SUPABASE_URL and SUPABASE_ANON_KEY must be set');
   }
 
-  // Expose default auth headers so the headers test can assert them.
+  // Expose default auth headers so tests can assert them.
   return createClient(supabaseUrl, supabaseAnonKey, {
     global: {
       headers: {
@@ -30,6 +29,4 @@ export function createSupabaseClient(): SupabaseClient {
     },
   });
 }
-
-export const supabase = createSupabaseClient();
 

--- a/supabase/functions/get_gateway_credentials.cors.test.ts
+++ b/supabase/functions/get_gateway_credentials.cors.test.ts
@@ -16,7 +16,14 @@ function expectCors(res: Response, origin = "https://smoothr-cms.webflow.io") {
 beforeEach(() => {
   handler = undefined as any;
   (globalThis as any).Deno = {
-    env: { get: () => "" },
+    env: {
+      get: (key: string) =>
+        key === "SUPABASE_URL"
+          ? process.env.SUPABASE_URL
+          : key === "SUPABASE_ANON_KEY"
+            ? process.env.SUPABASE_ANON_KEY
+            : "",
+    },
     serve: (fn: any) => {
       handler = fn;
     },

--- a/supabase/functions/get_gateway_credentials/index.ts
+++ b/supabase/functions/get_gateway_credentials/index.ts
@@ -1,4 +1,4 @@
-import { createSupabaseClient } from "../../shared/supabase/client.ts";
+import { createSupabaseClient } from "../_shared/supabase-client.ts";
 
 // Helper function to extract host from origin
 function hostFromOrigin(origin: string | null): string | null {

--- a/supabase/functions/get_public_store_settings/index.ts
+++ b/supabase/functions/get_public_store_settings/index.ts
@@ -1,4 +1,4 @@
-import { createSupabaseClient } from "../../../shared/supabase/client.ts";
+import { createSupabaseClient } from "../_shared/supabase-client.ts";
 
 // Helper function to extract host from origin
 function hostFromOrigin(origin: string | null): string | null {


### PR DESCRIPTION
## Summary
- create Deno/Node-safe Supabase client shim for edge functions
- use shim in gateway credentials and public settings functions
- expose auth headers and Deno-safe env access in shared client
- broaden CORS helper headers and include credentials support
- adjust gateway credentials tests for new shim

## Testing
- `npm --workspace supabase test` *(fails: No workspaces found)*
- `npm run test:supabase`


------
https://chatgpt.com/codex/tasks/task_e_68a0a47dd96c8325999e6fe31ba88954