### PR TITLE
feat(auth): bubble sign-out events and redirect

### DIFF
--- a/storefronts/tests/sdk/global-auth.test.js
+++ b/storefronts/tests/sdk/global-auth.test.js
@@ -8,39 +8,49 @@ function flushPromises() {
 describe("global auth", () => {
   let signOutHandler;
 
+  function createTarget(triggerDom = false) {
+    const listeners = {};
+    return {
+      addEventListener: vi.fn((evt, cb) => {
+        (listeners[evt] ||= []).push(cb);
+        if (triggerDom && evt === "DOMContentLoaded") cb();
+      }),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn((evt) => {
+        (listeners[evt.type] || []).forEach((cb) => cb(evt));
+        return true;
+      }),
+    };
+  }
+
   beforeEach(() => {
     signOutHandler = undefined;
     const { getUserMock, signOutMock } = currentSupabaseMocks();
     getUserMock.mockClear();
     signOutMock.mockClear();
     getUserMock.mockResolvedValue({ data: { user: null } });
-    global.window = {
-      location: { origin: "", href: "", hostname: "" },
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-    };
-    global.document = {
-      addEventListener: vi.fn((evt, cb) => {
-        if (evt === "DOMContentLoaded") cb();
-      }),
-      dispatchEvent: vi.fn(),
-      querySelectorAll: vi.fn((selector) => {
-        if (selector.includes('[data-smoothr="sign-out"]')) {
-          const btn = {
-            tagName: "DIV",
-            dataset: { smoothr: "sign-out" },
-            addEventListener: vi.fn((event, cb) => {
-              if (event === "click") signOutHandler = cb;
-            }),
-          };
-          return [btn];
-        }
-        return [];
-      }),
-    };
+    const win = createTarget();
+    win.location = { origin: "", href: "", hostname: "", assign: vi.fn() };
+    global.window = win;
+    global.location = win.location;
+    const doc = createTarget(true);
+    doc.querySelectorAll = vi.fn((selector) => {
+      if (selector.includes('[data-smoothr="sign-out"]')) {
+        const btn = {
+          tagName: "DIV",
+          dataset: { smoothr: "sign-out" },
+          addEventListener: vi.fn((event, cb) => {
+            if (event === "click") signOutHandler = cb;
+          }),
+        };
+        return [btn];
+      }
+      return [];
+    });
+    global.document = doc;
   });
 
-  it("sets and clears window.Smoothr.auth.user", async () => {
+  it("sets and clears window.Smoothr.auth.user and emits sign-out events", async () => {
     const { getUserMock } = currentSupabaseMocks();
     const user = { id: "1", email: "test@example.com" };
     getUserMock.mockResolvedValueOnce({ data: { user } });
@@ -49,9 +59,15 @@ describe("global auth", () => {
     await flushPromises();
     expect(global.window.Smoothr.auth.user.value).toEqual(user);
 
+    const seen = [];
+    window.addEventListener("smoothr:sign-out", () => seen.push("signout"));
+    window.addEventListener("smoothr:auth:close", () => seen.push("close"));
+
     getUserMock.mockResolvedValueOnce({ data: { user: null } });
     await signOutHandler({ preventDefault: () => {} });
     await flushPromises();
     expect(global.window.Smoothr.auth.user.value).toBeNull();
+    expect(seen).toContain("signout");
+    expect(seen).toContain("close");
   });
 });


### PR DESCRIPTION
## Summary
- bubble `smoothr:sign-out` via emitAuth
- close auth UI and redirect after sign-out
- test sign-out events and redirect wiring

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68afb90f8d6c83259386b4f913a587ca