### PR TITLE
test: stabilize mocking and document handling

### DIFF
--- a/storefronts/tests/adapters/webflow-domReady.test.js
+++ b/storefronts/tests/adapters/webflow-domReady.test.js
@@ -1,16 +1,18 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { initAdapter } from 'storefronts/adapters/webflow.js';
+import * as currencyAdapter from 'storefronts/adapters/webflow/currencyDomAdapter.js';
 
-vi.mock('../../adapters/webflow/currencyDomAdapter.js', () => ({
-  initCurrencyDom: vi.fn(),
-}));
-
-import { initAdapter } from '../../adapters/webflow.js';
-import { initCurrencyDom } from '../../adapters/webflow/currencyDomAdapter.js';
+const initCurrencyDom = vi
+  .spyOn(currencyAdapter, 'initCurrencyDom')
+  .mockImplementation(() => {});
 
 describe('webflow adapter domReady', () => {
+  let realDocument;
+
   beforeEach(() => {
     vi.useFakeTimers();
     globalThis.SMOOTHR_CONFIG = {};
+    realDocument = global.document;
     global.document = {
       readyState: 'loading',
       addEventListener: vi.fn(),
@@ -22,6 +24,7 @@ describe('webflow adapter domReady', () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.clearAllMocks();
+    global.document = realDocument;
   });
 
   it('resolves when DOMContentLoaded fires', async () => {

--- a/storefronts/tests/adapters/webflow-legacyAttributes.test.js
+++ b/storefronts/tests/adapters/webflow-legacyAttributes.test.js
@@ -1,13 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { initAdapter } from 'storefronts/adapters/webflow.js';
+import * as currencyAdapter from 'storefronts/adapters/webflow/currencyDomAdapter.js';
 
-vi.mock('../../adapters/webflow/currencyDomAdapter.js', () => ({
-  initCurrencyDom: vi.fn(),
-}));
-
-import { initAdapter } from '../../adapters/webflow.js';
+vi.spyOn(currencyAdapter, 'initCurrencyDom').mockImplementation(() => {});
 
 describe('webflow adapter legacy attribute normalization', () => {
   let elements;
+  let realDocument;
 
   beforeEach(() => {
     elements = {};
@@ -55,15 +54,17 @@ describe('webflow adapter legacy attribute normalization', () => {
       ],
     };
 
+    realDocument = global.document;
     global.document = {
       readyState: 'complete',
       querySelectorAll: vi.fn((sel) => selectorMap[sel] || []),
+      addEventListener: vi.fn(),
     };
   });
 
   afterEach(() => {
     vi.clearAllMocks();
-    delete global.document;
+    global.document = realDocument;
   });
 
   it('normalizes legacy attributes on domReady', async () => {

--- a/storefronts/tests/sdk/oauth-google-popup.test.js
+++ b/storefronts/tests/sdk/oauth-google-popup.test.js
@@ -23,7 +23,7 @@ describe('signInWithGoogle popup', () => {
     realDocument = global.document;
     globalThis.ensureConfigLoaded = vi.fn().mockResolvedValue();
     globalThis.getCachedBrokerBase = vi.fn().mockReturnValue('https://smoothr.vercel.app');
-    const popup = { location: '', close: vi.fn(), closed: false };
+    const popup = { location: { href: '' }, close: vi.fn(), closed: false };
     const supabase = { auth: { setSession: vi.fn().mockResolvedValue({}) } };
     const win = {
       location: { origin: 'https://store.example', replace: vi.fn() },
@@ -79,9 +79,9 @@ describe('signInWithGoogle popup', () => {
     await Promise.resolve();
     const handler = window.addEventListener.mock.calls.find(c => c[0] === 'message')?.[1];
     expect(typeof handler).toBe('function');
-    expect(window.__popup.location).toBe('https://supabase.co/auth/authorize');
     await handler({ origin: 'https://smoothr.vercel.app', data: { type: 'smoothr_oauth_success', access_token: 'tok', refresh_token: 'ref', store_id: 'store_test' } });
     await promise;
+    expect(window.__popup.location.href).toBe('https://supabase.co/auth/authorize');
     expect(window.open).toHaveBeenCalled();
     const specs = window.open.mock.calls[0][2];
     expect(specs).toContain('width=480');

--- a/storefronts/tests/sdk/supabase-ready.test.js
+++ b/storefronts/tests/sdk/supabase-ready.test.js
@@ -3,14 +3,7 @@
 // @vitest-environment jsdom
 // Vitest: use browser globals for Smoothr
 // (kept as explicit env to avoid runner ambiguity)
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-
-// IMPORTANT: mock @supabase/supabase-js at module scope for ESM friendliness
-const createClient = vi.fn(() => ({}));
-vi.mock('@supabase/supabase-js', () => ({
-  createClient,
-  default: { createClient },
-}));
+import { describe, it, expect, beforeEach } from 'vitest';
 
 import {
   ensureSupabaseReady,

--- a/storefronts/tests/utils/supabase-mock.ts
+++ b/storefronts/tests/utils/supabase-mock.ts
@@ -1,6 +1,26 @@
 import { vi } from "vitest";
 import { __setSupabaseReadyForTests } from '../../smoothr-sdk.mjs';
 
+export const createClient = vi.fn(() => {
+  const { client, mocks } = buildSupabaseMock();
+  useWindowSupabaseMock(client, mocks);
+  return client;
+});
+
+vi.mock('@supabase/supabase-js', async () => {
+  const importOriginal = await vi.importActual<any>('@supabase/supabase-js');
+  return {
+    ...importOriginal,
+    __esModule: true,
+    default: { createClient },
+    createClient,
+  };
+});
+
+vi.mock('@supabase/node-fetch', () => ({
+  default: vi.fn(async () => ({ json: vi.fn(async () => ({})) })),
+}));
+
 export type SupabaseClientMock = ReturnType<typeof buildSupabaseMock>["client"];
 export type SupabaseClientMocks = ReturnType<typeof buildSupabaseMock>["mocks"];
 
@@ -77,13 +97,6 @@ export function currentSupabaseMocks(): SupabaseClientMocks {
 export function createClientMock() {
   return createClient();
 }
-
-// Named export that mirrors the real SDK's import style
-export const createClient = vi.fn(() => {
-  const { client, mocks } = buildSupabaseMock();
-  useWindowSupabaseMock(client, mocks);
-  return client;
-});
 
 // Some modules import the Supabase client as a default export
 export default { createClient };

--- a/storefronts/tests/utils/supabase-singleton.test.js
+++ b/storefronts/tests/utils/supabase-singleton.test.js
@@ -2,8 +2,12 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 const createClientMock = vi.hoisted(() => vi.fn());
 vi.mock('@supabase/supabase-js', () => ({
-  createClient: createClientMock,
+  __esModule: true,
   default: { createClient: createClientMock },
+  createClient: createClientMock,
+}));
+vi.mock('@supabase/node-fetch', () => ({
+  default: vi.fn(async () => ({ json: vi.fn(async () => ({})) })),
 }));
 
 import { getSupabaseClient } from '../../../supabase/client/browserClient.js';


### PR DESCRIPTION
## Summary
- restore and reset `global.document` in Webflow adapter tests
- model popup location as object and verify OAuth flow updates `href`
- expose Supabase mock as ESM default and stub `@supabase/node-fetch`
- isolate Supabase client in singleton test with proper mocks

## Testing
- `npm test -- tests/adapters/webflow-domReady.test.js tests/adapters/webflow-legacyAttributes.test.js tests/sdk/oauth-google-popup.test.js tests/sdk/supabase-ready.test.js tests/utils/supabase-singleton.test.js` *(fails: supabase-ready.test.js, oauth-google-popup.test.js [redirects on iOS Safari])* 
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b8fc7b29948325829ef221f1b53c15