### PR TITLE
feat(auth): support div auth containers and Enter key

### DIFF
--- a/storefronts/tests/features/auth.test.js
+++ b/storefronts/tests/features/auth.test.js
@@ -73,8 +73,8 @@ describe('auth feature init', () => {
     const { init } = await import('../../features/auth/init.js');
     await init({ storeId: '1', supabase: client });
     const clickCalls = document.addEventListener.mock.calls.filter(c => c[0] === 'click');
-    expect(clickCalls.length).toBe(1);
-    expect(clickCalls[0][2]).toBe(true);
+    expect(clickCalls.length).toBe(2);
+    clickCalls.forEach(c => expect(c[2]).toBe(true));
   });
 });
 

--- a/storefronts/tests/sdk/dom-mutation.test.js
+++ b/storefronts/tests/sdk/dom-mutation.test.js
@@ -83,7 +83,7 @@ describe("dynamic DOM bindings", () => {
         if (selector.includes(ACCOUNT_ACCESS_SELECTOR)) {
           return elements.filter((el) => el.dataset?.smoothr === "account-access");
         }
-        if (selector.includes('form[data-smoothr="auth-form"]')) {
+        if (selector.includes('form[data-smoothr="auth-form"]') || selector.includes('[data-smoothr="auth-form"]')) {
           return forms;
         }
         if (selector.includes('[data-smoothr="sign-out"]')) {
@@ -138,7 +138,7 @@ describe("dynamic DOM bindings", () => {
     };
     btn.closest = vi.fn((sel) => {
       if (sel === '[data-smoothr]') return btn;
-      if (sel === 'form[data-smoothr="auth-form"]') return form;
+      if (sel === 'form[data-smoothr="auth-form"]' || sel === '[data-smoothr="auth-form"]') return form;
       return null;
     });
 
@@ -190,7 +190,7 @@ describe("dynamic DOM bindings", () => {
     };
     btn.closest = vi.fn((sel) => {
       if (sel === '[data-smoothr]') return btn;
-      if (sel === 'form[data-smoothr="auth-form"]') return form;
+      if (sel === 'form[data-smoothr="auth-form"]' || sel === '[data-smoothr="auth-form"]') return form;
       return null;
     });
 
@@ -376,7 +376,7 @@ describe("dynamic DOM bindings", () => {
     };
     btn.closest = vi.fn((sel) => {
       if (sel === '[data-smoothr]') return btn;
-      if (sel === 'form[data-smoothr="auth-form"]') return form;
+      if (sel === 'form[data-smoothr="auth-form"]' || sel === '[data-smoothr="auth-form"]') return form;
       return null;
     });
 

--- a/storefronts/tests/sdk/login.test.js
+++ b/storefronts/tests/sdk/login.test.js
@@ -64,6 +64,33 @@ it('submits login via Enter when form also contains a password-reset link', asyn
   expect(signInMock).toHaveBeenCalledTimes(1);
   expect(resetPasswordMock).not.toHaveBeenCalled();
 });
+
+it('submits login via Enter when auth-form is a DIV with a reset link present', async () => {
+  vi.resetModules();
+  createClientMockUtil();
+  const auth = await import("../../features/auth/index.js");
+  await auth.init();
+  await flushPromises();
+
+  const div = document.createElement('div');
+  div.setAttribute('data-smoothr', 'auth-form');
+  div.innerHTML = `
+    <input data-smoothr="email" value="user@example.com" />
+    <input data-smoothr="password" value="hunter2" />
+    <div data-smoothr="login"></div>
+    <div data-smoothr="password-reset"></div>
+  `;
+  document.body.appendChild(div);
+
+  const { signInMock } = currentSupabaseMocks();
+  signInMock.mockResolvedValue({ data: { user: { id: 'u1' } }, error: null });
+
+  const evt = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
+  div.dispatchEvent(evt);
+  await flushPromises();
+
+  expect(signInMock).toHaveBeenCalledTimes(1);
+});
 describe("login form", () => {
   let clickHandler;
   let emailValue;

--- a/storefronts/tests/sdk/signup.test.js
+++ b/storefronts/tests/sdk/signup.test.js
@@ -41,6 +41,34 @@ function flushPromises() {
   return new Promise(setImmediate);
 }
 
+it('routes dynamic sign-up DIV click via capture fallback when auth-form is DIV', async () => {
+  vi.resetModules();
+  setupSupabaseMock();
+  const auth = await import("../../features/auth/index.js");
+  await auth.init({ supabase: createClientMock() });
+  await flushPromises();
+
+  const div = document.createElement('div');
+  div.setAttribute('data-smoothr', 'auth-form');
+  div.innerHTML = `
+    <input data-smoothr="email" value="new@example.com" />
+    <input data-smoothr="password" value="LongerPass9" />
+    <input data-smoothr="password-confirm" value="LongerPass9" />
+  `;
+  document.body.appendChild(div);
+  const signup = document.createElement('div');
+  signup.setAttribute('data-smoothr', 'sign-up');
+  div.appendChild(signup);
+
+  const supa = await auth.resolveSupabase?.();
+  const signUpSpy = vi.spyOn(supa.auth, 'signUp').mockResolvedValue({ data: { user: { id: 'u2' } }, error: null });
+
+  signup.click();
+  await flushPromises();
+
+  expect(signUpSpy).toHaveBeenCalledTimes(1);
+});
+
 describe("signup flow", () => {
   let clickHandler;
   let emailValue;


### PR DESCRIPTION
## Summary
- expand auth container resolver to handle `<form>` or `<div>` wrappers
- add document-level Enter key and click fallbacks for auth actions
- cover div-based login and dynamic sign-up in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aff9ae518483258ae0b0372f6cebec