### PR TITLE
ci: strengthen auth dist integrity (ban legacy selectors; require keyboard routing)

### DIFF
--- a/scripts/assert-auth-dist-integrity.mjs
+++ b/scripts/assert-auth-dist-integrity.mjs
@@ -12,12 +12,27 @@ if (!fs.existsSync(distPath)) {
 const content = fs.readFileSync(distPath, 'utf8');
 
 const checks = [
-  { ok: content.includes('[data-smoothr="auth-form"]'), msg: 'missing [data-smoothr="auth-form"]' },
+  {
+    ok: content.includes('[data-smoothr="auth-form"]'),
+    msg: 'missing [data-smoothr="auth-form"] marker',
+  },
+  {
+    ok: content.includes('[data-smoothr="sign-up"]'),
+    msg: 'missing [data-smoothr="sign-up"] marker',
+  },
   { ok: content.includes('keydown'), msg: 'missing keydown handler' },
-  { ok: content.includes('sign-up'), msg: 'missing sign-up handler' },
+  { ok: content.includes('Enter'), msg: 'missing Enter key handler' },
   {
     ok: !content.includes('form[data-smoothr="auth-form"]'),
     msg: 'contains deprecated form[data-smoothr="auth-form"] selector',
+  },
+  {
+    ok: !content.includes("querySelectorAll('form[data-smoothr=\"auth-form\"]')"),
+    msg: 'contains deprecated querySelectorAll(\'form[data-smoothr="auth-form"]\') call',
+  },
+  {
+    ok: !content.includes('querySelectorAll("form[data-smoothr=\'auth-form\']")'),
+    msg: 'contains deprecated querySelectorAll("form[data-smoothr=\'auth-form\']") call',
   },
 ];
 


### PR DESCRIPTION
## Summary
- tighten auth dist integrity check to require data-smoothr markers and keyboard routing
- flag legacy form selectors and querySelectorAll usage

## Testing
- `npm test`
- `node scripts/assert-auth-dist-integrity.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b1a22be63083259d8df111b6453dd7