### PR TITLE
feat(auth): handle auth-pop-up and auth-drop-down targets

### DIFF
--- a/storefronts/adapters/webflow.js
+++ b/storefronts/adapters/webflow.js
@@ -13,20 +13,12 @@ const legacyMap = {
   'data-smoothr-password-reset-confirm': 'password-reset-confirm',
   // Extra legacy conveniences for auth entry points:
   'data-smoothr-account': 'account-access',
-  'data-smoothr-auth': 'auth-panel'
+  'data-smoothr-auth': 'auth-pop-up',
+  'data-smoothr-auth-panel': 'auth-pop-up',
+  'data-smoothr-auth-popup': 'auth-pop-up',
+  'data-smoothr-auth-dropdown': 'auth-drop-down',
+  'data-smoothr-auth-drop-down': 'auth-drop-down'
 };
-
-// Normalize unified auth trigger aliases:
-// - prefer data-smoothr="auth" with optional data-smoothr-mode
-// - keep account-access as alias for "auth" trigger
-function normalizeUnifiedAuth(root = document) {
-  // account-access → auth (trigger), preserve any mode attribute
-  root.querySelectorAll('[data-smoothr="account-access"]').forEach(el => {
-    if (el.getAttribute('data-smoothr') !== 'auth') {
-      el.setAttribute('data-smoothr', 'auth');
-    }
-  });
-}
 
 function normalizeLegacyAttributes(root = document) {
   const debug = getConfig().debug;
@@ -42,8 +34,6 @@ function normalizeLegacyAttributes(root = document) {
       }
     });
   });
-  // then normalize unified auth trigger aliases
-  normalizeUnifiedAuth(root);
 }
 
 function observeDOMChanges() {

--- a/storefronts/tests/sdk/account-access.test.js
+++ b/storefronts/tests/sdk/account-access.test.js
@@ -69,7 +69,7 @@ describe("account access trigger", () => {
         return [];
       }),
       querySelector: vi.fn((sel) => {
-        if (sel === '[data-smoothr="auth-panel"]') return {};
+        if (sel === '[data-smoothr="auth-pop-up"]') return {};
         return null;
       }),
       dispatchEvent: vi.fn(),
@@ -125,7 +125,7 @@ describe("account access trigger", () => {
       const second = global.document.dispatchEvent.mock.calls[1][0];
       expect(first.type).toBe("smoothr:auth:open");
       expect(second.type).toBe("smoothr:open-auth");
-      expect(second.detail.targetSelector).toBe('[data-smoothr="auth-panel"]');
+      expect(second.detail.targetSelector).toBe('[data-smoothr="auth-pop-up"]');
     });
   });
 });

