### PR TITLE
fix: configure vitest for ESM with shared aliases

### DIFF
--- a/storefronts/tests/sdk/supabase-ready.test.js
+++ b/storefronts/tests/sdk/supabase-ready.test.js
@@ -1,3 +1,6 @@
+/// <reference types="vitest" />
+/// <reference types="vitest/globals" />
+// Ensure jsdom env (belt-and-braces)
 // @vitest-environment jsdom
 // /storefronts/tests/sdk/supabase-ready.test.js
 import { describe, it, expect, beforeEach, vi } from 'vitest';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,40 +1,6 @@
+// Root config kept minimal so workspace configs (like storefronts/vitest.config.ts)
+// fully control their environment. Do not force SSR here.
 import { defineConfig } from 'vitest/config';
-import path from 'node:path';
 
-const repoRoot = __dirname;
+export default defineConfig({});
 
-export default defineConfig({
-  test: {
-    // Use jsdom so that browser globals like `window` are available in tests
-    environment: 'jsdom',
-    globals: true,
-    setupFiles: ['./vitest.setup.ts', './storefronts/tests/setup.ts'],
-    testTimeout: 10000,
-    deps: {
-      inline: ['@supabase/supabase-js'], // Enable npm imports
-      resolver: 'node', // Force Node resolver for npm packages
-    },
-    resolve: {
-      conditions: ['module'], // Ensure ES module resolution
-    },
-    isolate: true,
-    transformMode: {
-      web: [/\.[jt]sx?$/],
-      ssr: [/node_modules/],
-    },
-  },
-  resolve: {
-    alias: {
-      '@': path.resolve(repoRoot, 'smoothr'),
-      '@/lib/findOrCreateCustomer': path.resolve(repoRoot, 'shared/lib/findOrCreateCustomer.ts'),
-      'npm:@supabase/supabase-js@2.38.4': '@supabase/supabase-js',
-      shared: path.resolve(repoRoot, 'shared'),
-      'shared/*': path.resolve(repoRoot, 'shared'),
-      smoothr: path.resolve(repoRoot, 'smoothr'),
-      'smoothr/*': path.resolve(repoRoot, 'smoothr'),
-    },
-  },
-  esbuild: {
-    target: 'es2020',
-  },
-});


### PR DESCRIPTION
## Summary
- simplify root Vitest config so workspaces control their own environments
- add robust Vitest config in storefronts for ESM transforms, aliases, and inline deps
- annotate supabase-ready test with Vitest references and jsdom directive

## Testing
- `npm test` *(fails: 'import', and 'export' cannot be used outside of module code)*

------
https://chatgpt.com/codex/tasks/task_e_68b8084754dc8325a7acf6f65a39c430