### PR TITLE
chore: add setup logging and inline deps for storefront tests

### DIFF
--- a/storefronts/tests/sdk/oauth-google-popup.test.js
+++ b/storefronts/tests/sdk/oauth-google-popup.test.js
@@ -1,5 +1,9 @@
 import { test, describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
+vi.mock('storefronts/features/checkout/init.js', () => ({
+  init: vi.fn(),
+}));
+
 let signInWithGoogle;
 let signInWithGooglePopup;
 let realWindow;

--- a/storefronts/vite.config.js
+++ b/storefronts/vite.config.js
@@ -43,6 +43,7 @@ export default defineConfig(({ mode }) => {
     },
     build: {
       target: 'es2020',
+      modulePreload: false,
       rollupOptions: {
         external: [],
         input: {

--- a/storefronts/vitest.config.ts
+++ b/storefronts/vitest.config.ts
@@ -6,6 +6,13 @@ import url from 'node:url';
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const r = (p: string) => path.resolve(__dirname, p);
 
+const setupFiles = [
+  r('../vitest.setup.ts'),
+  r('./tests/setup.ts'),
+  r('./tests/vitest-config-log.ts'),
+];
+console.log('vitest.config.ts setupFiles loaded', setupFiles);
+
 // Map "shared/..." to the monorepo shared folder so imports like
 // "shared/auth/resolveRecoveryDestination" resolve in tests.
 
@@ -30,6 +37,7 @@ export default defineConfig({
             'whatwg-fetch',
             'node-fetch',
           ],
+          enabled: true,
         },
       },
     },
@@ -42,15 +50,12 @@ export default defineConfig({
           'whatwg-fetch',
           'node-fetch',
           'smoothr-sdk.js',
+          'storefronts/*',
         ],
       },
     },
     // Ensure storefront tests also load the shared setup when executed directly in this workspace.
-    setupFiles: [
-      r('../vitest.setup.ts'),
-      r('./tests/setup.ts'),
-      r('./tests/vitest-config-log.ts'),
-    ],
+    setupFiles,
     transformMode: {
       // Force "web" mode for anything under this package
       web: [/.*\.(m?[jt]sx?)$/],

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,8 @@
 // vitest.setup.ts
 import { vi } from 'vitest';
 
+console.log('vitest.setup.ts ran');
+
 // Idempotent global bootstrapping for tests.
 // If these shims are applied twice (root + workspace), guard with flags.
 if (!(globalThis as any).__smoothrSetupApplied) {


### PR DESCRIPTION
## Summary
- log vitest setup execution
- inline more deps and disable module preload for storefront build
- mock checkout init in OAuth popup test

## Testing
- `npm --workspace storefronts test` *(fails: 'import', and 'export' cannot be used outside of module code)*
- `npm --workspace storefronts run build` *(fails: 'import', and 'export' cannot be used outside of module code)*

------
https://chatgpt.com/codex/tasks/task_e_68b8dfe3a2a88325bff77a78bd3730ae