### PR TITLE
Fix Vitest ESM transform by using a workspace-local config and web transform mode

### DIFF
--- a/storefronts/README.md
+++ b/storefronts/README.md
@@ -423,3 +423,13 @@ The workflow automatically publishes `storefronts/dist` to Cloudflare Pages.
 The latest deployed commit can be found in `DEPLOY_LOG.md`. When embedding the
 SDK on your site, perform a hard refresh after each deploy so browsers load the
 new bundle.
+
+## Testing notes (ESM)
+- Storefront tests now use a workspace-local `vitest.config.ts` to force ESM/web transforms.
+- Run: `npm --workspace storefronts test`
+- If you still see `'import'/'export' outside of module code`, clear caches and re-run:
+  ```
+  rm -rf node_modules .vite .vitest
+  npm i
+  npm --workspace storefronts test
+  ```

--- a/storefronts/package.json
+++ b/storefronts/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "storefronts",
   "version": "1.0.0",
@@ -11,9 +10,10 @@
   "scripts": {
     "build": "vite build",
     "dev": "vite",
-    "test": "vitest run --config ../vitest.config.ts --exclude tests/sdk/signup-dist.test.js",
+    "test": "vitest run --config vitest.config.ts --exclude tests/sdk/signup-dist.test.js",
     "build:storefronts": "vite build",
-    "test:dist-auth": "vitest run --config vitest.dist.config.ts"
+    "test:dist-auth": "vitest run --config vitest.dist.config.ts",
+    "test:watch": "vitest --config vitest.config.ts --watch"
   },
   "dependencies": {
     "esbuild": "^0.19.12",

--- a/storefronts/tests/sdk/supabase-ready.test.js
+++ b/storefronts/tests/sdk/supabase-ready.test.js
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 // /storefronts/tests/sdk/supabase-ready.test.js
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 

--- a/storefronts/vitest.config.ts
+++ b/storefronts/vitest.config.ts
@@ -1,16 +1,50 @@
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+// Ensure the project root for Vitest is the storefronts workspace,
+// not the monorepo root (important for package.json `type` resolution).
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const wsRoot = resolve(__dirname, '.');
 
 export default defineConfig({
+  root: wsRoot,
+
+  // Keep ESM semantics for tests (avoid SSR/script transform on tests)
   test: {
     environment: 'jsdom',
-    // Helps when mocking ESM deps
-    deps: {
-      inline: ['@supabase/supabase-js'],
+    globals: true,
+    isolate: true,
+    threads: false, // simplify env for jsdom + ESM
+    // Force Vite to treat our tests as web code (ESM), not SSR.
+    transformMode: {
+      web: [/\.(m?[jt]sx?)$/],
+      ssr: [/node_modules/], // only SSR-transform node_modules when required
     },
+    deps: {
+      // Inline ESM deps so Vite transforms them instead of Node requiring them as CJS
+      inline: [
+        /@supabase\/supabase-js/,
+      ],
+    },
+    // Helpful for diagnosing first failure file; you can toggle to 'verbose'
+    reporters: ['default'],
   },
+
+  // Prefer ESM/browser entry points
+  resolve: {
+    conditions: ['browser', 'module', 'import', 'default'],
+  },
+
+  // Ensure TS/JS transpile target matches our ESM usage
   esbuild: {
-    // keep ESM semantics for tests
-    format: 'esm',
     target: 'es2020',
+    format: 'esm',
+  },
+
+  // Useful defines for modules that branch on NODE_ENV
+  define: {
+    'process.env.NODE_ENV': JSON.stringify('test'),
   },
 });


### PR DESCRIPTION
## Summary
- scope storefronts vitest to workspace root and enforce ESM/web transform mode
- run storefront tests through local config and add `test:watch`
- document ESM test usage and add jsdom pragma for Supabase ready tests

## Testing
- `npm --workspace storefronts test` *(fails: multiple tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68b8066bfe2083258333f7b9c4bd901d