### PR TITLE
feat: improve google oauth popup reliability

### DIFF
--- a/smoothr/pages/auth/callback.tsx
+++ b/smoothr/pages/auth/callback.tsx
@@ -1,25 +1,16 @@
-import React from 'react';
-import { createClient } from '@supabase/supabase-js';
+// Minimal OAuth callback handler with zero UI.
 
-export async function handleAuthCallback(w: any = window) {
+export function handleAuthCallback(w = window) {
   const hash = w.location?.hash || '';
   const params = new URLSearchParams(hash.startsWith('#') ? hash.slice(1) : hash);
-  const access_token = params.get('access_token');
-  const refresh_token = params.get('refresh_token');
-  if (!access_token || !refresh_token) return { ok: false };
-  const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  );
-  const {
-    data: { session }
-  } = await supabase.auth.setSession({ access_token, refresh_token });
-  w.history?.replaceState?.(null, '', w.location?.pathname + w.location?.search);
+  const access_token = params.get('access_token') || '';
+  try { w.history?.replaceState?.(null, '', w.location?.pathname + w.location?.search); } catch {}
+
   let store_id: string | null = null;
   let orig: string | null = null;
   try {
     const cookie = w.document?.cookie || '';
-    const match = cookie.split('; ').find((c: string) => c.startsWith('smoothr_oauth_ctx='));
+    const match = cookie.split('; ').find(c => c.startsWith('smoothr_oauth_ctx='));
     if (match) {
       const value = decodeURIComponent(match.split('=')[1] || '');
       const parsed = JSON.parse(value);
@@ -27,45 +18,51 @@ export async function handleAuthCallback(w: any = window) {
       orig = parsed.orig || null;
     }
   } catch {}
-  if (!store_id) {
-    store_id =
-      (session?.user as any)?.user_metadata?.store_id ||
-      new URLSearchParams(w.location.search).get('store_id') ||
-      w.SMOOTHR_CONFIG?.store_id ||
-      null;
-  }
-  if (!store_id || !session) return { ok: false };
+
   if (w.opener) {
-    try {
-      w.opener.postMessage(
-        { type: 'smoothr:oauth', ok: true, access_token, store_id },
-        orig || '*'
-      );
-    } catch {}
+    if (orig) {
+      const payload = access_token && store_id
+        ? { type: 'smoothr:oauth', ok: true, access_token, store_id }
+        : { type: 'smoothr:oauth', ok: false, reason: 'missing' };
+      try { w.opener.postMessage(payload, orig); } catch {}
+    }
     try { w.close(); } catch {}
+    return { ok: !!(access_token && store_id && orig) };
+  }
+
+  if (access_token && store_id) {
+    try { w.document?.documentElement && (w.document.documentElement.style.visibility = 'hidden'); } catch {}
+    const form = w.document.createElement('form');
+    form.method = 'POST';
+    form.action = '/api/auth/session-sync';
+    form.style.display = 'none';
+    const f1 = w.document.createElement('input');
+    f1.type = 'hidden';
+    f1.name = 'store_id';
+    f1.value = store_id;
+    form.appendChild(f1);
+    const f2 = w.document.createElement('input');
+    f2.type = 'hidden';
+    f2.name = 'access_token';
+    f2.value = access_token;
+    form.appendChild(f2);
+    w.document.body.appendChild(form);
+    try { form.submit(); } catch {}
     return { ok: true };
   }
-  const form = w.document.createElement('form');
-  form.method = 'POST';
-  form.action = '/api/auth/session-sync';
-  const f1 = w.document.createElement('input');
-  f1.type = 'hidden';
-  f1.name = 'store_id';
-  f1.value = store_id;
-  form.appendChild(f1);
-  const f2 = w.document.createElement('input');
-  f2.type = 'hidden';
-  f2.name = 'access_token';
-  f2.value = access_token;
-  form.appendChild(f2);
-  w.document.body.appendChild(form);
-  form.submit();
-  return { ok: true };
+
+  try { w.location?.replace?.('/'); } catch {}
+  return { ok: false };
 }
 
 export default function OAuthCallbackPage() {
-  React.useEffect(() => {
-    handleAuthCallback().catch(() => {});
-  }, []);
   return null;
 }
+
+if (typeof document !== 'undefined') {
+  try { document.documentElement.style.visibility = 'hidden'; } catch {}
+}
+if (typeof window !== 'undefined') {
+  try { handleAuthCallback(window); } catch {}
+}
+


### PR DESCRIPTION
## Summary
- center and guard Google OAuth popup, handle early close and strict postMessage
- streamline OAuth callback to zero-UI handoff with strict origin
- expand OAuth popup and callback tests

## Testing
- `npm --workspace storefronts test`
- `npx vitest run smoothr/__tests__/auth-callback.test.ts`
- `npx vitest run smoothr/__tests__/auth-oauth-start.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b7cbac499c8325a7d95b14176e8ded