### PR TITLE
feat(auth): canonical auth submit with session-sync events

### DIFF
--- a/storefronts/tests/sdk/dom-mutation.test.js
+++ b/storefronts/tests/sdk/dom-mutation.test.js
@@ -137,10 +137,9 @@ describe("dynamic DOM bindings", () => {
     await flushPromises();
 
     expect(global.window.Smoothr.auth.user.value).toEqual(user);
-    expect(global.document.dispatchEvent).toHaveBeenCalledWith(expect.any(CustomEvent));
-    const evt = global.document.dispatchEvent.mock.calls.at(-1)[0];
-    expect(evt).toBeInstanceOf(CustomEvent);
-    expect(evt.type).toBe("smoothr:login");
+    const types = global.document.dispatchEvent.mock.calls.map(c => c[0]?.type);
+    expect(types).toContain("smoothr:login");
+    expect(types.at(-1)).toBe("smoothr:auth:close");
   });
 
   it("attaches listeners to added signup elements and updates auth state", async () => {
@@ -188,10 +187,9 @@ describe("dynamic DOM bindings", () => {
     await flushPromises();
 
     expect(global.window.Smoothr.auth.user.value).toEqual(user);
-    expect(global.document.dispatchEvent).toHaveBeenCalledWith(expect.any(CustomEvent));
-    const evt = global.document.dispatchEvent.mock.calls.at(-1)[0];
-    expect(evt).toBeInstanceOf(CustomEvent);
-    expect(evt.type).toBe("smoothr:login");
+    const types = global.document.dispatchEvent.mock.calls.map(c => c[0]?.type);
+    expect(types).toContain("smoothr:login");
+    expect(types.at(-1)).toBe("smoothr:auth:close");
   });
 
   it("attaches listeners to added google login elements and dispatches login event", async () => {

--- a/storefronts/tests/sdk/password-reset.test.js
+++ b/storefronts/tests/sdk/password-reset.test.js
@@ -67,7 +67,7 @@ describe("password reset request", () => {
     await flushPromises();
     expect(resetPasswordMock).toHaveBeenCalledWith(
       "user@example.com",
-      expect.objectContaining({ redirectTo: "" })
+      expect.objectContaining({ redirectTo: expect.stringContaining('/api/callback') })
     );
     expect(global.window.alert).toHaveBeenCalled();
   });

--- a/storefronts/tests/sdk/signup.test.js
+++ b/storefronts/tests/sdk/signup.test.js
@@ -125,7 +125,7 @@ describe("signup flow", () => {
     global.document.dispatchEvent.mockClear();
     await clickHandler({ preventDefault: () => {} });
     await flushPromises();
-    expect(global.document.dispatchEvent).not.toHaveBeenCalled();
+    expect(global.document.dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'smoothr:auth:error' }));
     expect(global.window.location.href).toBe("");
   });
 


### PR DESCRIPTION
## Summary
- implement canonical auth form submit that signs in, syncs session and emits auth events
- sync session and emit auth events for login, signup, password reset confirm, and OAuth providers
- update tests for new auth events and password reset redirect

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af7b93e80883259c1ffe8672808310