### PR TITLE
auth: unify container resolution and keyboard binding

### DIFF
--- a/storefronts/features/auth/constants.js
+++ b/storefronts/features/auth/constants.js
@@ -1,0 +1,5 @@
+export const AUTH_CONTAINER_SELECTOR = '[data-smoothr="auth-form"]';
+export const ATTR_EMAIL = '[data-smoothr="email"]';
+export const ATTR_PASSWORD = '[data-smoothr="password"]';
+export const ATTR_PASSWORD_CONFIRM = '[data-smoothr="password-confirm"]';
+export const ATTR_SIGNUP = '[data-smoothr="sign-up"]';

--- a/storefronts/features/auth/index.js
+++ b/storefronts/features/auth/index.js
@@ -2,6 +2,7 @@
 export {
   default,
   init,
+  resolveAuthContainer,
   setSupabaseClient,
   resolveSupabase,
   lookupRedirectUrl,
@@ -16,3 +17,5 @@ export {
   mutationCallback,
   bindAuthElements,
 } from './init.js';
+
+export { AUTH_CONTAINER_SELECTOR } from './constants.js';


### PR DESCRIPTION
## Summary
- centralize auth DOM selectors
- ensure signup resolves container for both FORM and DIV wrappers
- handle Space/Enter key activation with priority for sign-up

## Testing
- `npm --workspace storefronts test tests/sdk/signup.test.js`
- `npm --workspace storefronts test tests/sdk/password-reset.test.js`
- `npm --workspace storefronts test tests/sdk/dom-mutation.test.js`
- `npm --workspace storefronts test tests/sdk/account-access.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b00fd8f2788325914d368837217fa6