### PR TITLE
feat(auth): brandable reset page (logo + theme variables per store, optional custom CSS)

### DIFF
--- a/smoothr/README.md
+++ b/smoothr/README.md
@@ -7,3 +7,19 @@ Next.js admin dashboard application.
 This workspace currently has no automated tests. If you add any in the future,
 ensure `vitest` is listed in `devDependencies` and run `npm install` in this
 directory before executing `npm test` from the repository root.
+
+## Store branding
+
+The auth pages support per-store theming via the `store_branding` table. The
+following fields are used, falling back to sensible defaults if absent:
+
+- `logo_url` – logo image URL *(default: none)*
+- `primary_color` – primary brand color *(default: `#0E7AFE`)*
+- `bg_color` – page background *(default: `#FFFFFF`)*
+- `text_color` – main text color *(default: `#111111`)*
+- `muted_color` – hint text color *(default: `#666666`)*
+- `btn_radius` – button border radius in pixels *(default: `8`)*
+- `font_family` – CSS font stack *(default: `Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif`)*
+- `custom_css_url` – optional stylesheet URL *(default: none)*
+
+Any missing values will use the defaults shown above.

--- a/smoothr/lib/branding.ts
+++ b/smoothr/lib/branding.ts
@@ -1,0 +1,75 @@
+import { createClient } from '@supabase/supabase-js';
+
+export type Theme = {
+  logoUrl?: string | null;
+  primary: string;
+  bg: string;
+  text: string;
+  muted: string;
+  btnRadius: number;
+  fontFamily: string;
+  customCssUrl?: string | null;
+};
+
+const DEFAULT_THEME: Theme = {
+  logoUrl: null,
+  primary: '#0E7AFE',
+  bg: '#FFFFFF',
+  text: '#111111',
+  muted: '#666666',
+  btnRadius: 8,
+  fontFamily: 'Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif',
+  customCssUrl: null,
+};
+
+export async function loadStoreTheme(storeId: string): Promise<Theme> {
+  try {
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    );
+
+    // Prefer dedicated branding table if present
+    const { data: b } = await supabase
+      .from('store_branding')
+      .select('logo_url, primary_color, bg_color, text_color, muted_color, btn_radius, font_family, custom_css_url')
+      .eq('store_id', storeId)
+      .is('deleted_at', null as any)
+      .maybeSingle();
+
+    if (b) {
+      return {
+        logoUrl: b.logo_url ?? null,
+        primary: b.primary_color || DEFAULT_THEME.primary,
+        bg: b.bg_color || DEFAULT_THEME.bg,
+        text: b.text_color || DEFAULT_THEME.text,
+        muted: b.muted_color || DEFAULT_THEME.muted,
+        btnRadius: typeof b.btn_radius === 'number' ? b.btn_radius : DEFAULT_THEME.btnRadius,
+        fontFamily: b.font_family || DEFAULT_THEME.fontFamily,
+        customCssUrl: b.custom_css_url || null,
+      };
+    }
+
+    // Optional fallback: a theme JSON in public_store_settings.theme (if you have it)
+    const { data: pss } = await supabase
+      .from('public_store_settings')
+      .select('theme, logo_url')
+      .eq('store_id', storeId)
+      .maybeSingle();
+
+    if (pss?.theme) {
+      const t = { ...DEFAULT_THEME, ...(pss.theme as Record<string, any>) };
+      return {
+        logoUrl: (pss.logo_url as string) ?? t.logoUrl,
+        primary: t.primary, bg: t.bg, text: t.text, muted: t.muted,
+        btnRadius: Number(t.btnRadius) || DEFAULT_THEME.btnRadius,
+        fontFamily: String(t.fontFamily || DEFAULT_THEME.fontFamily),
+        customCssUrl: t.customCssUrl ?? null,
+      };
+    }
+
+    return DEFAULT_THEME;
+  } catch {
+    return DEFAULT_THEME;
+  }
+}


### PR DESCRIPTION
## Summary
- load per-store branding theme with fallback defaults
- apply branding variables on password reset page, including custom CSS and logo
- document `store_branding` fields for theming

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b615935104832599e594e39524d190