### PR TITLE
fix: stabilize Vitest/Vite configs for storefronts

### DIFF
--- a/storefronts/tests/setup.ts
+++ b/storefronts/tests/setup.ts
@@ -7,7 +7,14 @@ declare global {
 }
 
 beforeEach(() => {
+  console.log('storefronts/tests/setup.ts ran');
   const { client, mocks } = buildSupabaseMock();
   (globalThis as any).__smoothrTest = { supabase: client, mocks };
   useWindowSupabaseMock(client, mocks);
+  // Ensure debug mode for log-based tests
+  (globalThis as any).Smoothr = (globalThis as any).Smoothr || {};
+  (globalThis as any).Smoothr.config = {
+    ...(globalThis as any).Smoothr.config || {},
+    debug: true,
+  };
 });

--- a/storefronts/tests/vitest-config-log.ts
+++ b/storefronts/tests/vitest-config-log.ts
@@ -1,0 +1,1 @@
+console.log('vitest.config.ts setupFiles loaded');

--- a/storefronts/vite.config.js
+++ b/storefronts/vite.config.js
@@ -12,7 +12,7 @@ export default defineConfig(({ mode }) => {
     // Only expose env vars prefixed with VITE_
     envPrefix: ['VITE_'],
     optimizeDeps: {
-      include: ['@supabase/supabase-js']
+      include: ['@supabase/supabase-js', 'stripe', 'cross-fetch', 'whatwg-fetch']
     },
     define: {
       // Map Cloudflare’s VITE_* secrets into process.env
@@ -35,7 +35,7 @@ export default defineConfig(({ mode }) => {
       )
     },
     build: {
-      target: 'esnext', // ✅ Enables top-level await
+      target: 'es2020',
       rollupOptions: {
         external: [],
         input: {
@@ -55,6 +55,13 @@ export default defineConfig(({ mode }) => {
       outDir: 'dist',
       emptyOutDir: true,
       assetsDir: ''
+    },
+    resolve: {
+      alias: [
+        { find: /^shared\/(.*)$/, replacement: (_, p1) => path.resolve(__dirname, `../shared/${p1}`) },
+        { find: /^smoothr\/(.*)$/, replacement: (_, p1) => path.resolve(__dirname, `../smoothr/${p1}`) },
+        { find: /^storefronts\/(.*)$/, replacement: (_, p1) => path.resolve(__dirname, p1) },
+      ],
     }
   };
 });

--- a/storefronts/vitest.config.ts
+++ b/storefronts/vitest.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
             '@supabase/supabase-js',
             'cross-fetch',
             'whatwg-fetch',
+            'stripe',
           ],
         },
       },
@@ -37,17 +38,19 @@ export default defineConfig({
           '@supabase/supabase-js',
           'cross-fetch',
           'whatwg-fetch',
+          'stripe',
         ],
       },
     },
     // Ensure storefront tests also load the shared setup when executed directly in this workspace.
     setupFiles: [
       r('../vitest.setup.ts'),
-      r('./tests/setup.ts')
+      r('./tests/setup.ts'),
+      r('./tests/vitest-config-log.ts'),
     ],
     transformMode: {
       // Force "web" mode for anything under this package
-      web: [/\.([cm]?[jt]s)x?$/],
+      web: [/^.*storefronts.*\.(m?[jt]sx?)$/],
     },
     esbuild: {
       target: 'es2020',


### PR DESCRIPTION
## Summary
- ensure storefront tests run in debug mode and log setup execution
- inline Stripe deps and restrict web transforms in Vitest
- align Vite build to es2020 and add monorepo aliases

## Testing
- `npm test` *(fails: 'import' and 'export' cannot be used outside of module code)*
- `npm run build` *(fails: smoothr-sdk.js 'import' and 'export' cannot be used outside of module code)*

------
https://chatgpt.com/codex/tasks/task_e_68b8da2e4c04832594436da05f0cfb1e