### PR TITLE
refactor(sdk): make supabaseReady writable and test-friendly

### DIFF
--- a/storefronts/core/credentials.js
+++ b/storefronts/core/credentials.js
@@ -1,12 +1,12 @@
 import { getConfig } from '../features/config/globalConfig.js';
+import { ensureSupabaseReady } from '../smoothr-sdk.js';
 
 export async function getGatewayCredential(gateway) {
   const w = typeof window !== 'undefined' ? window : globalThis;
   const debug = new URLSearchParams(w.location?.search || '').has('smoothr-debug');
 
   try {
-    const supabase =
-      (await (w.Smoothr?.supabaseReady || Promise.resolve(null))) || null;
+    const supabase = await ensureSupabaseReady();
 
     if (!supabase) {
       debug && console.warn('[Smoothr] Supabase not ready in getGatewayCredential');

--- a/storefronts/features/checkout/init.js
+++ b/storefronts/features/checkout/init.js
@@ -1,4 +1,5 @@
 // checkout.js
+import { ensureSupabaseReady } from '../../smoothr-sdk.js';
 
 let getConfig;
 
@@ -44,7 +45,7 @@ async function init(opts = {}) {
 
     const resolvedSupabase =
       supabase ??
-      (await globalThis.Smoothr?.supabaseReady) ??
+      (await ensureSupabaseReady()) ??
       globalThis.supabaseAuth ??
       globalThis.Smoothr?.supabaseAuth ??
       globalThis.smoothr?.supabaseAuth ??

--- a/storefronts/tests/core/credential-helper.test.js
+++ b/storefronts/tests/core/credential-helper.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { __setSupabaseReadyForTests } from '../../smoothr-sdk.js';
 
 const invokeMock = vi.fn();
 const ensureMock = vi.fn();
@@ -15,13 +16,11 @@ describe('credential helper', () => {
   beforeEach(() => {
     invokeMock.mockReset();
     ensureMock.mockReset();
-    globalThis.Smoothr = {
-      supabaseReady: Promise.resolve({ functions: { invoke: invokeMock } }),
-    };
+    __setSupabaseReadyForTests({ functions: { invoke: invokeMock } });
   });
 
   afterEach(() => {
-    delete globalThis.Smoothr;
+    __setSupabaseReadyForTests(null);
   });
 
   it('invokes edge function with store id and gateway', async () => {

--- a/storefronts/tests/sdk/supabase-ready.test.js
+++ b/storefronts/tests/sdk/supabase-ready.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ensureSupabaseReady, __setSupabaseReadyForTests } from '../../smoothr-sdk.js';
+
+describe('ensureSupabaseReady', () => {
+  beforeEach(() => {
+    __setSupabaseReadyForTests(null);
+    if (typeof window !== 'undefined') {
+      window.Smoothr = window.Smoothr || {};
+      delete window.Smoothr.__supabase;
+      window.Smoothr.ready = Promise.resolve({
+        storeId: 'store_test',
+        supabaseUrl: 'https://example.supabase.co',
+        supabaseAnonKey: 'anon'
+      });
+    }
+  });
+
+  afterEach(() => {
+    __setSupabaseReadyForTests(null);
+    vi.doUnmock('@supabase/supabase-js');
+  });
+
+  it('initializes only once', async () => {
+    const createClient = vi.fn(() => ({}));
+    vi.doMock('@supabase/supabase-js', () => ({ createClient }), { virtual: true });
+    const p1 = ensureSupabaseReady();
+    const p2 = ensureSupabaseReady();
+    await p1;
+    await p2;
+    expect(createClient).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows test override', async () => {
+    const fake = {};
+    __setSupabaseReadyForTests(fake);
+    expect(await ensureSupabaseReady()).toBe(fake);
+  });
+
+  it('wraps raw client values', async () => {
+    const fake = {};
+    __setSupabaseReadyForTests(fake);
+    await expect(ensureSupabaseReady()).resolves.toBe(fake);
+  });
+});

--- a/storefronts/tests/utils/supabase-mock.ts
+++ b/storefronts/tests/utils/supabase-mock.ts
@@ -1,4 +1,5 @@
 import { vi } from "vitest";
+import { __setSupabaseReadyForTests } from '../../smoothr-sdk.js';
 
 export type SupabaseClientMock = ReturnType<typeof buildSupabaseMock>["client"];
 export type SupabaseClientMocks = ReturnType<typeof buildSupabaseMock>["mocks"];
@@ -64,7 +65,7 @@ export function useWindowSupabaseMock(client: SupabaseClientMock, mocks?: Supaba
   const w: any = (globalThis as any).window || (globalThis as any);
   w.Smoothr = w.Smoothr || {};
   w.Smoothr.__supabase = client;
-  w.Smoothr.supabaseReady = Promise.resolve(client);
+  __setSupabaseReadyForTests(client);
   // stash mocks for easy access in specs
   (globalThis as any).__smoothrTest = { ...(globalThis as any).__smoothrTest, supabase: client, mocks };
 }

--- a/storefronts/tests/utils/supabase-singleton.test.js
+++ b/storefronts/tests/utils/supabase-singleton.test.js
@@ -1,11 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { getSupabaseClient } from '../../../supabase/client/browserClient.js';
+import { __setSupabaseReadyForTests } from '../../smoothr-sdk.js';
 
 describe('supabase browser client singleton', () => {
   beforeEach(() => {
     global.window = global.window || {};
-    window.Smoothr = window.Smoothr || {};
-    window.Smoothr.supabaseReady = Promise.resolve({
+    const client = {
       auth: {
         getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
         setSession: vi.fn().mockResolvedValue({}),
@@ -17,7 +17,8 @@ describe('supabase browser client singleton', () => {
       functions: {
         invoke: vi.fn().mockResolvedValue({ data: null, error: null }),
       },
-    });
+    };
+    __setSupabaseReadyForTests(client);
     delete window.Smoothr.__supabase;
   });
 


### PR DESCRIPTION
## Summary
- replace getter-only `Smoothr.supabaseReady` with writable promise and helpers for lazy init and testing
- update SDK and feature modules to use `ensureSupabaseReady()` singleton
- add tests and utilities to override `supabaseReady` in specs

## Testing
- `npm --workspace storefronts test` *(fails: 'import', and 'export' cannot be used outside of module code)*

------
https://chatgpt.com/codex/tasks/task_e_68b7eb2f700c83258ec8486dd8a1742d