### PR TITLE
fix: narrow storefront transforms and mock gateways

### DIFF
--- a/storefronts/tests/providers/provider-stripe.test.ts
+++ b/storefronts/tests/providers/provider-stripe.test.ts
@@ -14,6 +14,12 @@ vi.mock('../../../shared/checkout/getActiveGatewayCreds.ts', () => {
   return { getActiveGatewayCreds: credsMock };
 });
 
+vi.mock('storefronts/features/gateways/stripeGateway.js', () => ({ init: vi.fn() }));
+vi.mock('storefronts/features/gateways/authorizeNet.js', () => ({ init: vi.fn() }));
+vi.mock('storefronts/features/gateways/paypal.js', () => ({ init: vi.fn() }));
+vi.mock('storefronts/features/gateways/nmiGateway.js', () => ({ init: vi.fn() }));
+vi.mock('storefronts/features/gateways/segpay.js', () => ({ init: vi.fn() }));
+
 async function loadModule() {
   const mod = await import('../../../shared/checkout/providers/stripeProvider.ts');
   handleStripe = mod.default;
@@ -49,6 +55,10 @@ beforeEach(async () => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+});
+
+it('setup ran with debug mode', () => {
+  expect(window.Smoothr?.config?.debug).toBe(true);
 });
 
 describe('handleStripe', () => {

--- a/storefronts/vite.config.js
+++ b/storefronts/vite.config.js
@@ -18,7 +18,8 @@ export default defineConfig(({ mode }) => {
         'cross-fetch',
         'whatwg-fetch',
         'node-fetch',
-        'smoothr-sdk.js'
+        'smoothr-sdk.js',
+        'storefronts/*'
       ]
     },
     define: {
@@ -45,7 +46,7 @@ export default defineConfig(({ mode }) => {
       target: 'es2020',
       modulePreload: false,
       rollupOptions: {
-        external: [],
+        external: [/^\/smoothr\/pages\/api\/.*$/],
         input: {
           'smoothr-sdk': path.resolve(__dirname, 'smoothr-sdk.js')
         },

--- a/storefronts/vitest.config.ts
+++ b/storefronts/vitest.config.ts
@@ -6,74 +6,84 @@ import url from 'node:url';
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const r = (p: string) => path.resolve(__dirname, p);
 
-const setupFiles = [
-  r('../vitest.setup.ts'),
-  r('./tests/setup.ts'),
-  r('./tests/vitest-config-log.ts'),
-];
-console.log('vitest.config.ts setupFiles loaded', setupFiles);
+let config;
 
-// Map "shared/..." to the monorepo shared folder so imports like
-// "shared/auth/resolveRecoveryDestination" resolve in tests.
+try {
+  const setupFiles = [
+    r('../vitest.setup.ts'),
+    r('./tests/setup.ts'),
+    r('./tests/vitest-config-log.ts'),
+  ];
+  console.log('vitest.config.ts setupFiles loaded', setupFiles);
 
-export default defineConfig({
-  root: r('.'),
-  server: {
-    fs: {
-      allow: [path.resolve(__dirname, '..')],
+  // Map "shared/..." to the monorepo shared folder so imports like
+  // "shared/auth/resolveRecoveryDestination" resolve in tests.
+
+  config = defineConfig({
+    root: r('.'),
+    server: {
+      fs: {
+        allow: [path.resolve(__dirname, '..')],
+      },
     },
-  },
-  test: {
-    environment: 'jsdom',
-    globals: true,
-    isolate: true,
-    deps: {
-      optimizer: {
-        web: {
-          include: [
+    test: {
+      environment: 'jsdom',
+      globals: true,
+      isolate: true,
+      deps: {
+        optimizer: {
+          web: {
+            include: [
+              '@supabase/supabase-js',
+              'stripe',
+              'cross-fetch',
+              'whatwg-fetch',
+              'node-fetch',
+              'storefronts/*',
+            ],
+            enabled: true,
+          },
+        },
+      },
+      server: {
+        deps: {
+          inline: [
             '@supabase/supabase-js',
             'stripe',
             'cross-fetch',
             'whatwg-fetch',
             'node-fetch',
+            'smoothr-sdk.js',
+            'storefronts/*',
           ],
-          enabled: true,
         },
       },
-    },
-    server: {
-      deps: {
-        inline: [
-          '@supabase/supabase-js',
-          'stripe',
-          'cross-fetch',
-          'whatwg-fetch',
-          'node-fetch',
-          'smoothr-sdk.js',
-          'storefronts/*',
-        ],
+      // Ensure storefront tests also load the shared setup when executed directly in this workspace.
+      setupFiles,
+      transformMode: {
+        // Force "web" mode for storefront files only
+        web: [/^storefronts\/.*\.(m?[jt]sx?)$/],
+      },
+      esbuild: {
+        target: 'es2020',
       },
     },
-    // Ensure storefront tests also load the shared setup when executed directly in this workspace.
-    setupFiles,
-    transformMode: {
-      // Force "web" mode for anything under this package
-      web: [/.*\.(m?[jt]sx?)$/],
+    resolve: {
+      alias: [
+        // shared/* → ../shared/*
+        { find: /^shared\/(.*)$/, replacement: (_: string, p1: string) => r(`../shared/${p1}`) },
+        // Optional: alias 'smoothr' to the app package root in case tests import from it
+        { find: /^smoothr\/(.*)$/, replacement: (_: string, p1: string) => r(`../smoothr/${p1}`) },
+        // storefronts/* → ./*
+        { find: /^storefronts\/(.*)$/, replacement: (_: string, p1: string) => r(p1) }
+      ],
+      extensions: ['.mjs', '.cjs', '.js', '.mts', '.cts', '.ts', '.jsx', '.tsx', '.json'],
     },
-    esbuild: {
-      target: 'es2020',
-    },
-  },
-  resolve: {
-    alias: [
-      // shared/* → ../shared/*
-      { find: /^shared\/(.*)$/, replacement: (_: string, p1: string) => r(`../shared/${p1}`) },
-      // Optional: alias 'smoothr' to the app package root in case tests import from it
-      { find: /^smoothr\/(.*)$/, replacement: (_: string, p1: string) => r(`../smoothr/${p1}`) },
-      // storefronts/* → ./*
-      { find: /^storefronts\/(.*)$/, replacement: (_: string, p1: string) => r(p1) }
-    ],
-    extensions: ['.mjs', '.cjs', '.js', '.mts', '.cts', '.ts', '.jsx', '.tsx', '.json']
-  }
-});
+  });
+} catch (error) {
+  console.error('vitest.config.ts parse error:', error);
+  throw error;
+}
+
+export default config;
 


### PR DESCRIPTION
## Summary
- restrict vitest web transform scope to storefront files and add config error logging
- mock checkout gateway modules in provider-stripe tests and verify debug setup
- externalize server-side API modules in Vite build

## Testing
- `npx vitest run --config vitest.config.ts --no-threads` *(fails: command not found: npx)*
- `npm run build` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e430579083259aa189d0363f069d