### PR TITLE
feat(auth): toggle auth panels

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -72,6 +72,24 @@ function bindAuthElements(root = globalThis.document) {
       attach(el, handler);
     });
   root.querySelectorAll('[data-smoothr="sign-out"]').forEach(el => attach(el, signOutHandler));
+  root.querySelectorAll('[data-smoothr="auth-panel"]').forEach(el => {
+    attach(el, () => {
+      const active = el.classList.toggle('is-active');
+      log(`auth panel ${active ? 'opened' : 'closed'}`);
+    });
+  });
+  const doc = root?.ownerDocument || globalThis.document;
+  if (doc && !_bound.has(doc)) {
+    doc.addEventListener('smoothr:open-auth', (e = {}) => {
+      const selector = e?.detail?.targetSelector || '[data-smoothr="auth-panel"]';
+      const panel = doc.querySelector(selector);
+      if (panel) {
+        panel.classList.add('is-active');
+        log('auth panel opened', selector);
+      }
+    });
+    _bound.add(doc);
+  }
 }
 
 // ---- Supabase client plumbings ----


### PR DESCRIPTION
## Summary
- toggle auth panels via `is-active` class when clicked
- expose `smoothr:open-auth` event listener to show target panels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a62b5321848325850e2d278330c33f