### PR TITLE
fix: avoid double auth click handling

### DIFF
--- a/storefronts/features/auth/index.js
+++ b/storefronts/features/auth/index.js
@@ -14,4 +14,5 @@ export {
   docClickHandler,
   onAuthStateChangeHandler,
   mutationCallback,
+  bindAuthElements,
 } from './init.js';


### PR DESCRIPTION
## Summary
- mark bound auth elements to prevent capture fallback from double-invoking handlers
- add event-level guard to doc capture fallback
- test that sign-up and password-reset clicks only trigger one Supabase call

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b009a99a048325b997acbcc536c3ec