### PR TITLE
ci(storefronts): verify dist build before deploy

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -40,6 +40,10 @@ jobs:
         working-directory: storefronts
         run: npm run build
 
+      - name: Verify build output
+        working-directory: storefronts
+        run: test -f dist/smoothr-sdk.js
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/pages-action@v1
         with:


### PR DESCRIPTION
## Summary
- fail CI if `storefronts/dist/smoothr-sdk.js` is missing, guarding against stale SDK deployments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa96c7ebbc83259670d640334ccbbf