### PR TITLE
refactor: standardize auth redirects

### DIFF
--- a/smoothr/pages/auth/set-password.tsx
+++ b/smoothr/pages/auth/set-password.tsx
@@ -41,7 +41,7 @@ export default function SetPasswordPage() {
       const json = await resp.json();
       if (!resp.ok || !json?.ok) throw new Error(json?.error || 'Sync failed');
 
-      Router.replace(json.dashboard_home_url || '/');
+      Router.replace(json.redirect_url || json.sign_in_redirect_url || '/');
     } catch (err: any) {
       console.error('[set-password] error', err);
       setMsg(err?.message || 'Something went wrong'); setBusy(false);

--- a/storefronts/features/auth/index.js
+++ b/storefronts/features/auth/index.js
@@ -5,7 +5,6 @@ export {
   setSupabaseClient,
   resolveSupabase,
   lookupRedirectUrl,
-  lookupDashboardHomeUrl,
   normalizeDomain,
   initPasswordResetConfirmation,
   clickHandler,

--- a/storefronts/features/config/sdkConfig.js
+++ b/storefronts/features/config/sdkConfig.js
@@ -11,7 +11,7 @@ export async function loadPublicConfig(storeId, supabase) {
     const { data, error } = await supabase
       .from('v_public_store')
       .select(
-        'store_id,active_payment_gateway,publishable_key,base_currency,public_settings,sign_in_redirect_url,dashboard_home_url'
+        'store_id,active_payment_gateway,publishable_key,base_currency,public_settings,sign_in_redirect_url,sign_out_redirect_url'
       )
       .eq('store_id', storeId)
       .maybeSingle();
@@ -26,7 +26,7 @@ export async function loadPublicConfig(storeId, supabase) {
         public_settings: {},
         active_payment_gateway: null,
         sign_in_redirect_url: null,
-        dashboard_home_url: null
+        sign_out_redirect_url: null
       };
     }
 
@@ -35,7 +35,7 @@ export async function loadPublicConfig(storeId, supabase) {
       public_settings: data.public_settings || {},
       active_payment_gateway: data.active_payment_gateway ?? null,
       sign_in_redirect_url: data?.sign_in_redirect_url ?? null,
-      dashboard_home_url: data?.dashboard_home_url ?? null
+      sign_out_redirect_url: data?.sign_out_redirect_url ?? null
     };
 
     log('Config fetched');
@@ -50,7 +50,7 @@ export async function loadPublicConfig(storeId, supabase) {
       public_settings: {},
       active_payment_gateway: null,
       sign_in_redirect_url: null,
-      dashboard_home_url: null
+      sign_out_redirect_url: null
     };
   }
 }

--- a/storefronts/tests/sdk/account-access.test.js
+++ b/storefronts/tests/sdk/account-access.test.js
@@ -85,7 +85,7 @@ describe("account access trigger", () => {
       const { getUserMock } = currentSupabaseMocks();
       authHelpers = await import("../../../supabase/authHelpers.js");
       vi
-        .spyOn(authHelpers, "lookupDashboardHomeUrl")
+        .spyOn(authHelpers, "lookupRedirectUrl")
         .mockResolvedValue("/dashboard");
       user = { id: "1", email: "test@example.com" };
       getUserMock.mockResolvedValueOnce({ data: { user } });
@@ -99,7 +99,7 @@ describe("account access trigger", () => {
 
       await clickHandler({ target: btn, preventDefault: () => {} });
       await flushPromises();
-      expect(authHelpers.lookupDashboardHomeUrl).toHaveBeenCalled();
+      expect(authHelpers.lookupRedirectUrl).toHaveBeenCalled();
       expect(global.window.location.href).toBe("/dashboard");
     });
   });

