### PR TITLE
auth(reset): send Supabase reset emails to /reset-password on client domain (includes store_id)

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -519,9 +519,13 @@ export async function init(options = {}) {
         const successEl = container?.querySelector('[data-smoothr-success]');
         const errorEl = container?.querySelector('[data-smoothr-error]');
         try {
-          const cb = new URL('/api/callback', getBrokerBaseUrl());
-          if (w?.SMOOTHR_CONFIG?.storeId) cb.searchParams.set('store_id', w.SMOOTHR_CONFIG.storeId);
-          const { error: resetErr } = await c.auth.resetPasswordForEmail(email, { redirectTo: cb.toString() });
+          const cfg = (typeof getConfig === 'function' ? getConfig() : (w.SMOOTHR_CONFIG || {}));
+          const storeId = cfg.storeId || w.document?.getElementById('smoothr-sdk')?.dataset?.storeId || '';
+          const base = w.location?.origin || '';
+          const qs = new URLSearchParams(w.location?.search || '');
+          if (storeId && !qs.has('store_id')) qs.set('store_id', storeId);
+          const redirectTo = `${base}/reset-password${qs.toString() ? `?${qs}` : ''}`;
+          const { error: resetErr } = await c.auth.resetPasswordForEmail(email, { redirectTo });
           if (resetErr) throw resetErr;
           w.Smoothr.auth.user.value = null;
           if (successEl) {


### PR DESCRIPTION
## Summary
- point password reset email redirects to `/reset-password` on the current site
- include `store_id` in redirect when available
- test password-reset redirect construction

## Testing
- `npm --workspace storefronts test`
- `npm --workspace storefronts run test:dist-auth`


------
https://chatgpt.com/codex/tasks/task_e_68b1f4317ba88325ab51f33848cc2aa3