### PR TITLE
feat: add session sync endpoints and set password page

### DIFF
--- a/smoothr/lib/supabaseAdmin.ts
+++ b/smoothr/lib/supabaseAdmin.ts
@@ -1,0 +1,15 @@
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+const service = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+
+if (!url || !anon || !service) {
+  throw new Error('Missing env: NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY, or SUPABASE_SERVICE_ROLE_KEY');
+}
+
+// For verifying bearer access tokens server-side without exposing service role
+export const supabaseAnonServer = createClient(url, anon);
+
+// Service-role client — server-only DB ops
+export const supabaseAdmin = createClient(url, service);

--- a/smoothr/pages/api/auth/session-sync.ts
+++ b/smoothr/pages/api/auth/session-sync.ts
@@ -1,0 +1,59 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { supabaseAdmin, supabaseAnonServer } from '../../../lib/supabaseAdmin';
+
+type Ok = { ok: true; dashboard_home_url: string | null; features?: any };
+type Err = { ok: false; error: string };
+export default async function handler(req: NextApiRequest, res: NextApiResponse<Ok | Err>) {
+  if (req.method !== 'POST') return res.status(405).json({ ok: false, error: 'Method Not Allowed' });
+
+  try {
+    const authz = req.headers.authorization || '';
+    const token = authz.startsWith('Bearer ') ? authz.slice(7) : '';
+    const body = typeof req.body === 'string' ? JSON.parse(req.body) : (req.body ?? {});
+    const store_id = body?.store_id;
+
+    if (!token) return res.status(401).json({ ok: false, error: 'Missing bearer token' });
+    if (!store_id) return res.status(400).json({ ok: false, error: 'Missing store_id' });
+
+    // Verify Supabase access token
+    const { data: userRes, error: userErr } = await supabaseAnonServer.auth.getUser(token);
+    if (userErr || !userRes?.user) return res.status(401).json({ ok: false, error: 'Invalid access token' });
+
+    const user = userRes.user;
+    const email = user.email ?? null;
+
+    // Upsert per-store customer record (adjust table/columns if your schema differs)
+    await supabaseAdmin
+      .from('customers')
+      .upsert(
+        { store_id, user_id: user.id, email, last_seen_at: new Date().toISOString() },
+        { onConflict: 'store_id,user_id' }
+      );
+
+    // Get dashboard_home_url from your public view/settings
+    let dashboard_home_url: string | null = null;
+
+    const vres = await supabaseAdmin
+      .from('v_public_store')
+      .select('dashboard_home_url')
+      .eq('store_id', store_id)
+      .maybeSingle();
+
+    if (!vres.error && vres.data) {
+      dashboard_home_url = vres.data.dashboard_home_url ?? null;
+    } else {
+      const sres = await supabaseAdmin
+        .from('public_store_settings')
+        .select('dashboard_home_url')
+        .eq('store_id', store_id)
+        .maybeSingle();
+      if (!sres.error && sres.data) dashboard_home_url = sres.data.dashboard_home_url ?? null;
+    }
+
+    // (Phase-2 will add an httpOnly smoothr_sid cookie; omitted for MVP.)
+    return res.status(200).json({ ok: true, dashboard_home_url, features: {} });
+  } catch (e: any) {
+    console.error('[session-sync] error', e);
+    return res.status(500).json({ ok: false, error: 'Internal Server Error' });
+  }
+}

--- a/smoothr/pages/api/callback.ts
+++ b/smoothr/pages/api/callback.ts
@@ -1,0 +1,10 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  // For password recovery flows we route to our Set Password page.
+  const { store_id } = req.query;
+  const base = '/auth/set-password';
+  const loc = store_id ? `${base}?store_id=${encodeURIComponent(String(store_id))}` : base;
+  res.setHeader('Location', loc);
+  res.status(302).end();
+}

--- a/smoothr/pages/auth/set-password.tsx
+++ b/smoothr/pages/auth/set-password.tsx
@@ -1,0 +1,72 @@
+import { useCallback, useEffect, useState } from 'react';
+import Head from 'next/head';
+import Router, { useRouter } from 'next/router';
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);
+
+export default function SetPasswordPage() {
+  const { query } = useRouter();
+  const [email, setEmail] = useState<string | null>(null);
+  const [pwd, setPwd] = useState(''); const [pwd2, setPwd2] = useState('');
+  const [msg, setMsg] = useState<string | null>(null); const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    supabase.auth.getUser().then(({ data }) => { if (mounted) setEmail(data?.user?.email ?? null) });
+    return () => { mounted = false; };
+  }, []);
+
+  const onSubmit = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (pwd.length < 8) return setMsg('Password must be at least 8 characters.');
+    if (pwd !== pwd2) return setMsg('Passwords do not match.');
+    setBusy(true); setMsg(null);
+    try {
+      const { error } = await supabase.auth.updateUser({ password: pwd });
+      if (error) throw error;
+
+      const { data: sess } = await supabase.auth.getSession();
+      const token = sess?.session?.access_token;
+      const store_id = (query.store_id as string) || null;
+
+      const resp = await fetch('/api/auth/session-sync', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...(token ? { Authorization: `Bearer ${token}` } : {}) },
+        body: JSON.stringify({ store_id }),
+      });
+      const json = await resp.json();
+      if (!resp.ok || !json?.ok) throw new Error(json?.error || 'Sync failed');
+
+      Router.replace(json.dashboard_home_url || '/');
+    } catch (err: any) {
+      console.error('[set-password] error', err);
+      setMsg(err?.message || 'Something went wrong'); setBusy(false);
+    }
+  }, [pwd, pwd2, query.store_id]);
+
+  return (
+    <>
+      <Head><title>Set your password</title></Head>
+      <main style={{ maxWidth: 420, margin: '64px auto', fontFamily: 'system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial' }}>
+        <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 16 }}>Set your password</h1>
+        <p style={{ marginBottom: 16, opacity: 0.8 }}>
+          {email ? <>For <strong>{email}</strong></> : 'Complete your password reset.'}
+        </p>
+        <form onSubmit={onSubmit}>
+          <div style={{ display: 'grid', gap: 12 }}>
+            <input type="password" placeholder="New password" value={pwd} onChange={e => setPwd(e.target.value)} required />
+            <input type="password" placeholder="Confirm new password" value={pwd2} onChange={e => setPwd2(e.target.value)} required />
+            <div role="button" tabIndex={0} onClick={onSubmit as any} onKeyDown={(e)=>{if(e.key==='Enter') onSubmit(e as any)}} style={{ padding: 10, border: '1px solid #ddd', textAlign: 'center', cursor: 'pointer' }}>
+              {busy ? 'Saving…' : 'Save password'}
+            </div>
+          </div>
+        </form>
+        {msg && <p style={{ color: 'crimson', marginTop: 12 }}>{msg}</p>}
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add Supabase admin utility for server-side operations
- create session-sync and callback API routes
- add Set Password page that posts to session-sync

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af5ea561e483258ecfcb30134945a6