### PR TITLE
feat(auth): per-store Google popup with broker start URL + postMessage callback

### DIFF
--- a/smoothr/pages/api/auth/oauth-start.ts
+++ b/smoothr/pages/api/auth/oauth-start.ts
@@ -17,6 +17,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const provider = (req.query.provider as string) || 'google';
   const store_id = (req.query.store_id as string) || '';
   const orig = (req.query.orig as string) || '';
+  const mode = (req.query.mode as string) || '';
   if (provider !== 'google' || !store_id || !orig) {
     return res.status(400).json({ ok: false, error: 'Invalid request' });
   }
@@ -29,6 +30,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const authorize = `https://${supaUrl.host}/auth/v1/authorize?provider=google&redirect_to=${encodeURIComponent(
     brokerOrigin + '/auth/callback'
   )}`;
+  if (mode === 'url') {
+    res.setHeader('Access-Control-Allow-Origin', allow);
+    res.setHeader('Access-Control-Allow-Methods', 'GET');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+    res.setHeader('Vary', 'Origin');
+    return res.status(200).json({ ok: true, authorizeUrl: authorize });
+  }
   res.setHeader('Location', authorize);
   res.status(302).end();
 }

--- a/smoothr/pages/api/config.js
+++ b/smoothr/pages/api/config.js
@@ -48,7 +48,7 @@ export default async function handler(req, res) {
   const response = await supabase
     .from('v_public_store')
     .select(
-      'store_id,active_payment_gateway,publishable_key,base_currency,public_settings'
+      'store_id,active_payment_gateway,publishable_key,base_currency,public_settings,oauth_popup_enabled'
     )
     .eq('store_id', req.query.store_id)
     .maybeSingle();
@@ -75,7 +75,8 @@ export default async function handler(req, res) {
     active_payment_gateway: activePaymentGateway = null,
     publishable_key: publishableKey = null,
     base_currency: baseCurrency = null,
-    public_settings: publicSettings = {}
+    public_settings: publicSettings = {},
+    oauth_popup_enabled: oauthPopupEnabled = false
   } = data;
 
   const {
@@ -89,6 +90,7 @@ export default async function handler(req, res) {
     supabaseAnonKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
     baseCurrency,
     activePaymentGateway,
+    oauth_popup_enabled: !!oauthPopupEnabled,
     gateway: {
       stripe: { publishableKey },
       nmi: { tokenizationKey },

--- a/storefronts/README.md
+++ b/storefronts/README.md
@@ -53,6 +53,11 @@ deploys.
 Authentication will initialize automatically. The SDK is available as
 `window.Smoothr` or the lowercase `window.smoothr`.
 
+Google sign-in obeys `oauth_popup_enabled` (from `v_public_store` via
+`/api/config`). A popup is attempted on user click; if blocked or timed out the
+SDK falls back to the redirect flow. iOS Safari and iframe contexts always use
+redirect mode.
+
 Password reset requests always `POST` to the broker and use
 `credentials:'omit'`.
 

--- a/storefronts/features/config/sdkConfig.js
+++ b/storefronts/features/config/sdkConfig.js
@@ -11,7 +11,7 @@ export async function loadPublicConfig(storeId, supabase) {
     const { data, error } = await supabase
       .from('v_public_store')
       .select(
-        'store_id,active_payment_gateway,publishable_key,base_currency,public_settings,sign_in_redirect_url,sign_out_redirect_url'
+        'store_id,active_payment_gateway,publishable_key,base_currency,public_settings,sign_in_redirect_url,sign_out_redirect_url,oauth_popup_enabled'
       )
       .eq('store_id', storeId)
       .maybeSingle();
@@ -26,7 +26,8 @@ export async function loadPublicConfig(storeId, supabase) {
         public_settings: {},
         active_payment_gateway: null,
         sign_in_redirect_url: null,
-        sign_out_redirect_url: null
+        sign_out_redirect_url: null,
+        oauth_popup_enabled: false
       };
     }
 
@@ -35,7 +36,8 @@ export async function loadPublicConfig(storeId, supabase) {
       public_settings: data.public_settings || {},
       active_payment_gateway: data.active_payment_gateway ?? null,
       sign_in_redirect_url: data?.sign_in_redirect_url ?? null,
-      sign_out_redirect_url: data?.sign_out_redirect_url ?? null
+      sign_out_redirect_url: data?.sign_out_redirect_url ?? null,
+      oauth_popup_enabled: data?.oauth_popup_enabled ?? false
     };
 
     const cfg = getConfig();
@@ -54,7 +56,8 @@ export async function loadPublicConfig(storeId, supabase) {
       public_settings: {},
       active_payment_gateway: null,
       sign_in_redirect_url: null,
-      sign_out_redirect_url: null
+      sign_out_redirect_url: null,
+      oauth_popup_enabled: false
     };
   }
 }

--- a/storefronts/tests/sdk/oauth-google-popup.test.js
+++ b/storefronts/tests/sdk/oauth-google-popup.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let signInWithGoogle;
+let signInWithGooglePopup;
+
+const startUrl = 'https://smoothr.vercel.app/api/auth/oauth-start?provider=google&store_id=store_test&orig=https%3A%2F%2Fstore.example&mode=url';
+const redirectUrl = 'https://smoothr.vercel.app/api/auth/oauth-start?provider=google&store_id=store_test&orig=https%3A%2F%2Fstore.example';
+
+describe('signInWithGoogle popup', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    globalThis.ensureConfigLoaded = vi.fn().mockResolvedValue();
+    globalThis.getCachedBrokerBase = vi.fn().mockReturnValue('https://smoothr.vercel.app');
+    const popup = { location: '', close: vi.fn() };
+    const win = {
+      location: { origin: 'https://store.example', replace: vi.fn() },
+      document: { getElementById: vi.fn(() => ({ dataset: { storeId: 'store_test' } })) },
+      SMOOTHR_CONFIG: { store_id: 'store_test', oauth_popup_enabled: true },
+      open: vi.fn(() => popup),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+    win.top = win;
+    win.self = win;
+    global.window = win;
+    global.fetch = vi.fn(async (url, opts) => {
+      if (url === startUrl) {
+        return { json: async () => ({ authorizeUrl: 'https://supabase.co/auth/authorize' }) };
+      }
+      if (url === 'https://smoothr.vercel.app/api/auth/session-sync') {
+        return { json: async () => ({}), ok: true };
+      }
+      return { json: async () => ({}) };
+    });
+    ({ signInWithGoogle, signInWithGooglePopup } = await import('../../features/auth/init.js'));
+    // expose popup for tests
+    window.__popup = popup;
+  });
+
+  it('opens popup and syncs session on message', async () => {
+    const promise = signInWithGooglePopup();
+    const handler = window.addEventListener.mock.calls.find(c => c[0] === 'message')?.[1];
+    expect(typeof handler).toBe('function');
+    await handler({ origin: 'https://smoothr.vercel.app', data: { type: 'smoothr:oauth', ok: true, access_token: 'tok', store_id: 'store_test' } });
+    await promise;
+    expect(window.open).toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalledWith('https://smoothr.vercel.app/api/auth/session-sync', expect.any(Object));
+    expect(window.__popup.close).toHaveBeenCalled();
+  });
+
+  it('falls back to redirect when popup blocked', async () => {
+    window.open.mockReturnValueOnce(null);
+    await signInWithGoogle();
+    expect(window.location.replace).toHaveBeenCalledWith(redirectUrl);
+  });
+
+  it('falls back to redirect on timeout', async () => {
+    vi.useFakeTimers();
+    let handler;
+    window.addEventListener.mockImplementation((event, fn) => { if (event === 'message') handler = fn; });
+    const promise = signInWithGoogle();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(window.location.replace).toHaveBeenCalledWith(redirectUrl);
+    expect(window.__popup.close).toHaveBeenCalled();
+    vi.useRealTimers();
+    await promise;
+  });
+});

