### PR TITLE
feat(auth): robust Google popup and strict callback

### DIFF
--- a/smoothr/pages/auth/callback.tsx
+++ b/smoothr/pages/auth/callback.tsx
@@ -20,11 +20,13 @@ export function handleAuthCallback(w = window) {
   } catch {}
 
   if (w.opener) {
-    if (orig) {
-      const payload = access_token && store_id
-        ? { type: 'smoothr:oauth', ok: true, access_token, store_id }
-        : { type: 'smoothr:oauth', ok: false, reason: 'missing' };
-      try { w.opener.postMessage(payload, orig); } catch {}
+    if (access_token && store_id && orig) {
+      try {
+        w.opener.postMessage(
+          { type: 'smoothr:oauth', ok: true, access_token, store_id },
+          orig,
+        );
+      } catch {}
     }
     try { w.close(); } catch {}
     return { ok: !!(access_token && store_id && orig) };


### PR DESCRIPTION
## Summary
- allow popup messaging with centered window, fast fallbacks, and session sync
- make OAuth callback invisible and post strictly to its origin
- expand OAuth popup and callback tests, covering navigation, closure, and stalled fetches

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7d11d9f0c83258217677603577b0b