### PR TITLE
fix(auth): reset via broker base (config-url) + CORS (OPTIONS + ACAO:*) + omit credentials

### DIFF
--- a/smoothr/pages/api/auth/send-reset.ts
+++ b/smoothr/pages/api/auth/send-reset.ts
@@ -45,6 +45,18 @@ async function getStoreBranding(supabaseAdmin: any, store_id: string) {
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<Ok | Err>) {
+  // CORS: allow cross-origin, no credentials needed (OPTIONS handled)
+  function setCors(res: any) {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'content-type');
+    res.setHeader('Access-Control-Max-Age', '86400');
+  }
+  if (req.method === 'OPTIONS') {
+    setCors(res);
+    return res.status(204).end();
+  }
+  setCors(res);
   try {
     if (req.method !== 'POST') return res.status(405).json({ ok: false, error: 'Method Not Allowed' });
     const { email, store_id, redirectTo: _redirectTo } = (typeof req.body === 'string' ? JSON.parse(req.body) : req.body) || {};

--- a/storefronts/README.md
+++ b/storefronts/README.md
@@ -10,11 +10,21 @@ The bundled SDK is designed for zero‑config installation on platforms like
 Webflow. Simply include
 
 ```html
-<script type="module" src="https://sdk.smoothr.io/smoothr-sdk.js"></script>
+<script
+  id="smoothr-sdk"
+  type="module"
+  src="https://sdk.smoothr.io/smoothr-sdk.js"
+  data-store-id="…"
+  platform="webflow"
+  data-config-url="https://YOUR-BROKER-DOMAIN/api/config"
+></script>
 ```
 
 and authentication will initialize automatically. The SDK is available as
 `window.Smoothr` or the lowercase `window.smoothr`.
+
+Password reset requests post to the broker derived from `getBrokerBaseUrl()`,
+which uses the loader tag's `data-config-url` attribute.
 
 Create a `.env` file in this directory and provide your Supabase project details.
 These variables are injected at build time so the final SDK has no

--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -372,7 +372,7 @@ export const resolveSupabase = async () => {
 export async function requestPasswordResetForEmail(email) {
   const redirectTo = getPasswordResetRedirectUrl();
   const script = document.getElementById('smoothr-sdk');
-  const brokerBase = script?.src ? new URL(script.src).origin : window.location.origin; // fallback
+  const brokerBase = getBrokerBaseUrl();
   const body = JSON.stringify({
     email,
     store_id:
@@ -386,7 +386,7 @@ export async function requestPasswordResetForEmail(email) {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body,
-    credentials: 'include',
+    credentials: 'omit',
   });
   if (!resp.ok) {
     try {


### PR DESCRIPTION
## Summary
- route password reset requests through broker-derived origin and omit credentials
- handle CORS preflight for password reset endpoint
- document data-config-url on loader tag and update tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4d4f61b008325a94d468d87bfd133