### PR TITLE
fix: disable SSR transforms for storefront tests and build

### DIFF
--- a/storefronts/vite.config.js
+++ b/storefronts/vite.config.js
@@ -11,15 +11,14 @@ export default defineConfig(({ mode }) => {
     base: 'https://sdk.smoothr.io/',
     // Only expose env vars prefixed with VITE_
     envPrefix: ['VITE_'],
+    ssr: false,
     optimizeDeps: {
       include: [
         '@supabase/supabase-js',
         'stripe',
         'cross-fetch',
         'whatwg-fetch',
-        'node-fetch',
-        'smoothr-sdk.js',
-        'storefronts/*'
+        'node-fetch'
       ]
     },
     define: {

--- a/storefronts/vitest.config.ts
+++ b/storefronts/vitest.config.ts
@@ -42,6 +42,9 @@ try {
             ],
             enabled: true,
           },
+          ssr: {
+            enabled: false,
+          },
         },
       },
       server: {
@@ -60,7 +63,7 @@ try {
       setupFiles,
       transformMode: {
         // Force "web" mode for storefront files only
-        web: [/\/storefronts\/.*\.(m?[jt]sx?)$/],
+        web: [/.*\/storefronts\/.*\.(m?[jt]sx?)$/],
       },
       esbuild: {
         target: 'es2020',


### PR DESCRIPTION
## Summary
- improve Vitest config to match storefront paths and disable SSR optimizer
- turn off SSR in Vite build and trim optimizeDeps includes

## Testing
- `npm test` *(fails: 'import', and 'export' cannot be used outside of module code)*
- `npm run build` *(fails: 'import', and 'export' cannot be used outside of module code)*

------
https://chatgpt.com/codex/tasks/task_e_68b8eb87ea3c8325a4d38dc04afa99b3