### PR TITLE
Handle password reset on form submit

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -634,13 +634,23 @@ export async function init(options = {}) {
 
       const hasSignUp = !!form.querySelector('[data-smoothr="sign-up"]');
       const hasResetConfirm = !!form.querySelector('[data-smoothr="password-reset-confirm"]');
+      const hasResetRequest = !!form.querySelector('[data-smoothr="password-reset"]');
       const target =
         (hasSignUp && form.querySelector('[data-smoothr="sign-up"]')) ||
         (hasResetConfirm && form.querySelector('[data-smoothr="password-reset-confirm"]')) ||
+        (hasResetRequest && form.querySelector('[data-smoothr="password-reset"]')) ||
         form.querySelector('[data-smoothr="login"]');
 
-      if (target) {
-        await clickHandler({ target });
+      if (!target) {
+        emitAuth?.('smoothr:auth:error', { code: 'NO_ACTION', message: 'No auth action available in form' });
+        return;
+      }
+
+      const fakeEvt = { preventDefault() {}, target, currentTarget: target }; // clickHandler reads data-smoothr on target
+      try {
+        await clickHandler(fakeEvt);
+      } catch (err) {
+        emitAuth?.('smoothr:auth:error', { code: 'SUBMIT_FAILED', message: err?.message || 'Submit failed' });
       }
     };
 

--- a/storefronts/tests/sdk/dom-mutation.test.js
+++ b/storefronts/tests/sdk/dom-mutation.test.js
@@ -15,6 +15,25 @@ const OTHER_SELECTOR =
   '[data-smoothr="sign-up"], [data-smoothr="login-google"], [data-smoothr="login-apple"], [data-smoothr="password-reset"]';
 const ACCOUNT_ACCESS_SELECTOR = '[data-smoothr="account-access"]';
 
+it('routes submit on reset-only form to password-reset handler', async () => {
+  vi.resetModules();
+  createClientMock();
+  auth = await import("../../features/auth/index.js");
+  await auth.init();
+  await flushPromises();
+
+  const form = document.createElement('form');
+  form.setAttribute('data-smoothr', 'auth-form');
+  form.innerHTML = `
+    <input data-smoothr="email" value="user@example.com" />
+    <div data-smoothr="password-reset"></div>
+  `;
+  document.body.appendChild(form);
+  const evt = new Event('submit', { bubbles: true, cancelable: true });
+  // Should not throw; router should pick the reset control and handle gracefully
+  expect(() => form.dispatchEvent(evt)).not.toThrow();
+});
+
 describe("dynamic DOM bindings", () => {
   let mutationCallback;
   let elements;

--- a/storefronts/tests/sdk/password-reset.test.js
+++ b/storefronts/tests/sdk/password-reset.test.js
@@ -7,6 +7,32 @@ function flushPromises() {
   return new Promise(setImmediate);
 }
 
+it('submits password-reset via Enter on reset-only form', async () => {
+  vi.resetModules();
+  createClientMock();
+  const { resetPasswordMock } = currentSupabaseMocks();
+  auth = await import("../../features/auth/index.js");
+  await auth.init();
+  await flushPromises();
+
+  const form = document.createElement('form');
+  form.setAttribute('data-smoothr', 'auth-form');
+  const email = document.createElement('input');
+  email.setAttribute('data-smoothr', 'email');
+  email.value = 'user@example.com';
+  const reset = document.createElement('div');
+  reset.setAttribute('data-smoothr', 'password-reset');
+  form.append(email, reset);
+  document.body.appendChild(form);
+
+  resetPasswordMock.mockResolvedValue({ data: {}, error: null });
+  const evt = new Event('submit', { bubbles: true, cancelable: true });
+  form.dispatchEvent(evt);
+  await flushPromises();
+
+  expect(resetPasswordMock).toHaveBeenCalledWith('user@example.com', expect.any(Object));
+});
+
 describe("password reset request", () => {
   let clickHandler;
   let emailValue;


### PR DESCRIPTION
## Summary
- route auth-form submissions to password reset when present
- verify reset submits work with Enter key
- ensure submit routing handles password reset in DOM bindings

## Testing
- `npm --workspace storefronts test -- tests/sdk/password-reset.test.js tests/sdk/dom-mutation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68afe421c3f08325a1d071c33307e674