### PR TITLE
fix: reset document between tests

### DIFF
--- a/storefronts/tests/features/auth.test.js
+++ b/storefronts/tests/features/auth.test.js
@@ -1,10 +1,11 @@
-import { describe, it, beforeEach, expect, vi } from 'vitest';
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
 
 let fromMock;
 let supabaseMock;
 let client;
 
 describe('auth feature init', () => {
+  let realDocument;
   beforeEach(async () => {
     vi.resetModules();
     fromMock = vi.fn(() => ({
@@ -50,6 +51,7 @@ describe('auth feature init', () => {
       smoothr: {},
       SMOOTHR_DEBUG: true
     };
+    realDocument = global.document;
     global.document = {
       readyState: 'complete',
       addEventListener: vi.fn(),
@@ -60,6 +62,10 @@ describe('auth feature init', () => {
     const test = global.window.Smoothr.config.__test;
     client = await test.tryImportClient();
     test.resetAuth();
+  });
+
+  afterEach(() => {
+    global.document = realDocument;
   });
 
   it('loads v_public_store during init', async () => {

--- a/storefronts/tests/features/checkout.test.js
+++ b/storefronts/tests/features/checkout.test.js
@@ -1,30 +1,36 @@
-import { describe, it, beforeEach, expect, vi } from 'vitest';
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
 
 let loadPublicConfigMock;
 let supabaseMock;
 
-describe('checkout feature init', () => {
-  beforeEach(() => {
-    vi.resetModules();
-    supabaseMock = { from: vi.fn() };
-    globalThis.Zc = supabaseMock;
-    loadPublicConfigMock = vi.fn().mockResolvedValue({});
-    vi.doMock('../../features/config/sdkConfig.js', () => ({
-      loadPublicConfig: loadPublicConfigMock
-    }));
-    let cfg = { storeId: '1', supabase: undefined, settings: {}, debug: false };
-    vi.doMock('../../features/config/globalConfig.js', () => ({
-      getConfig: vi.fn(() => cfg),
-      mergeConfig: vi.fn(obj => Object.assign(cfg, obj))
-    }));
-    vi.doMock('../../utils/platformReady.js', () => ({ platformReady: vi.fn().mockResolvedValue() }));
-    vi.doMock('../../features/checkout/utils/checkoutLogger.js', () => ({
-      default: () => ({ log: vi.fn(), warn: vi.fn(), err: vi.fn(), select: vi.fn().mockResolvedValue(), q: vi.fn() })
-    }));
-    vi.doMock('../../features/checkout/utils/resolveGateway.js', () => ({ default: vi.fn(() => null) }));
-    global.window = { Smoothr: {}, smoothr: {} };
-    global.document = {};
-  });
+  describe('checkout feature init', () => {
+    let realDocument;
+    beforeEach(() => {
+      vi.resetModules();
+      supabaseMock = { from: vi.fn() };
+      globalThis.Zc = supabaseMock;
+      loadPublicConfigMock = vi.fn().mockResolvedValue({});
+      vi.doMock('../../features/config/sdkConfig.js', () => ({
+        loadPublicConfig: loadPublicConfigMock
+      }));
+      let cfg = { storeId: '1', supabase: undefined, settings: {}, debug: false };
+      vi.doMock('../../features/config/globalConfig.js', () => ({
+        getConfig: vi.fn(() => cfg),
+        mergeConfig: vi.fn(obj => Object.assign(cfg, obj))
+      }));
+      vi.doMock('../../utils/platformReady.js', () => ({ platformReady: vi.fn().mockResolvedValue() }));
+      vi.doMock('../../features/checkout/utils/checkoutLogger.js', () => ({
+        default: () => ({ log: vi.fn(), warn: vi.fn(), err: vi.fn(), select: vi.fn().mockResolvedValue(), q: vi.fn() })
+      }));
+      vi.doMock('../../features/checkout/utils/resolveGateway.js', () => ({ default: vi.fn(() => null) }));
+      global.window = { Smoothr: {}, smoothr: {} };
+      realDocument = global.document;
+      global.document = {};
+    });
+
+    afterEach(() => {
+      global.document = realDocument;
+    });
 
   it('fetches public config using supplied Supabase client', async () => {
     const { init } = await import('../../features/checkout/init.js');

--- a/storefronts/tests/sdk/password-reset.test.js
+++ b/storefronts/tests/sdk/password-reset.test.js
@@ -42,9 +42,9 @@ it('does not set loading class on non-reset routes when hash exists', async () =
 
 it('submits password-reset via Enter on reset-only form', async () => {
   vi.resetModules();
-  document.body.innerHTML = '<script id="smoothr-sdk" src="https://sdk.smoothr.io/smoothr-sdk.mjs" data-config-url="https://broker.example/api/config" data-store-id="store_test"></script>';
-  createClientMock();
-  globalThis.getCachedBrokerBase = () => 'https://broker.example';
+    document.body.innerHTML = '<script id="smoothr-sdk" src="https://sdk.smoothr.io/smoothr-sdk.mjs" data-config-url="https://smoothr.vercel.app/api/config" data-store-id="store_test"></script>';
+    createClientMock();
+    globalThis.getCachedBrokerBase = () => 'https://smoothr.vercel.app';
   globalThis.ensureConfigLoaded = () => Promise.resolve();
   const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true, json: async () => ({ ok: true }) });
   auth = await import("../../features/auth/index.js");
@@ -101,9 +101,9 @@ it('does not send duplicate reset emails when clicking a bound reset control', a
 // Case A: config URL present (modern)
 it('sends reset via broker API with redirectTo (bridge + orig)', async () => {
   vi.resetModules();
-  document.body.innerHTML = `<script id="smoothr-sdk" src="https://sdk.smoothr.io/smoothr-sdk.mjs" data-store-id="store_test" data-config-url="https://broker.example/api/config"></script><form data-smoothr="auth-form"></form>`;
-  window.SMOOTHR_CONFIG = { store_id: 'store_test', storeId: 'store_test', routes: { resetPassword: '/reset-password' } };
-  globalThis.getCachedBrokerBase = () => 'https://broker.example';
+    document.body.innerHTML = `<script id="smoothr-sdk" src="https://sdk.smoothr.io/smoothr-sdk.mjs" data-store-id="store_test" data-config-url="https://smoothr.vercel.app/api/config"></script><form data-smoothr="auth-form"></form>`;
+    window.SMOOTHR_CONFIG = { store_id: 'store_test', storeId: 'store_test', routes: { resetPassword: '/reset-password' } };
+    globalThis.getCachedBrokerBase = () => 'https://smoothr.vercel.app';
   globalThis.ensureConfigLoaded = () => Promise.resolve();
   const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true, json: async () => ({ ok: true }) });
 
@@ -125,8 +125,8 @@ it('sends reset via broker API with redirectTo (bridge + orig)', async () => {
 // Case B: no config URL (legacy), script hosted on broker
 it('falls back to script origin when no config URL present', async () => {
   vi.resetModules();
-  document.body.innerHTML = `<script id="smoothr-sdk" src="https://broker.example/smoothr-sdk.mjs" data-store-id="store_test"></script><form data-smoothr="auth-form"></form>`;
-  globalThis.getCachedBrokerBase = () => 'https://broker.example';
+    document.body.innerHTML = `<script id="smoothr-sdk" src="https://smoothr.vercel.app/smoothr-sdk.mjs" data-store-id="store_test"></script><form data-smoothr="auth-form"></form>`;
+    globalThis.getCachedBrokerBase = () => 'https://smoothr.vercel.app';
   globalThis.ensureConfigLoaded = () => Promise.resolve();
   const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true, json: async () => ({ ok: true }) });
 
@@ -354,13 +354,13 @@ describe('send-reset auto-forward flag', () => {
 describe('recovery-bridge auto-forward', () => {
   it('auto-forwards when auto=1 and host matches', () => {
     vi.resetModules();
-    const replace = vi.fn();
-    const orig = window.location;
-    delete window.location;
-    // @ts-ignore
-    window.location = { hash: '#access_token=abc', host: orig.host, replace };
+      const replace = vi.fn();
+      const orig = window.location;
+      delete window.location;
+      // @ts-ignore
+      window.location = { hash: '#access_token=abc', host: orig.host, replace };
     const props = {
-      redirect: 'https://broker.example/reset',
+        redirect: 'https://smoothr.vercel.app/reset',
       auto: '1',
       brokerHost: window.location.host,
       storeName: 'Test Store',
@@ -373,7 +373,7 @@ describe('recovery-bridge auto-forward', () => {
         window.location.replace(dest);
       }
     }
-    expect(replace).toHaveBeenCalledWith('https://broker.example/reset#access_token=abc');
+      expect(replace).toHaveBeenCalledWith('https://smoothr.vercel.app/reset#access_token=abc');
     window.location = orig;
   });
 
@@ -385,7 +385,7 @@ describe('recovery-bridge auto-forward', () => {
     // @ts-ignore
     window.location = { hash: '#access_token=abc', host: orig.host, replace };
     const props = {
-      redirect: 'https://broker.example/reset',
+        redirect: 'https://smoothr.vercel.app/reset',
       auto: null,
       brokerHost: window.location.host,
       storeName: 'Demo Store',
@@ -405,7 +405,7 @@ describe('recovery-bridge auto-forward', () => {
     }
     expect(replace).not.toHaveBeenCalled();
     const anchor = document.querySelector('a');
-    expect(anchor?.getAttribute('href')).toBe('https://broker.example/reset#access_token=abc');
+      expect(anchor?.getAttribute('href')).toBe('https://smoothr.vercel.app/reset#access_token=abc');
     expect(anchor?.textContent).toBe('Continue to reset on Demo Store');
     document.body.innerHTML = '';
     window.location = orig;

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,5 +1,8 @@
 // vitest.setup.ts
-import { vi } from 'vitest';
+import { vi, afterEach } from 'vitest';
+
+let originalConfig: any;
+let originalDocument: any;
 
 console.log('vitest.setup.ts ran');
 
@@ -92,6 +95,8 @@ if (!(globalThis as any).__smoothrSetupApplied) {
     debug: true,
     // you can add platform, currency, etc. here if needed
   };
+  originalConfig = { ...(globalThis as any).SMOOTHR_CONFIG };
+  originalDocument = (globalThis as any).document;
 
   (globalThis as any).Smoothr = (globalThis as any).Smoothr || {};
   (globalThis as any).Smoothr.config = {
@@ -128,3 +133,9 @@ if (!(globalThis as any).__smoothrSetupApplied) {
     injectPreconnects();
   }
 }
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  (globalThis as any).document = originalDocument;
+  (globalThis as any).SMOOTHR_CONFIG = { ...originalConfig };
+});


### PR DESCRIPTION
## Summary
- reset global document and config between tests
- ensure document stubs are restored after tests
- update password-reset tests to use smoothr.vercel.app

## Testing
- `npm test` *(fails: Config fetch failed; aborting feature initialization)*

------
https://chatgpt.com/codex/tasks/task_e_68b90d9fac28832585c1dd97f51ca0a8