--- a/storefronts/tests/v_public_store.test.ts
+++ b/storefronts/tests/v_public_store.test.ts
@@ -39,7 +39,8 @@ describe('loadPublicConfig', () => {
       base_currency: 'GBP',
       public_settings: {},
       sign_in_redirect_url: '/sign-in',
-      sign_out_redirect_url: '/bye'
+      sign_out_redirect_url: '/bye',
+      oauth_popup_enabled: true
     };
     builder.maybeSingle.mockResolvedValue({ data: row, error: null });
 
@@ -47,7 +48,7 @@ describe('loadPublicConfig', () => {
 
     expect(config).toEqual(row);
     expect(builder.select).toHaveBeenCalledWith(
-      'store_id,active_payment_gateway,publishable_key,base_currency,public_settings,sign_in_redirect_url,sign_out_redirect_url'
+      'store_id,active_payment_gateway,publishable_key,base_currency,public_settings,sign_in_redirect_url,sign_out_redirect_url,oauth_popup_enabled'
     );
     expect(builder.eq).toHaveBeenCalledWith('store_id', storeId);
     expect(builder.maybeSingle).toHaveBeenCalledTimes(1);
@@ -60,6 +61,7 @@ describe('loadPublicConfig', () => {
       publishable_key: 'pk_live_123',
       base_currency: 'GBP',
       public_settings: {},
+      oauth_popup_enabled: null
     };
     builder.maybeSingle.mockResolvedValue({ data: row, error: null });
 
@@ -69,6 +71,7 @@ describe('loadPublicConfig', () => {
     expect(config.public_settings).toEqual({});
     expect(config.sign_in_redirect_url).toBeNull();
     expect(config.sign_out_redirect_url).toBeNull();
+    expect(config.oauth_popup_enabled).toBe(false);
   });
 
   it('returns fallback settings on query error', async () => {
@@ -84,7 +87,8 @@ describe('loadPublicConfig', () => {
       public_settings: {},
       active_payment_gateway: null,
       sign_in_redirect_url: null,
-      sign_out_redirect_url: null
+      sign_out_redirect_url: null,
+      oauth_popup_enabled: false
     });
   });
 });


### PR DESCRIPTION
## Summary
- expose `oauth_popup_enabled` in public config and broker API
- add popup-capable OAuth start endpoint and postMessage callback
- support per-store Google login popup with timeout and fallbacks
- document toggle and add popup tests

## Testing
- `npm --workspace storefronts test`
- `npx vitest run smoothr/__tests__/auth-oauth-start.test.ts`
- `npx vitest run smoothr/__tests__/auth-callback.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b770fd44048325a02c16a3105e9dab