### PR TITLE
feat(auth): invisible Google OAuth polish

### DIFF
--- a/storefronts/tests/sdk/oauth-google-popup.test.js
+++ b/storefronts/tests/sdk/oauth-google-popup.test.js
@@ -14,6 +14,7 @@ describe('signInWithGoogle popup', () => {
     globalThis.ensureConfigLoaded = vi.fn().mockResolvedValue();
     globalThis.getCachedBrokerBase = vi.fn().mockReturnValue('https://smoothr.vercel.app');
     const popup = { location: '', close: vi.fn(), closed: false };
+    const supabase = { auth: { setSession: vi.fn().mockResolvedValue({}) } };
     const win = {
       location: { origin: 'https://store.example', replace: vi.fn() },
       document: { getElementById: vi.fn(() => ({ dataset: { storeId: 'store_test' } })) },
@@ -25,10 +26,14 @@ describe('signInWithGoogle popup', () => {
       screenY: 0,
       outerWidth: 1024,
       outerHeight: 768,
+      Smoothr: { __supabase: supabase },
+      navigator: { userAgent: 'desktop' }
     };
     win.top = win;
     win.self = win;
     global.window = win;
+    global.document = win.document;
+    global.Smoothr = win.Smoothr;
     global.fetch = vi.fn(async (url) => {
       if (url === startUrl) {
         return { json: async () => ({ authorizeUrl: 'https://supabase.co/auth/authorize' }) };
@@ -49,24 +54,30 @@ describe('signInWithGoogle popup', () => {
     // ensure no leak for other suites
     // @ts-ignore
     delete global.fetch;
+    // @ts-ignore
+    delete global.Smoothr;
   });
 
   it('opens popup and syncs session on message', async () => {
     const promise = signInWithGooglePopup();
     await Promise.resolve();
+    await Promise.resolve();
     const handler = window.addEventListener.mock.calls.find(c => c[0] === 'message')?.[1];
     expect(typeof handler).toBe('function');
-    await handler({ origin: 'https://smoothr.vercel.app', data: { type: 'smoothr:oauth', ok: true, access_token: 'tok', store_id: 'store_test' } });
+    expect(window.__popup.location).toBe('https://supabase.co/auth/authorize');
+    await handler({ origin: 'https://smoothr.vercel.app', data: { type: 'smoothr_oauth_success', access_token: 'tok', refresh_token: 'ref', store_id: 'store_test' } });
     await promise;
     expect(window.open).toHaveBeenCalled();
     const specs = window.open.mock.calls[0][2];
+    expect(specs).toContain('width=480');
+    expect(specs).toContain('height=640');
     expect(specs).toContain('left=272');
     expect(specs).toContain('top=64');
-    expect(window.__popup.location).toBe('https://supabase.co/auth/authorize');
     const syncCall = fetch.mock.calls.find(c => c[0] === 'https://smoothr.vercel.app/api/auth/session-sync');
     expect(syncCall).toBeTruthy();
     expect(window.__popup.close).toHaveBeenCalled();
     expect(window.location.replace).not.toHaveBeenCalled();
+    expect(window.Smoothr.__supabase.auth.setSession).toHaveBeenCalledWith({ access_token: 'tok', refresh_token: 'ref' });
   });
 
   it('falls back to redirect when popup blocked', async () => {
@@ -92,7 +103,7 @@ describe('signInWithGoogle popup', () => {
     vi.useFakeTimers();
     const promise = signInWithGooglePopup();
     window.__popup.closed = true;
-    await vi.advanceTimersByTimeAsync(400);
+    await vi.advanceTimersByTimeAsync(250);
     expect(window.location.replace).toHaveBeenCalledWith(redirectUrl);
     expect(window.__popup.close).toHaveBeenCalled();
     const syncCall = fetch.mock.calls.find(c => c[0] === 'https://smoothr.vercel.app/api/auth/session-sync');
@@ -122,9 +133,31 @@ describe('signInWithGoogle popup', () => {
     await promise;
   });
 
+  it('ignores messages from unexpected origins', async () => {
+    vi.useFakeTimers();
+    const promise = signInWithGooglePopup();
+    await Promise.resolve();
+    const handler = window.addEventListener.mock.calls.find(c => c[0] === 'message')?.[1];
+    await handler({ origin: 'https://evil.example', data: { type: 'smoothr_oauth_success', access_token: 'bad', refresh_token: 'bad', store_id: 'store_test' } });
+    expect(window.location.replace).not.toHaveBeenCalled();
+    expect(window.Smoothr.__supabase.auth.setSession).not.toHaveBeenCalled();
+    window.__popup.closed = true;
+    await vi.advanceTimersByTimeAsync(250);
+    expect(window.location.replace).toHaveBeenCalledWith(redirectUrl);
+    vi.useRealTimers();
+    await promise;
+  });
+
   it('redirects when framed', async () => {
     window.top = {};
     window.self = {};
+    await signInWithGoogle();
+    expect(window.open).not.toHaveBeenCalled();
+    expect(window.location.replace).toHaveBeenCalledWith(redirectUrl);
+  });
+
+  it('redirects on iOS Safari', async () => {
+    window.navigator.userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1';
     await signInWithGoogle();
     expect(window.open).not.toHaveBeenCalled();
     expect(window.location.replace).toHaveBeenCalledWith(redirectUrl);

--- a/storefronts/tests/sdk/oauth-google.test.js
+++ b/storefronts/tests/sdk/oauth-google.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 let signInWithGoogle;
+let injectAuthPreconnects;
 
 describe('signInWithGoogle', () => {
   beforeEach(async () => {
@@ -13,6 +14,7 @@ describe('signInWithGoogle', () => {
       SMOOTHR_CONFIG: { store_id: 'store_test' }
     };
     ({ signInWithGoogle } = await import('../../features/auth/init.js'));
+    ({ injectAuthPreconnects } = await import('../../smoothr-sdk.js'));
   });
 
   it('navigates to broker oauth-start with store and origin', async () => {
@@ -20,5 +22,18 @@ describe('signInWithGoogle', () => {
     expect(global.window.location.replace).toHaveBeenCalledWith(
       'https://smoothr.vercel.app/api/auth/oauth-start?provider=google&store_id=store_test&orig=https%3A%2F%2Fstore.example'
     );
+  });
+
+  it('injects preconnect links for auth endpoints', () => {
+    document.head.innerHTML = '';
+    window.SMOOTHR_CONFIG.supabase_url = 'https://foo.supabase.co';
+    injectAuthPreconnects(window.SMOOTHR_CONFIG);
+    const pre = document.head.querySelectorAll('link[rel="preconnect"]');
+    const dns = document.head.querySelectorAll('link[rel="dns-prefetch"]');
+    const hrefs = Array.from(document.head.querySelectorAll('link')).map(l => l.getAttribute('href'));
+    expect(pre.length).toBe(2);
+    expect(dns.length).toBe(2);
+    expect(hrefs).toContain('https://accounts.google.com');
+    expect(hrefs).toContain('https://foo.supabase.co');
   });
 });


### PR DESCRIPTION
## Summary
- Improve popup flow with centered window, faster close detection and parent-side Supabase session handling
- Make callback page invisible and hand off tokens via strict postMessage or hidden form
- Add preconnect hints and iOS Safari detection to skip popup on unsupported platforms

## Testing
- `npm test` *(fails: TypeError cannot set property supabaseReady...)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e5de65248325b9b91fbc59430da9