### PR TITLE
Remove hard-coded Supabase defaults and lock session-sync CORS

### DIFF
--- a/smoothr/lib/cors.ts
+++ b/smoothr/lib/cors.ts
@@ -1,0 +1,38 @@
+import { supabaseAdmin } from './supabaseAdmin';
+
+const wildcardDomains = ['webflow.io', 'framer.website', 'webstudio.is'];
+
+export async function getAllowOrigin(
+  origin?: string,
+  storeId?: string
+): Promise<string | null> {
+  if (!origin) return null;
+
+  try {
+    const { hostname } = new URL(origin);
+    const envList = (process.env.SESSION_SYNC_ALLOWED_ORIGINS || '')
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean);
+
+    const allowList = [...envList];
+    if (storeId) {
+      const { data } = await supabaseAdmin
+        .from('stores')
+        .select('store_domain, live_domain')
+        .eq('id', storeId)
+        .maybeSingle();
+      if (data?.store_domain) allowList.push(data.store_domain);
+      if (data?.live_domain) allowList.push(data.live_domain);
+    }
+
+    const isAllowed =
+      allowList.includes(hostname) ||
+      wildcardDomains.some(domain => hostname.endsWith(`.${domain}`));
+
+    return isAllowed ? origin : null;
+  } catch {
+    return null;
+  }
+}
+

--- a/storefronts/vite.config.js
+++ b/storefronts/vite.config.js
@@ -17,11 +17,10 @@ export default defineConfig(({ mode }) => {
     define: {
       // Map Cloudflare’s VITE_* secrets into process.env
       'process.env.VITE_SUPABASE_URL': JSON.stringify(
-        process.env.VITE_SUPABASE_URL ||
-          'https://lpuqrzvokroazwlricgn.supabase.co'
+        process.env.VITE_SUPABASE_URL
       ),
       'process.env.VITE_SUPABASE_ANON_KEY': JSON.stringify(
-        process.env.VITE_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImxwdXFyenZva3JvYXp3bHJpY2duIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk3MTM2MzQsImV4cCI6MjA2NTI4OTYzNH0.bIItSJMzdx9BgXm5jOtTFI03yq94CLVHepiPQ0Xl_lU'
+        process.env.VITE_SUPABASE_ANON_KEY
       ),
       __NEXT_PUBLIC_SUPABASE_OAUTH_REDIRECT_URL__: JSON.stringify(
         env.NEXT_PUBLIC_SUPABASE_OAUTH_REDIRECT_URL


### PR DESCRIPTION
## Summary
- remove hard-coded Supabase credentials from Vite config
- restrict session-sync CORS to an allowlist with new helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1a50bba608325b9c3bd038fd64690