### PR TITLE
feat: client-side recovery redirect bridge

### DIFF
--- a/smoothr/pages/auth/recovery-bridge.tsx
+++ b/smoothr/pages/auth/recovery-bridge.tsx
@@ -114,7 +114,7 @@ export default function RecoveryBridgePage(props: Props) {
           <p>Forwarding you to the reset page…</p>
           {props.redirect && (
             <p>
-              If you’re not redirected, <a href={props.redirect}>click here</a>
+              If you’re not redirected automatically, <a href={props.redirect}>click here</a>.
               {/* The anchor cannot include the hash (not available server-side), but the effect above handles it. */}
             </p>
           )}


### PR DESCRIPTION
## Summary
- resolve recovery destination on the server and pass as redirect prop
- preserve window hash and recovery token with client-side redirect
- show progress message and fallback link when redirecting

## Testing
- `npm test`
- `npm run build --workspace smoothr` *(fails: Missing env: NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY, or SUPABASE_SERVICE_ROLE_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b4adfd901483259fabe26abe34e45e