### PR TITLE
Await SDK feature inits and load currency module

### DIFF
--- a/storefronts/features/checkout/init.js
+++ b/storefronts/features/checkout/init.js
@@ -294,7 +294,8 @@ async function init(opts = {}) {
       );
       const cfg = getConfig();
       const currency = cfg.baseCurrency;
-      const customer_id = window.smoothr.auth.user?.value?.id || null;
+      const smoothr = window.Smoothr || window.smoothr || {};
+      const customer_id = smoothr.auth?.user?.value?.id || null;
       const store_id = cfg.storeId;
       const platform = cfg.platform;
 


### PR DESCRIPTION
## Summary
- ensure `window.smoothr` alias exists
- await auth, checkout, cart, and currency initializers; load currency when price nodes are detected
- make checkout lookup customer ID via either global alias

## Testing
- `npm test`
- `npm run test:supabase`


------
https://chatgpt.com/codex/tasks/task_e_68a5e04b37c48325b7ea1adfa8e00acb