### PR TITLE
feat(auth): auto-detect mode and event-first lifecycle

### DIFF
--- a/storefronts/tests/sdk/account-access.test.js
+++ b/storefronts/tests/sdk/account-access.test.js
@@ -68,7 +68,10 @@ describe("account access trigger", () => {
         if (selector.includes('[data-smoothr="sign-out"]')) return [];
         return [];
       }),
-      querySelector: vi.fn(() => null),
+      querySelector: vi.fn((sel) => {
+        if (sel === '[data-smoothr="auth-panel"]') return {};
+        return null;
+      }),
       dispatchEvent: vi.fn(),
     };
   });
@@ -117,10 +120,12 @@ describe("account access trigger", () => {
       await clickHandler({ target: btn, preventDefault: () => {} });
       await flushPromises();
 
-      expect(global.document.dispatchEvent).toHaveBeenCalled();
-      const evt = global.document.dispatchEvent.mock.calls[0][0];
-      expect(evt.type).toBe("smoothr:open-auth");
-      expect(evt.detail.targetSelector).toBe('[data-smoothr="auth-panel"]');
+      expect(global.document.dispatchEvent).toHaveBeenCalledTimes(2);
+      const first = global.document.dispatchEvent.mock.calls[0][0];
+      const second = global.document.dispatchEvent.mock.calls[1][0];
+      expect(first.type).toBe("smoothr:auth:open");
+      expect(second.type).toBe("smoothr:open-auth");
+      expect(second.detail.targetSelector).toBe('[data-smoothr="auth-panel"]');
     });
   });
 });

--- a/storefronts/tests/sdk/auth-trigger.test.js
+++ b/storefronts/tests/sdk/auth-trigger.test.js
@@ -24,7 +24,11 @@ describe('auth triggers', () => {
   it('popup mode dispatches smoothr:open-auth and fires lifecycle events', async () => {
     const btn = { getAttribute: (k) => (k === 'data-smoothr-mode' ? 'popup' : null) };
     const evt = { target: { closest: () => btn }, preventDefault: vi.fn() };
-    const panel = { classList: { toggle: vi.fn(), contains: vi.fn(() => false) } };
+    const panel = {
+      classList: { toggle: vi.fn(), contains: vi.fn(() => false) },
+      getAttribute: (k) => (k === 'data-smoothr-autoclass' ? '1' : null),
+      setAttribute: vi.fn(),
+    };
     doc.querySelector = vi.fn(sel => (sel.includes('auth-panel') ? panel : null));
     await mod.docClickHandler(evt);
     const listener = doc.addEventListener.mock.calls.find(c => c[0] === 'smoothr:open-auth')[1];
@@ -42,10 +46,16 @@ describe('auth triggers', () => {
 
   it('dropdown mode toggles auth-dropdown and fires lifecycle', async () => {
     const btn = { getAttribute: (k) => (k === 'data-smoothr-mode' ? 'dropdown' : null) };
-    const dropdown = { classList: { contains: vi.fn(() => false), toggle: vi.fn() } };
+    const dropdown = {
+      classList: { contains: vi.fn(() => false), toggle: vi.fn() },
+      getAttribute: (k) => (k === 'data-smoothr-autoclass' ? '1' : k === 'data-smoothr-active' ? '0' : null),
+      setAttribute: vi.fn(),
+    };
     doc.querySelector = vi.fn(sel => (sel.includes('auth-dropdown') ? dropdown : null));
     const evt = { target: { closest: () => btn }, preventDefault: vi.fn() };
     await mod.docClickHandler(evt);
+    const listener = doc.addEventListener.mock.calls.find(c => c[0] === 'smoothr:open-auth')[1];
+    listener({ detail: { targetSelector: '[data-smoothr="auth-dropdown"]', open: true } });
     expect(dropdown.classList.toggle).toHaveBeenCalledWith('is-active', true);
   });
 });

--- a/storefronts/tests/sdk/dom-mutation.test.js
+++ b/storefronts/tests/sdk/dom-mutation.test.js
@@ -70,7 +70,10 @@ describe("dynamic DOM bindings", () => {
         if (selector.includes('[data-smoothr="sign-out"]')) return [];
         return [];
       }),
-      querySelector: vi.fn(() => null),
+      querySelector: vi.fn((sel) => {
+        if (sel === '[data-smoothr="auth-panel"]') return {};
+        return null;
+      }),
       dispatchEvent() {
         return true;
       },
@@ -412,9 +415,11 @@ describe("dynamic DOM bindings", () => {
 
     await docClickHandler({ target: btn, preventDefault: () => {} });
     await flushPromises();
-    expect(global.document.dispatchEvent).toHaveBeenCalled();
-    const evt = global.document.dispatchEvent.mock.calls[0][0];
-    expect(evt.type).toBe("smoothr:open-auth");
-    expect(evt.detail.targetSelector).toBe('[data-smoothr="auth-panel"]');
+    expect(global.document.dispatchEvent).toHaveBeenCalledTimes(2);
+    const first = global.document.dispatchEvent.mock.calls[0][0];
+    const second = global.document.dispatchEvent.mock.calls[1][0];
+    expect(first.type).toBe("smoothr:auth:open");
+    expect(second.type).toBe("smoothr:open-auth");
+    expect(second.detail.targetSelector).toBe('[data-smoothr="auth-panel"]');
   });
 });


### PR DESCRIPTION
## Summary
- auto-detect auth trigger mode and dispatch lifecycle + legacy events
- emit smoothr:auth open/close before optional .is-active toggling
- update tests for event-first auth behavior

## Testing
- `npm --workspace storefronts test`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa996550708325b835dc2b090ba0f9