### PR TITLE
feat(auth): support logout alias

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -71,7 +71,12 @@ function bindAuthElements(root = globalThis.document) {
         clickHandler;
       attach(el, handler);
     });
-  root.querySelectorAll('[data-smoothr="sign-out"]').forEach(el => attach(el, signOutHandler));
+  root
+    .querySelectorAll('[data-smoothr="sign-out"], [data-smoothr="logout"]')
+    .forEach(el => {
+      attach(el, signOutHandler);
+      log('logout handler bound to', `[data-smoothr="${el.getAttribute('data-smoothr')}"]`);
+    });
   root.querySelectorAll('[data-smoothr="auth-panel"]').forEach(el => {
     attach(el, () => {
       const active = el.classList.toggle('is-active');

--- a/storefronts/tests/sdk/account-access.test.js
+++ b/storefronts/tests/sdk/account-access.test.js
@@ -65,7 +65,7 @@ describe("account access trigger", () => {
         )
           return [];
         if (selector === 'form[data-smoothr="auth-form"]') return [];
-        if (selector === '[data-smoothr="sign-out"]') return [];
+        if (selector.includes('[data-smoothr="sign-out"]')) return [];
         return [];
       }),
       querySelector: vi.fn(() => null),

--- a/storefronts/tests/sdk/global-auth.test.js
+++ b/storefronts/tests/sdk/global-auth.test.js
@@ -25,7 +25,7 @@ describe("global auth", () => {
       }),
       dispatchEvent: vi.fn(),
       querySelectorAll: vi.fn((selector) => {
-        if (selector === '[data-smoothr="sign-out"]') {
+        if (selector.includes('[data-smoothr="sign-out"]')) {
           const btn = {
             tagName: "DIV",
             dataset: { smoothr: "sign-out" },


### PR DESCRIPTION
## Summary
- support `[data-smoothr="logout"]` as a sign-out trigger
- log which selector binds the logout handler when debug is enabled
- adjust tests for new sign-out selector

## Testing
- `npm test`
- `npm run test:supabase`


------
https://chatgpt.com/codex/tasks/task_e_68a62e86ce0c83258f6617a84343c68f