### PR TITLE
Fix smoothr build: inject envs in CI & lazy Supabase admin

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -28,6 +28,15 @@ jobs:
         with:
           node-version: 20
 
+      - name: Create smoothr/.env.local
+        run: |
+          mkdir -p smoothr
+          cat > smoothr/.env.local << 'EOF'
+          NEXT_PUBLIC_SUPABASE_URL=${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY=${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          EOF
+
       - name: Install dependencies
         working-directory: storefronts
         run: npm ci --ignore-scripts --loglevel verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,15 @@ jobs:
         with:
           node-version: 20
 
+      - name: Create smoothr/.env.local
+        run: |
+          mkdir -p smoothr
+          cat > smoothr/.env.local << 'EOF'
+          NEXT_PUBLIC_SUPABASE_URL=${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY=${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          EOF
+
       - name: Install root deps
         run: npm ci
 

--- a/smoothr/lib/cors.ts
+++ b/smoothr/lib/cors.ts
@@ -1,4 +1,4 @@
-import { supabaseAdmin } from './supabaseAdmin';
+import { getSupabaseAdmin } from './supabaseAdmin';
 
 const wildcardDomains = ['webflow.io', 'framer.website', 'webstudio.is'];
 
@@ -17,6 +17,7 @@ export async function getAllowOrigin(
 
     const allowList = [...envList];
     if (storeId) {
+      const supabaseAdmin = getSupabaseAdmin();
       const { data } = await supabaseAdmin
         .from('stores')
         .select('store_domain, live_domain')

--- a/smoothr/lib/supabaseAdmin.ts
+++ b/smoothr/lib/supabaseAdmin.ts
@@ -1,15 +1,19 @@
 import { createClient } from '@supabase/supabase-js';
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-const service = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-
-if (!url || !anon || !service) {
-  throw new Error('Missing env: NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY, or SUPABASE_SERVICE_ROLE_KEY');
+function req(name: string) {
+  const v = process.env[name];
+  if (!v) throw new Error(`Missing env: ${name}`);
+  return v;
 }
 
-// For verifying bearer access tokens server-side without exposing service role
-export const supabaseAnonServer = createClient(url, anon);
+export function getSupabaseAnonServer() {
+  const url = req('NEXT_PUBLIC_SUPABASE_URL');
+  const anon = req('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+  return createClient(url, anon);
+}
 
-// Service-role client — server-only DB ops
-export const supabaseAdmin = createClient(url, service);
+export function getSupabaseAdmin() {
+  const url = req('NEXT_PUBLIC_SUPABASE_URL');
+  const service = req('SUPABASE_SERVICE_ROLE_KEY');
+  return createClient(url, service);
+}

--- a/smoothr/pages/api/auth/session-sync.ts
+++ b/smoothr/pages/api/auth/session-sync.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { supabaseAdmin, supabaseAnonServer } from '../../../lib/supabaseAdmin';
+import { getSupabaseAdmin, getSupabaseAnonServer } from '../../../lib/supabaseAdmin';
 import { getAllowOrigin } from '../../../lib/cors';
 
 type Ok = {
@@ -20,6 +20,8 @@ export default async function handler(
       req.method === 'POST' &&
       contentType.startsWith('application/x-www-form-urlencoded');
 
+    const supabaseAdmin = getSupabaseAdmin();
+    const supabaseAnonServer = getSupabaseAnonServer();
     async function fetchRedirects(store_id: string) {
       let sign_in_redirect_url: string | null = null;
       let sign_out_redirect_url: string | null = null;

--- a/smoothr/pages/auth/recovery-bridge.tsx
+++ b/smoothr/pages/auth/recovery-bridge.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Head from 'next/head';
 import type { GetServerSideProps } from 'next';
-import { supabaseAdmin } from '../../lib/supabaseAdmin';
+import { getSupabaseAdmin } from '../../lib/supabaseAdmin';
 import { resolveRecoveryDestination } from '../../../shared/auth/resolveRecoveryDestination';
 
 interface Props {
@@ -15,6 +15,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async ({ query }) =
     return { props: { redirect: null, error: 'Missing store_id' } };
   }
   try {
+    const supabaseAdmin = getSupabaseAdmin();
     // 1) Fetch domains from stores
     const { data: storeRow } = await supabaseAdmin
       .from('stores')


### PR DESCRIPTION
## Summary
- inject Supabase envs into smoothr/.env.local during CI and build workflows
- use lazy `getSupabaseAdmin`/`getSupabaseAnonServer` helpers to avoid build-time env errors
- update callers to use new helpers

## Testing
- `NEXT_PUBLIC_SUPABASE_URL=http://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=anon SUPABASE_SERVICE_ROLE_KEY=service npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4b07cb6d88325bddd9848dac6cf2d