--- a/storefronts/tests/sdk/auth-account-access.spec.js
+++ b/storefronts/tests/sdk/auth-account-access.spec.js
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest';
+
+function setup({ user = null, popup = false, dropdown = false } = {}) {
+  const win = {
+    Smoothr: { auth: { user: { value: user } } },
+    location: { href: '/start' }
+  };
+  const doc = {
+    readyState: 'complete',
+    addEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    querySelector: vi.fn((sel) => {
+      if (popup && sel === '[data-smoothr="auth-pop-up"]') return {};
+      if (dropdown && sel === '[data-smoothr="auth-drop-down"]') return {};
+      return null;
+    }),
+    querySelectorAll: vi.fn(() => [])
+  };
+  global.window = win;
+  global.document = doc;
+  return { win, doc };
+}
+
+describe('account-access trigger', () => {
+  it('popup present, logged out opens auth pop-up', async () => {
+    vi.resetModules();
+    const { win, doc } = setup({ popup: true });
+    const mod = await import('../../features/auth/init.js');
+    await mod.init();
+    const evt = {
+      target: { closest: () => ({}) },
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      stopImmediatePropagation: vi.fn()
+    };
+    await mod.docClickHandler(evt);
+    expect(evt.preventDefault).toHaveBeenCalled();
+    expect(win.location.href).toBe('/start');
+    expect(doc.dispatchEvent).toHaveBeenCalledTimes(2);
+    const first = doc.dispatchEvent.mock.calls[0][0];
+    const second = doc.dispatchEvent.mock.calls[1][0];
+    expect(first.type).toBe('smoothr:auth:open');
+    expect(first.detail.selector).toBe('[data-smoothr="auth-pop-up"]');
+    expect(second.type).toBe('smoothr:open-auth');
+    expect(second.detail.targetSelector).toBe('[data-smoothr="auth-pop-up"]');
+  });
+
+  it('dropdown present, logged out skips SDK UI', async () => {
+    vi.resetModules();
+    const { win, doc } = setup({ dropdown: true });
+    const mod = await import('../../features/auth/init.js');
+    await mod.init();
+    const evt = {
+      target: { closest: () => ({}) },
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      stopImmediatePropagation: vi.fn()
+    };
+    await mod.docClickHandler(evt);
+    expect(evt.preventDefault).toHaveBeenCalled();
+    expect(win.location.href).toBe('/start');
+    expect(doc.dispatchEvent).not.toHaveBeenCalled();
+  });
+
+  it('no UI redirects to login URL', async () => {
+    vi.resetModules();
+    const { win, doc } = setup();
+    const lookupRedirectUrl = vi.fn().mockResolvedValue('/login-url');
+    vi.doMock('../../../supabase/authHelpers.js', () => ({
+      lookupRedirectUrl,
+      lookupDashboardHomeUrl: vi.fn()
+    }));
+    const mod = await import('../../features/auth/init.js');
+    await mod.init();
+    const evt = {
+      target: { closest: () => ({}) },
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      stopImmediatePropagation: vi.fn()
+    };
+    await mod.docClickHandler(evt);
+    expect(lookupRedirectUrl).toHaveBeenCalled();
+    expect(win.location.href).toBe('/login-url');
+    expect(doc.dispatchEvent).not.toHaveBeenCalled();
+  });
+
+  it('logged-in users redirect to preferred URL', async () => {
+    vi.resetModules();
+    const { win, doc } = setup();
+    const lookupDashboardHomeUrl = vi.fn().mockResolvedValue('/dashboard');
+    vi.doMock('../../../supabase/authHelpers.js', () => ({
+      lookupRedirectUrl: vi.fn(),
+      lookupDashboardHomeUrl
+    }));
+    const mod = await import('../../features/auth/init.js');
+    await mod.init();
+    win.Smoothr.auth.user.value = { id: '1' };
+    const evt = {
+      target: { closest: () => ({}) },
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      stopImmediatePropagation: vi.fn()
+    };
+    await mod.docClickHandler(evt);
+    expect(lookupDashboardHomeUrl).toHaveBeenCalled();
+    expect(win.location.href).toBe('/dashboard');
+    expect(doc.dispatchEvent).not.toHaveBeenCalled();
+  });
+});

--- a/storefronts/tests/sdk/dom-mutation.test.js
+++ b/storefronts/tests/sdk/dom-mutation.test.js
@@ -71,7 +71,7 @@ describe("dynamic DOM bindings", () => {
         return [];
       }),
       querySelector: vi.fn((sel) => {
-        if (sel === '[data-smoothr="auth-panel"]') return {};
+        if (sel === '[data-smoothr="auth-pop-up"]') return {};
         return null;
       }),
       dispatchEvent() {
@@ -420,6 +420,6 @@ describe("dynamic DOM bindings", () => {
     const second = global.document.dispatchEvent.mock.calls[1][0];
     expect(first.type).toBe("smoothr:auth:open");
     expect(second.type).toBe("smoothr:open-auth");
-    expect(second.detail.targetSelector).toBe('[data-smoothr="auth-panel"]');
+    expect(second.detail.targetSelector).toBe('[data-smoothr="auth-pop-up"]');
   });
 });


### PR DESCRIPTION
## Summary
- support `auth-pop-up` and `auth-drop-down` targets while keeping `account-access` trigger
- redirect logged-in users and block navigation for auth UI
- add tests for account-access trigger behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aaa45875bc832595d69eb5499259be