### PR TITLE
fix(cart/checkout): remove legacy getTotal; use getSubtotal (+discount) and harden global access in checkout init

### DIFF
--- a/storefronts/features/cart/index.js
+++ b/storefronts/features/cart/index.js
@@ -131,16 +131,3 @@ export function getDiscount() {
   return readCart().discount || null;
 }
 
-export function getTotal() {
-  const cart = readCart();
-  let subtotal = cart.items.reduce((sum, item) => sum + item.price * item.quantity, 0);
-  if (cart.discount) {
-    if (cart.discount.type === 'percent') {
-      subtotal -= Math.round(subtotal * (cart.discount.amount / 100));
-    } else {
-      subtotal -= cart.discount.amount;
-    }
-  }
-  return subtotal < 0 ? 0 : subtotal;
-}
-

--- a/storefronts/features/checkout/init.js
+++ b/storefronts/features/checkout/init.js
@@ -7,8 +7,8 @@ export function __test_resetCheckout() {
   __checkoutInitialized = false;
   try {
     if (typeof window !== 'undefined') {
-      if (window.Smoothr) delete window.Smoothr.checkout;
-      if (window.smoothr) delete window.smoothr.checkout;
+      const s = window.Smoothr || window.smoothr;
+      if (s?.checkout) delete s.checkout;
     }
   } catch {}
 }

--- a/storefronts/tests/adapters/checkout.test.js
+++ b/storefronts/tests/adapters/checkout.test.js
@@ -149,7 +149,8 @@ beforeEach(() => {
   const Smoothr = {
     cart: {
       getCart: () => cart,
-      getTotal: () => 100
+      getSubtotal: () => 100,
+      getDiscount: () => null
     },
     currency: { convertPrice: amt => amt },
     auth: { user: { id: 'cus_1' } },

--- a/storefronts/tests/sdk/cart.test.js
+++ b/storefronts/tests/sdk/cart.test.js
@@ -97,7 +97,17 @@ describe("cart module", () => {
     cart.updateQuantity("1", 3);
     cart.applyDiscount({ code: "SAVE", type: "percent", amount: 50 });
     expect(cart.getSubtotal()).toBe(300);
-    expect(cart.getTotal()).toBe(150);
+    const subtotal = cart.getSubtotal();
+    const discount = cart.getDiscount();
+    const total = discount
+      ? Math.max(
+          0,
+          discount.type === "percent"
+            ? subtotal - Math.round(subtotal * (discount.amount / 100))
+            : subtotal - discount.amount
+        )
+      : subtotal;
+    expect(total).toBe(150);
   });
 
   it("clears cart", () => {

--- a/storefronts/tests/sdk/checkout-payload.test.js
+++ b/storefronts/tests/sdk/checkout-payload.test.js
@@ -134,7 +134,8 @@ beforeEach(() => {
     Smoothr: {
       cart: {
         getCart: vi.fn(() => ({ items: [{ id: 1 }] })),
-        getTotal: vi.fn(() => 5000)
+        getSubtotal: vi.fn(() => 50),
+        getDiscount: vi.fn(() => null)
       }
     }
   };

--- a/storefronts/tests/sdk/gateway-dispatch.test.js
+++ b/storefronts/tests/sdk/gateway-dispatch.test.js
@@ -73,7 +73,13 @@ function setupEnv(modulePath) {
   };
   global.window = {
     location: { pathname: "", search: "" },
-    Smoothr: { cart: { getCart: () => ({ items: [] }), getTotal: () => 0 } },
+    Smoothr: {
+      cart: {
+        getCart: () => ({ items: [] }),
+        getSubtotal: () => 0,
+        getDiscount: () => null
+      }
+    },
     addEventListener: vi.fn(),
     removeEventListener: vi.fn()
   };

--- a/storefronts/tests/sdk/gateway-loader.test.js
+++ b/storefronts/tests/sdk/gateway-loader.test.js
@@ -65,7 +65,13 @@ function setupEnv(provider, modulePath) {
   };
   global.window = {
     location: { pathname: "", search: "" },
-    Smoothr: { cart: { getCart: () => ({ items: [] }), getTotal: () => 0 } },
+    Smoothr: {
+      cart: {
+        getCart: () => ({ items: [] }),
+        getSubtotal: () => 0,
+        getDiscount: () => null
+      }
+    },
     addEventListener: vi.fn(),
     removeEventListener: vi.fn()
   };

--- a/storefronts/tests/sdk/stripe-mount.test.js
+++ b/storefronts/tests/sdk/stripe-mount.test.js
@@ -65,7 +65,13 @@ beforeEach(() => {
       storeId: 'store-1',
       active_payment_gateway: 'stripe'
     },
-    Smoothr: { cart: { getCart: () => ({ items: [] }), getTotal: () => 0 } }
+    Smoothr: {
+      cart: {
+        getCart: () => ({ items: [] }),
+        getSubtotal: () => 0,
+        getDiscount: () => null
+      }
+    }
   };
 });
 


### PR DESCRIPTION
## Summary
- remove legacy getTotal from cart barrel
- consolidate checkout cleanup to a single global reference
- update tests to compute totals from getSubtotal and getDiscount

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa9c393ba08325b6acc9208456db22