### PR TITLE
feat: derive broker base URL for auth flows

### DIFF
--- a/smoothr/pages/api/auth/session-sync.ts
+++ b/smoothr/pages/api/auth/session-sync.ts
@@ -4,6 +4,14 @@ import { supabaseAdmin, supabaseAnonServer } from '../../../lib/supabaseAdmin';
 type Ok = { ok: true; dashboard_home_url: string | null; features?: any };
 type Err = { ok: false; error: string };
 export default async function handler(req: NextApiRequest, res: NextApiResponse<Ok | Err>) {
+  // CORS
+  const origin = req.headers.origin || '*';
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Vary', 'Origin');
+  res.setHeader('Access-Control-Allow-Credentials', 'true');
+  res.setHeader('Access-Control-Allow-Headers', 'authorization, content-type');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  if (req.method === 'OPTIONS') return res.status(204).end();
   if (req.method !== 'POST') return res.status(405).json({ ok: false, error: 'Method Not Allowed' });
 
   try {


### PR DESCRIPTION
## Summary
- allow CORS requests on `/api/auth/session-sync`
- compute broker base URL in SDK and use for session sync and password reset redirects

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af98c11ba88325a7ca90b25d56f7fb