### PR TITLE
feat(cart): quantity controls — updateQuantity API, delegated +/- handlers, render tagging; correct subtotal with qty

### DIFF
--- a/storefronts/features/cart/renderCart.js
+++ b/storefronts/features/cart/renderCart.js
@@ -99,9 +99,22 @@ export function renderCart() {
         }
       });
 
-      clone.querySelectorAll('[data-smoothr-quantity]').forEach(el => {
-        el.textContent = String(item.quantity);
-      });
+      clone
+        .querySelectorAll('[data-smoothr-qty], [data-smoothr-quantity]')
+        .forEach(el => {
+          el.textContent = String(Math.max(1, +item.quantity || 1));
+        });
+
+      clone
+        .querySelectorAll('[data-smoothr="qty-plus"],[data-smoothr="qty-minus"]')
+        .forEach(btn => {
+          btn.setAttribute('data-product-id', item.product_id);
+        });
+      clone
+        .querySelectorAll('[data-smoothr-qty="+"],[data-smoothr-qty="-"]')
+        .forEach(btn => {
+          btn.setAttribute('data-product-id', item.product_id);
+        });
 
       clone.querySelectorAll('[data-smoothr-price]').forEach(el => {
         const basePrice = item.price / 100;

--- a/storefronts/tests/adapters/renderCart.test.js
+++ b/storefronts/tests/adapters/renderCart.test.js
@@ -25,7 +25,13 @@ beforeEach(async () => {
   optionsEl.setAttribute('data-smoothr-options', '');
 
   const qtyEl = document.createElement('span');
-  qtyEl.setAttribute('data-smoothr-quantity', '');
+  qtyEl.setAttribute('data-smoothr-qty', '');
+
+  const minusBtn = document.createElement('button');
+  minusBtn.setAttribute('data-smoothr', 'qty-minus');
+
+  const plusBtn = document.createElement('button');
+  plusBtn.setAttribute('data-smoothr', 'qty-plus');
 
   const priceEl = document.createElement('span');
   priceEl.setAttribute('data-smoothr-price', '');
@@ -43,7 +49,9 @@ beforeEach(async () => {
     imageEl,
     nameEl,
     optionsEl,
+    minusBtn,
     qtyEl,
+    plusBtn,
     priceEl,
     subtotalEl,
     removeBtn
@@ -116,7 +124,7 @@ describe('renderCart', () => {
     renderCart();
     const clone = container.querySelector('.cart-rendered');
     expect(clone.querySelector('[data-smoothr-name]').textContent).toBe('Item Two');
-    expect(clone.querySelector('[data-smoothr-quantity]').textContent).toBe('1');
+    expect(clone.querySelector('[data-smoothr-qty]').textContent).toBe('1');
     expect(clone.querySelector('[data-smoothr-price]').textContent).toBe('$0.50');
     expect(clone.querySelector('[data-smoothr-subtotal]').textContent).toBe('$0.50');
     expect(totalEl.textContent).toBe('$2.50');
@@ -148,5 +156,21 @@ describe('renderCart', () => {
     const img = first.querySelector('[data-smoothr-image]');
     expect(img.getAttribute('src')).toBeNull();
     expect(img.alt).toBe('Item Two');
+  });
+
+  it('tags qty controls with product id', async () => {
+    const renderCart = await loadRenderCart();
+    renderCart();
+    const clone = container.querySelector('.cart-rendered');
+    expect(
+      clone
+        .querySelector('[data-smoothr="qty-plus"]')
+        .getAttribute('data-product-id')
+    ).toBe('p2');
+    expect(
+      clone
+        .querySelector('[data-smoothr="qty-minus"]')
+        .getAttribute('data-product-id')
+    ).toBe('p2');
   });
 });

--- a/storefronts/tests/features/cart.test.js
+++ b/storefronts/tests/features/cart.test.js
@@ -37,7 +37,7 @@ describe('Cart', () => {
     globalThis.il = localStorageMock;
     await initCart();
     expect(window.Smoothr.cart.getCart().items).toHaveLength(1);
-    expect(window.Smoothr.cart.getSubtotal()).toBe(1000);
+    expect(window.Smoothr.cart.getSubtotal()).toBe(2000);
   });
 });
 

--- a/storefronts/tests/sdk/cart-quantity.test.js
+++ b/storefronts/tests/sdk/cart-quantity.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../../features/cart/addToCart.js', () => ({
+  bindAddToCartButtons: vi.fn(),
+}));
+
+let cart;
+
+beforeEach(async () => {
+  vi.resetModules();
+  global.localStorage = {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+  };
+  global.window = {
+    Smoothr: {},
+    document: {
+      readyState: 'complete',
+      addEventListener: vi.fn(),
+      querySelectorAll: vi.fn(() => []),
+    },
+  };
+  global.document = window.document;
+  const mod = await import('../../features/cart/init.js');
+  cart = await mod.init();
+  cart.renderCart = vi.fn();
+});
+
+describe('cart quantity', () => {
+  it('addItem merges and increments quantity by product_id', () => {
+    cart.addItem({ product_id: 'p1', price: 100, quantity: 1 });
+    cart.addItem({ product_id: 'p1', price: 100, quantity: 2 });
+    const items = cart.getCart().items;
+    expect(items).toHaveLength(1);
+    expect(items[0].quantity).toBe(3);
+  });
+
+  it('updateQuantity clamps to min 1 and returns boolean', () => {
+    cart.addItem({ product_id: 'p1', price: 100, quantity: 2 });
+    expect(cart.updateQuantity('p1', 5)).toBe(true);
+    expect(cart.getCart().items[0].quantity).toBe(5);
+    expect(cart.updateQuantity('p1', 0)).toBe(true);
+    expect(cart.getCart().items[0].quantity).toBe(1);
+    expect(cart.updateQuantity('nope', 2)).toBe(false);
+  });
+
+  it('getSubtotal honors quantity', () => {
+    cart.addItem({ product_id: 'p1', price: 100, quantity: 2 });
+    cart.addItem({ product_id: 'p2', price: 50, quantity: 3 });
+    expect(cart.getSubtotal()).toBe(100 * 2 + 50 * 3);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add document-level delegated quantity +/- handlers and updateQuantity API for cart
- ensure subtotal and renderCart use quantity, tagging controls with data-product-id
- cover quantity merging, clamping and rendering in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a61116bef48325b55cf8902cc66ae1