### PR TITLE
fix(cart): attach renderCart to Smoothr.cart; improve add-to-cart validation

### DIFF
--- a/storefronts/features/cart/addToCart.js
+++ b/storefronts/features/cart/addToCart.js
@@ -88,8 +88,12 @@ export async function bindAddToCartButtons() {
         const isSubscription =
           btn.getAttribute('data-product-subscription') === 'true';
 
-        if (!product_id || !name || isNaN(price)) {
-          warn('Missing required cart attributes on:', btn);
+        const missing = [];
+        if (!product_id) missing.push('data-product-id');
+        if (!name) missing.push('data-product-name');
+        if (isNaN(price)) missing.push('data-product-price');
+        if (missing.length) {
+          warn(`Missing ${missing.join(', ')} on:`, btn);
           return;
         }
 
@@ -119,15 +123,10 @@ export async function bindAddToCartButtons() {
         };
         Smoothr.cart.addItem(item);
         if (debug) log('🧮 cart item count', Smoothr.cart.getCart().items.length);
-        if (typeof Smoothr.cart?.renderCart === 'function') {
-          if (debug) log('🧼 Calling renderCart() to update UI');
-          try {
-            Smoothr.cart.renderCart();
-          } catch (error) {
-            warn('renderCart failed', error);
-          }
-        } else {
-          warn('renderCart not found');
+        try {
+          Smoothr.cart.renderCart?.();
+        } catch (error) {
+          warn('renderCart failed', error);
         }
       } catch (error) {
         err('addToCart failed', error);

--- a/storefronts/features/cart/index.js
+++ b/storefronts/features/cart/index.js
@@ -3,6 +3,7 @@ export { init } from './init.js';
 export { init as default } from './init.js';
 export { init as initCart } from './init.js';
 export { __test_resetCart } from './init.js';
+export { renderCart } from './renderCart.js';
 
 const STORAGE_KEY = 'smoothr_cart';
 

--- a/storefronts/features/cart/init.js
+++ b/storefronts/features/cart/init.js
@@ -1,4 +1,5 @@
 import { getConfig } from '../config/globalConfig.js';
+import { renderCart } from './renderCart.js';
 
 const { debug } = getConfig();
 const log = (...args) => debug && console.log('[Smoothr Cart]', ...args);
@@ -82,6 +83,9 @@ export async function init() {
       await bindCartButtons();
       w.Smoothr = w.Smoothr || {};
       w.Smoothr.cart = api;
+      if (!w.Smoothr.cart.renderCart) {
+        w.Smoothr.cart.renderCart = renderCart;
+      }
       const { bindAddToCartButtons } = await import('./addToCart.js');
       await bindAddToCartButtons();
       // Single-shot late-node fallback for add-to-cart buttons
@@ -99,6 +103,9 @@ export async function init() {
     } catch {
       w.Smoothr = w.Smoothr || {};
       w.Smoothr.cart = api;
+      if (!w.Smoothr.cart.renderCart) {
+        w.Smoothr.cart.renderCart = renderCart;
+      }
       log('cart init complete (fallback)', _state.items.length, 'items');
     }
     return api;


### PR DESCRIPTION
## Summary
- attach `renderCart` to the runtime cart API with idempotent checks
- export `renderCart` from cart barrel
- enhance add-to-cart attribute validation and guard cart rendering

## Testing
- `npm test`
- `npm run test:supabase`


------
https://chatgpt.com/codex/tasks/task_e_68a5fae63f508325b47cd6a640e66623