--- a/storefronts/tests/sdk/auth-account-access.spec.js
+++ b/storefronts/tests/sdk/auth-account-access.spec.js
@@ -73,7 +73,6 @@ describe('account-access trigger', () => {
     const lookupRedirectUrl = vi.fn().mockResolvedValue('/login-url');
     vi.doMock('../../../supabase/authHelpers.js', () => ({
       lookupRedirectUrl,
-      lookupDashboardHomeUrl: vi.fn()
     }));
     const mod = await import('../../features/auth/init.js');
     await mod.init();
@@ -97,10 +96,9 @@ describe('account-access trigger', () => {
   it('logged-in users redirect to preferred URL', async () => {
     vi.resetModules();
     const { win, doc } = setup();
-    const lookupDashboardHomeUrl = vi.fn().mockResolvedValue('/dashboard');
+    const lookupRedirectUrl = vi.fn().mockResolvedValue('/dashboard');
     vi.doMock('../../../supabase/authHelpers.js', () => ({
-      lookupRedirectUrl: vi.fn(),
-      lookupDashboardHomeUrl
+      lookupRedirectUrl,
     }));
     const mod = await import('../../features/auth/init.js');
     await mod.init();
@@ -112,7 +110,7 @@ describe('account-access trigger', () => {
       stopImmediatePropagation: vi.fn()
     };
     await mod.docClickHandler(evt);
-    expect(lookupDashboardHomeUrl).toHaveBeenCalled();
+    expect(lookupRedirectUrl).toHaveBeenCalled();
     expect(win.location.href).toBe('/dashboard');
     expect(doc.dispatchEvent).not.toHaveBeenCalled();
     expect(win.dispatchEvent).not.toHaveBeenCalled();

--- a/storefronts/tests/sdk/auth-idempotent.test.js
+++ b/storefronts/tests/sdk/auth-idempotent.test.js
@@ -9,7 +9,6 @@ vi.mock('../../features/auth/index.js', () => {
     props: {},
     children: [],
     lookupRedirectUrl: vi.fn(),
-    lookupDashboardHomeUrl: vi.fn(),
   };
   return { default: authMock, ...authMock };
 });

--- a/storefronts/tests/sdk/cart.test.js
+++ b/storefronts/tests/sdk/cart.test.js
@@ -4,7 +4,6 @@ vi.mock("../../features/auth/index.js", () => {
   const authMock = {
     init: vi.fn().mockResolvedValue(),
     lookupRedirectUrl: vi.fn(),
-    lookupDashboardHomeUrl: vi.fn(),
   };
   return { default: authMock, ...authMock };
 });

--- a/storefronts/tests/sdk/load-config-api-base.test.js
+++ b/storefronts/tests/sdk/load-config-api-base.test.js
@@ -11,7 +11,6 @@ vi.mock('../../features/auth/index.js', () => {
     props: {},
     children: [],
     lookupRedirectUrl: vi.fn(),
-    lookupDashboardHomeUrl: vi.fn(),
   };
   return { default: authMock, ...authMock };
 });

--- a/storefronts/tests/sdk/load-config-merge.test.js
+++ b/storefronts/tests/sdk/load-config-merge.test.js
@@ -9,7 +9,6 @@ vi.mock('../../features/auth/index.js', () => {
     props: {},
     children: [],
     lookupRedirectUrl: vi.fn(),
-    lookupDashboardHomeUrl: vi.fn(),
   };
   return { default: authMock, ...authMock };
 });

--- a/storefronts/tests/v_public_store.test.ts
+++ b/storefronts/tests/v_public_store.test.ts
@@ -39,7 +39,7 @@ describe('loadPublicConfig', () => {
       base_currency: 'GBP',
       public_settings: {},
       sign_in_redirect_url: '/sign-in',
-      dashboard_home_url: '/dashboard'
+      sign_out_redirect_url: '/bye'
     };
     builder.maybeSingle.mockResolvedValue({ data: row, error: null });
 
@@ -47,7 +47,7 @@ describe('loadPublicConfig', () => {
 
     expect(config).toEqual(row);
     expect(builder.select).toHaveBeenCalledWith(
-      'store_id,active_payment_gateway,publishable_key,base_currency,public_settings,sign_in_redirect_url,dashboard_home_url'
+      'store_id,active_payment_gateway,publishable_key,base_currency,public_settings,sign_in_redirect_url,sign_out_redirect_url'
     );
     expect(builder.eq).toHaveBeenCalledWith('store_id', storeId);
     expect(builder.maybeSingle).toHaveBeenCalledTimes(1);
@@ -68,7 +68,7 @@ describe('loadPublicConfig', () => {
     expect(config.active_payment_gateway).toBeNull();
     expect(config.public_settings).toEqual({});
     expect(config.sign_in_redirect_url).toBeNull();
-    expect(config.dashboard_home_url).toBeNull();
+    expect(config.sign_out_redirect_url).toBeNull();
   });
 
   it('returns fallback settings on query error', async () => {
@@ -84,7 +84,7 @@ describe('loadPublicConfig', () => {
       public_settings: {},
       active_payment_gateway: null,
       sign_in_redirect_url: null,
-      dashboard_home_url: null
+      sign_out_redirect_url: null
     });
   });
 });

--- a/supabase/client/authHelpers.js
+++ b/supabase/client/authHelpers.js
@@ -132,7 +132,6 @@ export function normalizeDomain(hostname) {
 }
 
 const cachedRedirectUrls = {};
-let cachedDashboardHomeUrl;
 
 export async function lookupRedirectUrl(type = 'login') {
   if (cachedRedirectUrls[type]) return cachedRedirectUrls[type];
@@ -174,34 +173,6 @@ export async function lookupRedirectUrl(type = 'login') {
   }
 }
 
-export async function lookupDashboardHomeUrl() {
-  if (cachedDashboardHomeUrl) return cachedDashboardHomeUrl;
-
-  try {
-    const config = await loadPublicConfig(SMOOTHR_CONFIG.storeId);
-    const url =
-      config?.dashboard_home_url ??
-      config?.public_settings?.dashboard_home_url ??
-      null;
-    cachedDashboardHomeUrl = url;
-    if (!url && typeof window !== 'undefined' && window.SMOOTHR_DEBUG) {
-      console.warn('[Smoothr][auth] redirect helper missing value', {
-        helper: 'lookupDashboardHomeUrl',
-        reason: 'null-or-error',
-      });
-    }
-    return url;
-  } catch (error) {
-    if (typeof window !== 'undefined' && window.SMOOTHR_DEBUG) {
-      console.warn('[Smoothr][auth] redirect helper missing value', {
-        helper: 'lookupDashboardHomeUrl',
-        reason: 'null-or-error',
-      });
-    }
-    cachedDashboardHomeUrl = null;
-    return null;
-  }
-}
 
 export async function initAuth() {
   try {


### PR DESCRIPTION
## Summary
- standardize auth redirect flow on sign_in_redirect_url and sign_out_redirect_url
- drop legacy dashboard_home_url usage across SDK and API
- update tests and config for new redirect fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68afb4caa8c883258a0b48673896fd0c