### PR TITLE
feat(auth): defer popup lookup and tighten redirect helpers

### DIFF
--- a/storefronts/smoothr-sdk.js
+++ b/storefronts/smoothr-sdk.js
@@ -8,6 +8,13 @@ if (typeof globalThis.setSelectedCurrency !== 'function') {
 const Smoothr = (window.Smoothr = window.Smoothr || {});
 if (!window.smoothr) window.smoothr = Smoothr;
 
+if (window.SMOOTHR_DEBUG) {
+  console.info('[Smoothr] build', {
+    sdkTag: 'auth-trigger-no-fallback',
+    builtAt: '__BUILD_TIME__',
+  });
+}
+
 try {
   const adapter = initWebflowAdapter(Smoothr.config || {});
   Smoothr.adapter = adapter;

--- a/storefronts/tests/features/auth.test.js
+++ b/storefronts/tests/features/auth.test.js
@@ -47,7 +47,8 @@ describe('auth feature init', () => {
     global.window = {
       location: { hash: '', search: '' },
       Smoothr: {},
-      smoothr: {}
+      smoothr: {},
+      SMOOTHR_DEBUG: true
     };
     global.document = {
       readyState: 'complete',
@@ -56,8 +57,9 @@ describe('auth feature init', () => {
       querySelectorAll: vi.fn(() => [])
     };
     const mod = await import('../../features/auth/init.js');
-    client = await mod.__test_tryImportClient();
-    mod.__test_resetAuth();
+    const test = global.window.Smoothr.config.__test;
+    client = await test.tryImportClient();
+    test.resetAuth();
   });
 
   it('loads v_public_store during init', async () => {

--- a/storefronts/tests/sdk/auth-account-access.spec.js
+++ b/storefronts/tests/sdk/auth-account-access.spec.js
@@ -64,7 +64,7 @@ describe('account-access trigger', () => {
     expect(doc.dispatchEvent).not.toHaveBeenCalled();
   });
 
-  it('no UI redirects to login URL', async () => {
+  it('no UI with redirect mode navigates to login URL', async () => {
     vi.resetModules();
     const { win, doc } = setup();
     const lookupRedirectUrl = vi.fn().mockResolvedValue('/login-url');
@@ -75,7 +75,11 @@ describe('account-access trigger', () => {
     const mod = await import('../../features/auth/init.js');
     await mod.init();
     const evt = {
-      target: { closest: () => ({}) },
+      target: {
+        closest: () => ({
+          getAttribute: (name) => name === 'data-smoothr-auth-mode' ? 'redirect' : null
+        })
+      },
       preventDefault: vi.fn(),
       stopPropagation: vi.fn(),
       stopImmediatePropagation: vi.fn()

--- a/storefronts/tests/sdk/auth-idempotent.test.js
+++ b/storefronts/tests/sdk/auth-idempotent.test.js
@@ -45,6 +45,7 @@ beforeEach(async () => {
     location: { origin: '', href: '', hostname: '' },
     addEventListener: vi.fn(),
     removeEventListener: vi.fn(),
+    SMOOTHR_DEBUG: true,
   };
   global.document = {
     addEventListener: vi.fn((evt, cb) => {
@@ -68,8 +69,9 @@ beforeEach(async () => {
     }))
   };
   const mod = await import('../../features/auth/init.js');
-  client = await mod.__test_tryImportClient();
-  mod.__test_resetAuth();
+  const test = global.window.Smoothr.config.__test;
+  client = await test.tryImportClient();
+  test.resetAuth();
 });
 
 describe('auth init session restoration', () => {

--- a/storefronts/tests/sdk/auth-state-change.test.js
+++ b/storefronts/tests/sdk/auth-state-change.test.js
@@ -1,20 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import * as auth from "../../features/auth/index.js";
-import { onAuthStateChangeHandler } from "../../features/auth/index.js";
-import { currentSupabaseMocks } from "../utils/supabase-mock";
-import { __test_resetAuth } from "../../features/auth/init.js";
+import { currentSupabaseMocks, createClientMock } from "../utils/supabase-mock";
 
 function flushPromises() {
   return new Promise(setImmediate);
 }
 
 describe("auth state change", () => {
-  beforeEach(() => {
-    __test_resetAuth();
+  let auth;
+
+  beforeEach(async () => {
     global.window = {
       location: { origin: "", href: "", hostname: "" },
       addEventListener: vi.fn(),
-      removeEventListener: vi.fn()
+      removeEventListener: vi.fn(),
+      Smoothr: {},
+      smoothr: {},
+      SMOOTHR_DEBUG: true
     };
     global.document = {
       addEventListener: vi.fn((evt, cb) => {
@@ -23,16 +24,20 @@ describe("auth state change", () => {
       querySelectorAll: vi.fn(() => []),
       dispatchEvent: vi.fn()
     };
+    createClientMock();
     const { getUserMock } = currentSupabaseMocks();
     getUserMock.mockResolvedValue({ data: { user: null } });
+    const mod = await import("../../features/auth/index.js");
+    auth = mod;
+    const test = global.window.Smoothr.config.__test;
+    test.resetAuth();
   });
 
   it("updates user and global auth on session change", async () => {
     await auth.init();
     await flushPromises();
     const user = { id: "42", email: "test@example.com" };
-    // Use the exported live binding (set inside init())
-    onAuthStateChangeHandler("SIGNED_IN", { user });
+    auth.onAuthStateChangeHandler("SIGNED_IN", { user });
     expect(global.window.Smoothr.auth.user.value).toEqual(user);
     expect(global.window.Smoothr.auth.client).toBeDefined();
     await global.window.Smoothr.auth.client.auth.getSession();

--- a/storefronts/tests/sdk/lookupRedirectUrl.test.js
+++ b/storefronts/tests/sdk/lookupRedirectUrl.test.js
@@ -36,7 +36,7 @@ describe('lookupRedirectUrl login', () => {
     expect(url).toBe('/from-settings');
   });
 
-  it('falls back to window.location.origin', async () => {
+  it('returns null when config missing', async () => {
     vi.doMock('../../features/config/sdkConfig.js', () => ({
       loadPublicConfig: vi.fn().mockResolvedValue({
         sign_in_redirect_url: null,
@@ -45,6 +45,6 @@ describe('lookupRedirectUrl login', () => {
     }));
     const { lookupRedirectUrl } = await import('../../../supabase/authHelpers.js');
     const url = await lookupRedirectUrl('login');
-    expect(url).toBe('https://example.com');
+    expect(url).toBeNull();
   });
 });

--- a/supabase/client/authHelpers.js
+++ b/supabase/client/authHelpers.js
@@ -139,21 +139,33 @@ export async function lookupRedirectUrl(type = 'login') {
       url =
         config?.sign_in_redirect_url ??
         config?.public_settings?.sign_in_redirect_url ??
-        window.location.origin;
+        null;
     } else {
       const key = `${type}_redirect_url`;
       url =
         config?.[key] ??
         config?.public_settings?.[key] ??
-        window.location.origin;
+        null;
     }
     cachedRedirectUrls[type] = url;
+    if (!url && typeof window !== 'undefined' && window.SMOOTHR_DEBUG) {
+      console.warn('[Smoothr][auth] redirect helper missing value', {
+        helper: 'lookupRedirectUrl',
+        type,
+        reason: 'null-or-error',
+      });
+    }
     return url;
   } catch (error) {
-    console.warn('[Smoothr Auth] Redirect lookup failed:', error);
-    const fallback = window.location.origin;
-    cachedRedirectUrls[type] = fallback;
-    return fallback;
+    if (typeof window !== 'undefined' && window.SMOOTHR_DEBUG) {
+      console.warn('[Smoothr][auth] redirect helper missing value', {
+        helper: 'lookupRedirectUrl',
+        type,
+        reason: 'null-or-error',
+      });
+    }
+    cachedRedirectUrls[type] = null;
+    return null;
   }
 }
 
@@ -165,14 +177,24 @@ export async function lookupDashboardHomeUrl() {
     const url =
       config?.dashboard_home_url ??
       config?.public_settings?.dashboard_home_url ??
-      window.location.origin;
+      null;
     cachedDashboardHomeUrl = url;
+    if (!url && typeof window !== 'undefined' && window.SMOOTHR_DEBUG) {
+      console.warn('[Smoothr][auth] redirect helper missing value', {
+        helper: 'lookupDashboardHomeUrl',
+        reason: 'null-or-error',
+      });
+    }
     return url;
   } catch (error) {
-    console.warn('[Smoothr Auth] Dashboard home lookup failed:', error);
-    const fallback = window.location.origin;
-    cachedDashboardHomeUrl = fallback;
-    return fallback;
+    if (typeof window !== 'undefined' && window.SMOOTHR_DEBUG) {
+      console.warn('[Smoothr][auth] redirect helper missing value', {
+        helper: 'lookupDashboardHomeUrl',
+        reason: 'null-or-error',
+      });
+    }
+    cachedDashboardHomeUrl = null;
+    return null;
   }
 }
 


### PR DESCRIPTION
## Summary
- wait two animation frames before falling back to redirect so late-loading auth popups can open
- redirect helpers now return `null` instead of `window.location.origin` and log when missing
- emit build fingerprint under `SMOOTHR_DEBUG` and expose auth test hooks only in debug mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aabc33594c8325a055081d54a45567