### PR TITLE
auth(events): emit on window+document (bubbling); remove legacy events

### DIFF
--- a/storefronts/tests/sdk/account-access.test.js
+++ b/storefronts/tests/sdk/account-access.test.js
@@ -104,7 +104,7 @@ describe("account access trigger", () => {
     });
   });
 
-  describe("dispatches open-auth event for anonymous users", () => {
+  describe("dispatches auth:open event for anonymous users", () => {
     beforeEach(async () => {
       vi.resetModules();
       createClientMock();
@@ -116,16 +116,18 @@ describe("account access trigger", () => {
       await flushPromises();
     });
 
-    it("dispatches open-auth event for anonymous users", async () => {
+    it("dispatches auth:open event for anonymous users", async () => {
       await clickHandler({ target: btn, preventDefault: () => {} });
       await flushPromises();
 
-      expect(global.document.dispatchEvent).toHaveBeenCalledTimes(2);
-      const first = global.document.dispatchEvent.mock.calls[0][0];
-      const second = global.document.dispatchEvent.mock.calls[1][0];
-      expect(first.type).toBe("smoothr:auth:open");
-      expect(second.type).toBe("smoothr:open-auth");
-      expect(second.detail.targetSelector).toBe('[data-smoothr="auth-pop-up"]');
+      expect(global.document.dispatchEvent).toHaveBeenCalledTimes(1);
+      expect(global.window.dispatchEvent).toHaveBeenCalledTimes(1);
+      const docEvt = global.document.dispatchEvent.mock.calls[0][0];
+      const winEvt = global.window.dispatchEvent.mock.calls[0][0];
+      expect(docEvt.type).toBe("smoothr:auth:open");
+      expect(winEvt.type).toBe("smoothr:auth:open");
+      expect(docEvt.detail.targetSelector).toBe('[data-smoothr="auth-pop-up"]');
+      expect(winEvt.detail.targetSelector).toBe('[data-smoothr="auth-pop-up"]');
     });
   });
 });

--- a/storefronts/tests/sdk/auth-account-access.spec.js
+++ b/storefronts/tests/sdk/auth-account-access.spec.js
@@ -3,7 +3,8 @@ import { describe, it, expect, vi } from 'vitest';
 function setup({ user = null, popup = false, dropdown = false } = {}) {
   const win = {
     Smoothr: { auth: { user: { value: user } } },
-    location: { href: '/start' }
+    location: { href: '/start' },
+    dispatchEvent: vi.fn(),
   };
   const doc = {
     readyState: 'complete',
@@ -37,13 +38,14 @@ describe('account-access trigger', () => {
     expect(evt.preventDefault).toHaveBeenCalled();
     expect(evt.stopImmediatePropagation).toHaveBeenCalled();
     expect(win.location.href).toBe('/start');
-    expect(doc.dispatchEvent).toHaveBeenCalledTimes(2);
-    const first = doc.dispatchEvent.mock.calls[0][0];
-    const second = doc.dispatchEvent.mock.calls[1][0];
-    expect(first.type).toBe('smoothr:auth:open');
-    expect(first.detail.selector).toBe('[data-smoothr="auth-pop-up"]');
-    expect(second.type).toBe('smoothr:open-auth');
-    expect(second.detail.targetSelector).toBe('[data-smoothr="auth-pop-up"]');
+    expect(doc.dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(win.dispatchEvent).toHaveBeenCalledTimes(1);
+    const docEvt = doc.dispatchEvent.mock.calls[0][0];
+    const winEvt = win.dispatchEvent.mock.calls[0][0];
+    expect(docEvt.type).toBe('smoothr:auth:open');
+    expect(winEvt.type).toBe('smoothr:auth:open');
+    expect(docEvt.detail.targetSelector).toBe('[data-smoothr="auth-pop-up"]');
+    expect(winEvt.detail.targetSelector).toBe('[data-smoothr="auth-pop-up"]');
   });
 
   it('dropdown present, logged out skips SDK UI', async () => {
@@ -62,6 +64,7 @@ describe('account-access trigger', () => {
     expect(evt.stopImmediatePropagation).toHaveBeenCalled();
     expect(win.location.href).toBe('/start');
     expect(doc.dispatchEvent).not.toHaveBeenCalled();
+    expect(win.dispatchEvent).not.toHaveBeenCalled();
   });
 
   it('no UI with redirect mode navigates to login URL', async () => {
@@ -88,6 +91,7 @@ describe('account-access trigger', () => {
     expect(lookupRedirectUrl).toHaveBeenCalledWith('login');
     expect(win.location.href).toBe('/login-url');
     expect(doc.dispatchEvent).not.toHaveBeenCalled();
+    expect(win.dispatchEvent).not.toHaveBeenCalled();
   });
 
   it('logged-in users redirect to preferred URL', async () => {
@@ -111,6 +115,7 @@ describe('account-access trigger', () => {
     expect(lookupDashboardHomeUrl).toHaveBeenCalled();
     expect(win.location.href).toBe('/dashboard');
     expect(doc.dispatchEvent).not.toHaveBeenCalled();
+    expect(win.dispatchEvent).not.toHaveBeenCalled();
   });
 
   it('registers capture-phase listener for account-access triggers', async () => {

--- a/storefronts/tests/sdk/auth-trigger.test.js
+++ b/storefronts/tests/sdk/auth-trigger.test.js
@@ -6,7 +6,8 @@ describe('auth triggers', () => {
     vi.resetModules();
     win = {
       Smoothr: { auth: { user: { value: null } } },
-      location: { origin: 'https://example.com' }
+      location: { origin: 'https://example.com' },
+      dispatchEvent: vi.fn(),
     };
     doc = {
       readyState: 'complete',
@@ -21,7 +22,7 @@ describe('auth triggers', () => {
     await mod.init();
   });
 
-  it('popup mode dispatches smoothr:open-auth and fires lifecycle events', async () => {
+  it('popup mode dispatches smoothr:auth:open and toggles auth panel', async () => {
     const btn = {};
     const evt = {
       target: { closest: () => btn },
@@ -36,8 +37,14 @@ describe('auth triggers', () => {
     };
     doc.querySelector = vi.fn(sel => (sel.includes('auth-pop-up') ? panel : null));
     await mod.docClickHandler(evt);
-    const listener = doc.addEventListener.mock.calls.find(c => c[0] === 'smoothr:open-auth')[1];
-    listener({ detail: { targetSelector: '[data-smoothr="auth-pop-up"]' } });
+    expect(win.dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(doc.dispatchEvent).toHaveBeenCalledTimes(1);
+    const winEvt = win.dispatchEvent.mock.calls[0][0];
+    const docEvt = doc.dispatchEvent.mock.calls[0][0];
+    expect(winEvt.type).toBe('smoothr:auth:open');
+    expect(docEvt.type).toBe('smoothr:auth:open');
+    expect(winEvt.detail.targetSelector).toBe('[data-smoothr="auth-pop-up"]');
+    expect(docEvt.detail.targetSelector).toBe('[data-smoothr="auth-pop-up"]');
     expect(panel.classList.toggle).toHaveBeenCalledWith('is-active', true);
   });
 
@@ -65,6 +72,7 @@ describe('auth triggers', () => {
     };
     await mod.docClickHandler(evt);
     expect(doc.dispatchEvent).not.toHaveBeenCalled();
+    expect(win.dispatchEvent).not.toHaveBeenCalled();
   });
 });
 

--- a/storefronts/tests/sdk/dom-mutation.test.js
+++ b/storefronts/tests/sdk/dom-mutation.test.js
@@ -398,7 +398,7 @@ describe("dynamic DOM bindings", () => {
     expect(errorEl.style.display).toBe("");
   });
 
-  it("binds newly added account-access elements and dispatches open-auth", async () => {
+  it("binds newly added account-access elements and dispatches auth:open", async () => {
     const { getUserMock } = currentSupabaseMocks();
     getUserMock.mockResolvedValue({ data: { user: null } });
     const btn = {
@@ -415,11 +415,13 @@ describe("dynamic DOM bindings", () => {
 
     await docClickHandler({ target: btn, preventDefault: () => {} });
     await flushPromises();
-    expect(global.document.dispatchEvent).toHaveBeenCalledTimes(2);
-    const first = global.document.dispatchEvent.mock.calls[0][0];
-    const second = global.document.dispatchEvent.mock.calls[1][0];
-    expect(first.type).toBe("smoothr:auth:open");
-    expect(second.type).toBe("smoothr:open-auth");
-    expect(second.detail.targetSelector).toBe('[data-smoothr="auth-pop-up"]');
+    expect(global.document.dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(global.window.dispatchEvent).toHaveBeenCalledTimes(1);
+    const docEvt = global.document.dispatchEvent.mock.calls[0][0];
+    const winEvt = global.window.dispatchEvent.mock.calls[0][0];
+    expect(docEvt.type).toBe("smoothr:auth:open");
+    expect(winEvt.type).toBe("smoothr:auth:open");
+    expect(docEvt.detail.targetSelector).toBe('[data-smoothr="auth-pop-up"]');
+    expect(winEvt.detail.targetSelector).toBe('[data-smoothr="auth-pop-up"]');
   });
 });


### PR DESCRIPTION
## Summary
- add emitAuth helper to bubble auth events on window and document
- drop legacy smoothr:open-auth listener and use emitAuth for lifecycle
- adjust account-access specs to spy on window auth events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af4df5a23c8325adbcc97dea8367d5