### PR TITLE
chore: deno-friendly supabase imports

### DIFF
--- a/supabase/functions/_shared/findOrCreateCustomer.ts
+++ b/supabase/functions/_shared/findOrCreateCustomer.ts
@@ -1,4 +1,4 @@
-import type { SupabaseClient } from "@supabase/supabase-js";
+import type { SupabaseClient } from "npm:@supabase/supabase-js@2.38.4";
 
 export async function findOrCreateCustomer(
   supabase: SupabaseClient,

--- a/supabase/functions/_shared/supabase-client.ts
+++ b/supabase/functions/_shared/supabase-client.ts
@@ -1,19 +1,13 @@
-import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2.38.4";
 
-function getEnv(name: string): string | undefined {
-  // Prefer Deno env in Edge runtime; fall back to Node env for Vitest.
-  // IMPORTANT: let errors from Deno.env.get bubble so tests can assert 500.
-  const denoEnvGet = (globalThis as any)?.Deno?.env?.get;
-  if (typeof denoEnvGet === 'function') {
-    return denoEnvGet(name) ?? undefined;
-  }
-  if (typeof process !== 'undefined' && process?.env) return process.env[name];
-  return undefined;
-}
+const readEnv = (k: string): string | undefined =>
+  (typeof Deno !== "undefined" && Deno.env?.get?.(k)) ||
+  (typeof globalThis !== "undefined" && (globalThis as any).process?.env?.[k]) ||
+  undefined;
 
 export function createSupabaseClient(): SupabaseClient {
-  const supabaseUrl = getEnv('SUPABASE_URL');
-  const supabaseAnonKey = getEnv('SUPABASE_ANON_KEY');
+  const supabaseUrl = readEnv("SUPABASE_URL");
+  const supabaseAnonKey = readEnv("SUPABASE_ANON_KEY");
 
   if (!supabaseUrl || !supabaseAnonKey) {
     throw new Error('Missing Supabase credentials: SUPABASE_URL and SUPABASE_ANON_KEY must be set');
@@ -29,4 +23,12 @@ export function createSupabaseClient(): SupabaseClient {
     },
   });
 }
+
+export const supabase: SupabaseClient = (() => {
+  try {
+    return createSupabaseClient();
+  } catch {
+    return undefined as unknown as SupabaseClient;
+  }
+})();
 

--- a/supabase/functions/get_gateway_credentials/index.ts
+++ b/supabase/functions/get_gateway_credentials/index.ts
@@ -1,4 +1,5 @@
 import { createSupabaseClient } from "../_shared/supabase-client.ts";
+import { withCors, preflight } from "../_shared/cors.ts";
 
 // Helper function to extract host from origin
 function hostFromOrigin(origin: string | null): string | null {
@@ -9,25 +10,6 @@ function hostFromOrigin(origin: string | null): string | null {
     const raw = origin.replace(/^https?:\/\//i, "").toLowerCase();
     return raw.split("/")[0] || null;
   }
-}
-
-// Add CORS headers to response
-function withCors(res: Response, origin: string = "*"): Response {
-  const headers = new Headers(res.headers);
-  headers.set("Access-Control-Allow-Origin", origin);
-  headers.set("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
-  headers.set(
-    "Access-Control-Allow-Headers",
-    "authorization, x-client-info, apikey, content-type, x-store-id, user-agent"
-  );
-  headers.set("Access-Control-Allow-Credentials", "true");
-  headers.set("Access-Control-Max-Age", "86400"); // Cache preflight for 24 hours
-  return new Response(res.body, { status: res.status, headers });
-}
-
-// Create preflight response
-function preflight(origin: string = "*"): Response {
-  return withCors(new Response(null, { status: 204 }), origin);
 }
 
 // Debug helper function

--- a/supabase/functions/get_public_store_settings/index.ts
+++ b/supabase/functions/get_public_store_settings/index.ts
@@ -1,4 +1,5 @@
 import { createSupabaseClient } from "../_shared/supabase-client.ts";
+import { withCors, preflight } from "../_shared/cors.ts";
 
 // Helper function to extract host from origin
 function hostFromOrigin(origin: string | null): string | null {
@@ -9,25 +10,6 @@ function hostFromOrigin(origin: string | null): string | null {
     const raw = origin.replace(/^https?:\/\//i, "").toLowerCase();
     return raw.split("/")[0] || null;
   }
-}
-
-// Add CORS headers to response
-function withCors(res: Response, origin: string = "*"): Response {
-  const headers = new Headers(res.headers);
-  headers.set("Access-Control-Allow-Origin", origin);
-  headers.set("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
-  headers.set(
-    "Access-Control-Allow-Headers",
-    "authorization, x-client-info, apikey, content-type, x-store-id, user-agent",
-  );
-  headers.set("Access-Control-Allow-Credentials", "true");
-  headers.set("Access-Control-Max-Age", "86400"); // Cache preflight for 24 hours
-  return new Response(res.body, { status: res.status, headers });
-}
-
-// Create preflight response
-function preflight(origin: string = "*"): Response {
-  return withCors(new Response(null, { status: 204 }), origin);
 }
 
 // Debug helper function

--- a/supabase/functions/webflow-order-handler/index.ts
+++ b/supabase/functions/webflow-order-handler/index.ts
@@ -1,4 +1,4 @@
-import { createSupabaseClient } from "../../shared/supabase/client.ts";
+import { createSupabaseClient } from "../_shared/supabase-client.ts";
 import { findOrCreateCustomer } from "../_shared/findOrCreateCustomer.ts";
 
 const debug = Deno.env.get("SMOOTHR_DEBUG") === "true";


### PR DESCRIPTION
## Summary
- switch Supabase client shim to Deno-friendly npm imports and environment handling
- use shared cors helper and client shim across edge functions
- remove bare Node imports from edge handlers

## Testing
- `SUPABASE_URL=http://example.com SUPABASE_ANON_KEY=anonkey npm run test:supabase`


------
https://chatgpt.com/codex/tasks/task_e_68a0acdbb130832582a58dadf0f5788e