### PR TITLE
feat(auth): brand-forward reset emails (storeName in subject + From display name)

### DIFF
--- a/smoothr/lib/email/templates/reset.ts
+++ b/smoothr/lib/email/templates/reset.ts
@@ -3,20 +3,19 @@ export function renderResetEmail(opts: {
   logoUrl?: string | null;
   actionLink: string;
 }) {
-  const title = `Reset your password for ${opts.storeName}`;
-  const html = `<!doctype html>
-<html><body style="font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;margin:0;padding:24px;background:#f6f7f9;color:#111;">
-  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:560px;margin:0 auto;background:#fff;border-radius:12px;box-shadow:0 1px 4px rgba(0,0,0,0.06);overflow:hidden;">
-    <tr><td style="padding:24px 24px 0;">
-      ${opts.logoUrl ? `<div style="margin-bottom:12px;"><img src="${opts.logoUrl}" alt="${opts.storeName}" style="height:32px;"/></div>` : ''}
-      <h1 style="font-size:20px;margin:0 0 12px;">${title}</h1>
-      <p style="font-size:14px;line-height:1.5;margin:0 0 20px;">Click the button below to choose a new password.</p>
-      <p style="margin:0 0 28px;"><a href="${opts.actionLink}" style="display:inline-block;background:#111;color:#fff;text-decoration:none;padding:10px 16px;border-radius:10px;">Reset password</a></p>
-      <p style="font-size:12px;color:#555;margin:0 0 8px;">If you didn’t request this, you can ignore this email.</p>
-    </td></tr>
-  </table>
-  <p style="text-align:center;font-size:12px;color:#888;margin-top:12px;">© ${new Date().getFullYear()} ${opts.storeName}</p>
-</body></html>`;
-  const text = `Reset your password for ${opts.storeName}\n${opts.actionLink}\n\nIf you didn’t request this, ignore this email.`;
-  return { subject: title, html, text };
+  const { storeName, logoUrl, actionLink } = opts;
+  const logoBlock = logoUrl
+    ? `<img src="${logoUrl}" alt="${storeName}" style="max-width:160px; margin:0 auto 16px; display:block;" />`
+    : `<div style="font-weight:600; font-size:18px; text-align:center; margin:0 0 16px;">${storeName}</div>`;
+  const subject = `${storeName} • Reset your password`;
+  const html = `
+    <div style="font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif; padding:24px;">
+      ${logoBlock}
+      <h1 style="font-size:18px; margin:0 0 12px;">Reset your password</h1>
+      <p style="margin:0 0 16px;">Tap the button below to set a new password for ${storeName}.</p>
+      <p style="margin:24px 0;"><a href="${actionLink}" style="padding:12px 16px; border-radius:8px; text-decoration:none; display:inline-block; border:1px solid #ddd;">Set new password</a></p>
+      <p style="font-size:12px; color:#666;">If the button doesn’t work, copy and paste this link:<br>${actionLink}</p>
+    </div>`;
+  const text = `Reset your ${storeName} password:\n${actionLink}`;
+  return { subject, html, text };
 }

--- a/smoothr/pages/api/auth/send-reset.ts
+++ b/smoothr/pages/api/auth/send-reset.ts
@@ -108,12 +108,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
     const { subject, html, text } = renderResetEmail({ storeName, logoUrl, actionLink });
 
+    const rawFrom = process.env.EMAIL_FROM || '';
+    const addressMatch = rawFrom.match(/<([^>]+)>/);
+    const fromAddress = addressMatch ? addressMatch[1] : rawFrom; // fallback if no angle brackets
+    const fromDisplay = `${storeName} via Smoothr`;
+    const fromHeader = fromAddress ? `${fromDisplay} <${fromAddress}>` : rawFrom;
+
     const send = await sendEmail({
       to: email,
       subject,
       html,
       text,
-      from: process.env.EMAIL_FROM || null,
+      from: fromHeader,
     });
     if (!send.ok) {
       const errMsg = 'error' in send && send.error ? send.error : 'send_failed';


### PR DESCRIPTION
## Summary
- brand reset email template with storeName in subject and fallback logo block
- set branded From header in password reset handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4dcb0b2e483259783291bd0806912