### PR TITLE
feat(auth): brand reset emails per-store (logo from store_branding with safe fallback)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ AUTHNET_CLIENT_KEY=
 SUPABASE_URL=
 SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
+
+# Optional default logo when a store has no branding row
+DEFAULT_LOGO_URL=


### PR DESCRIPTION
## Summary
- use store_branding table to fetch logo for password reset email and fallback to DEFAULT_LOGO_URL
- allow optional default logo in .env example

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4cf1dc4c883259a8f4ed21ccf1530