### PR TITLE
test(dist): add vitest.dist.config; make build helper fail fast; tighten integrity checks

### DIFF
--- a/scripts/assert-auth-dist-integrity.mjs
+++ b/scripts/assert-auth-dist-integrity.mjs
@@ -4,19 +4,26 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const distPath = path.resolve(__dirname, '../storefronts/dist/smoothr-sdk.js');
+
+if (!fs.existsSync(distPath)) {
+  throw new Error(`assert-auth-dist-integrity: missing bundle at ${distPath}`);
+}
+
 const content = fs.readFileSync(distPath, 'utf8');
 
 const checks = [
   { ok: content.includes('[data-smoothr="auth-form"]'), msg: 'missing [data-smoothr="auth-form"]' },
   { ok: content.includes('keydown'), msg: 'missing keydown handler' },
   { ok: content.includes('sign-up'), msg: 'missing sign-up handler' },
-  { ok: !content.includes('form[data-smoothr="auth-form"]'), msg: 'contains deprecated form[data-smoothr="auth-form"] selector' },
+  {
+    ok: !content.includes('form[data-smoothr="auth-form"]'),
+    msg: 'contains deprecated form[data-smoothr="auth-form"] selector',
+  },
 ];
 
 for (const c of checks) {
   if (!c.ok) {
-    console.error(`assert-auth-dist-integrity: ${c.msg}`);
-    process.exit(1);
+    throw new Error(`assert-auth-dist-integrity: ${c.msg}`);
   }
 }
 

--- a/storefronts/tests/sdk/setup-dist.ts
+++ b/storefronts/tests/sdk/setup-dist.ts
@@ -1,0 +1,5 @@
+// JSDOM polyfills if needed
+Object.defineProperty(window, 'crypto', {
+  value: { getRandomValues: (arr: any) => crypto.getRandomValues(arr) },
+  configurable: true,
+});

--- a/storefronts/tests/sdk/signup-dist.test.js
+++ b/storefronts/tests/sdk/signup-dist.test.js
@@ -9,13 +9,17 @@ const repoRoot = path.resolve(
 );
 
 const buildStorefronts = () =>
-  new Promise((resolve) => {
+  new Promise((resolve, reject) => {
     const proc = spawn("pnpm", ["-C", "storefronts", "build:storefronts"], {
       stdio: "inherit",
       cwd: repoRoot,
     });
-    proc.on("close", () => resolve());
-    proc.on("error", () => resolve());
+    proc.on("exit", (code) =>
+      code === 0
+        ? resolve()
+        : reject(new Error(`storefronts build failed: ${code}`)),
+    );
+    proc.on("error", reject);
   });
 
 beforeAll(async () => {

--- a/storefronts/vitest.dist.config.ts
+++ b/storefronts/vitest.dist.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['tests/sdk/signup-dist.test.js'],
+    setupFiles: ['tests/sdk/setup-dist.ts'],
+    isolate: true,
+    testTimeout: 30000,
+  },
+});


### PR DESCRIPTION
## Summary
- add distribution-specific Vitest config and setup file for storefronts SDK
- make signup distribution build helper reject on build failure
- harden auth distribution integrity script

## Testing
- `npm --workspace storefronts run test:dist-auth` *(fails: expected "spy" to be called 1 times, but got 0 times)*
- `node scripts/assert-auth-dist-integrity.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b02016ab08832585d1af630072c5c4