### PR TITLE
auth: strip stale recovery hash on non-reset pages (no auto-redirect)

### DIFF
--- a/storefronts/README.md
+++ b/storefronts/README.md
@@ -59,6 +59,9 @@ html.smoothr-reset-loading body { visibility: hidden; }
 
 The class is removed once the URL is cleaned (no trailing hash) and the session is set.
 
+**Stale reset code on other pages**  
+If a recovery code (`#access_token=…`) appears on any page that isn’t your reset page, the SDK now **removes it silently** so your site works normally (auth popup opens, links work). The code is only used on `/reset-password`, where it’s consumed and then cleared.
+
 #### Password reset (success)
 On successful password change, the SDK performs a **top-level form POST** to `/api/auth/session-sync` so the broker issues a **303** to the store’s **Sign-in Success Redirect URL**, or `/` if not configured. This guarantees landing on the client homepage.  
 If passwords don’t match, the SDK shows an inline error **and throws** (`Error('password_mismatch')`) for programmatic flows.

--- a/storefronts/core/hash.js
+++ b/storefronts/core/hash.js
@@ -1,0 +1,28 @@
+export function hasRecoveryHash() {
+  const h = (location.hash || '').slice(1);
+  return /(^|&)(access_token|refresh_token)=/.test(h);
+}
+
+export function stripHash() {
+  try { history.replaceState?.(null, '', location.pathname + location.search); } catch {}
+}
+
+export function resetPath() {
+  return (
+    (window.SMOOTHR_CONFIG &&
+      window.SMOOTHR_CONFIG.routes &&
+      window.SMOOTHR_CONFIG.routes.resetPassword) ||
+    '/reset-password'
+  );
+}
+
+export function isOnResetRoute() {
+  return location.pathname === resetPath();
+}
+
+// New: ensure normal pages never carry recovery tokens
+export function stripRecoveryHashIfNotOnReset() {
+  if (hasRecoveryHash() && !isOnResetRoute()) {
+    stripHash();
+  }
+}

--- a/storefronts/tests/features/auth.test.js
+++ b/storefronts/tests/features/auth.test.js
@@ -74,8 +74,8 @@ describe('auth feature init', () => {
     const { init } = mod;
     await init({ storeId: '1', supabase: client });
     const clickCalls = document.addEventListener.mock.calls.filter(c => c[0] === 'click');
-    expect(clickCalls.length).toBe(2);
-    const captureCall = clickCalls.find(([, handler, opts]) => opts?.capture === true);
+    expect(clickCalls.length).toBe(3);
+    const captureCall = clickCalls.find(([, handler, opts]) => opts?.capture === true && handler === mod.docClickHandler);
     expect(captureCall?.[1]).toBe(mod.docClickHandler);
     expect(captureCall?.[2]).toMatchObject({ capture: true, passive: false });
     const bubbleCall = clickCalls.find(([, , opts]) => opts === false);


### PR DESCRIPTION
## Summary
- add hash utilities to drop recovery tokens outside reset route
- wire account-access triggers early and limit reset loading to reset page
- test coverage and docs for new hash behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4bdf362fc83258f570a09befad8dd