### PR TITLE
feat(auth): auto-forward recovery links and redirect session-sync to store home

### DIFF
--- a/shared/auth/resolveRecoveryDestination.ts
+++ b/shared/auth/resolveRecoveryDestination.ts
@@ -1,7 +1,7 @@
 export type ResolveArgs = {
   liveDomain?: string | null;
   storeDomain?: string | null;
-  signInRedirectUrl?: string | null; // full URL allowed
+  signInRedirectUrl?: string | null; // full URL allowed (recovery callers pass null to ignore)
   orig?: string | null;              // optional caller-provided origin (dev-only)
   nodeEnv?: string | undefined;      // process.env.NODE_ENV passthrough
 };

--- a/smoothr/__tests__/session-sync.test.ts
+++ b/smoothr/__tests__/session-sync.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+
+async function run(domains: { live_domain: string | null; store_domain: string | null }) {
+  vi.resetModules();
+  const supabaseAdmin = {
+    from(table: string) {
+      if (table === 'customers')
+        return { upsert: vi.fn().mockResolvedValue({}) } as any;
+      if (table === 'stores')
+        return {
+          select() {
+            return {
+              eq() {
+                return {
+                  maybeSingle: async () => ({ data: domains }),
+                } as any;
+              },
+            } as any;
+          },
+        } as any;
+      return {} as any;
+    },
+  } as any;
+  const supabaseAnonServer = {
+    auth: {
+      getUser: vi
+        .fn()
+        .mockResolvedValue({ data: { user: { id: 'u1', email: 'u@example.com', user_metadata: {}, app_metadata: {} } }, error: null }),
+    },
+  } as any;
+  vi.doMock('../lib/supabaseAdmin.ts', () => ({
+    getSupabaseAdmin: () => supabaseAdmin,
+    getSupabaseAnonServer: () => supabaseAnonServer,
+  }));
+  const { default: handler } = await import('../pages/api/auth/session-sync.ts');
+  const req: any = {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: 'store_id=s1&access_token=token',
+  };
+  const res: any = {
+    headers: {} as Record<string, string>,
+    setHeader(k: string, v: string) {
+      this.headers[k] = v;
+    },
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(data: any) {
+      this.data = data;
+      return this;
+    },
+    end() {
+      this.ended = true;
+    },
+  };
+  await handler(req, res);
+  return res;
+}
+
+describe('session-sync form redirect', () => {
+  it('redirects to live domain origin', async () => {
+    const res = await run({ live_domain: 'https://shop.example', store_domain: 'https://store.example' });
+    expect(res.statusCode).toBe(303);
+    expect(res.headers.Location).toBe('https://shop.example');
+  });
+  it('falls back to store domain', async () => {
+    const res = await run({ live_domain: null, store_domain: 'https://store.example' });
+    expect(res.headers.Location).toBe('https://store.example');
+  });
+  it('defaults to / when no domains set', async () => {
+    const res = await run({ live_domain: null, store_domain: null });
+    expect(res.headers.Location).toBe('/');
+  });
+});


### PR DESCRIPTION
## Summary
- auto-forward recovery links based on store branding and show store name on bridge page
- redirect session-sync form posts to store home domain instead of sign-in redirect
- ignore sign-in redirect origin when resolving recovery destinations
- test coverage for recovery auto-forward flag and session-sync home redirects

## Testing
- `npm --workspace storefronts test tests/sdk/password-reset.test.js`
- `npx vitest run smoothr/__tests__/session-sync.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b61edc60108325bd26c623db3abf77