### PR TITLE
refactor: use supabase mock util in sdk tests

### DIFF
--- a/storefronts/tests/sdk/account-access.test.js
+++ b/storefronts/tests/sdk/account-access.test.js
@@ -1,13 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { createClientMock, currentSupabaseMocks } from "../utils/supabase-mock";
+import {
+  createClientMock as createClientMockUtil,
+  currentSupabaseMocks,
+} from "../utils/supabase-mock";
 import { createDomStub } from "../utils/dom-stub";
 
 var getUserMock;
-var createClientMock;
 
 vi.mock("@supabase/supabase-js", () => {
   getUserMock = vi.fn();
-  createClientMock = vi.fn(() => ({
+  const createClientMock = vi.fn(() => ({
     auth: {
       getUser: getUserMock,
       signOut: vi.fn(),
@@ -81,7 +83,7 @@ describe("account access trigger", () => {
 
     beforeEach(async () => {
       vi.resetModules();
-      createClientMock();
+      createClientMockUtil();
       const { getUserMock } = currentSupabaseMocks();
       authHelpers = await import("../../../supabase/authHelpers.js");
       vi
@@ -107,7 +109,7 @@ describe("account access trigger", () => {
   describe("dispatches auth:open event for anonymous users", () => {
     beforeEach(async () => {
       vi.resetModules();
-      createClientMock();
+      createClientMockUtil();
       const { getUserMock } = currentSupabaseMocks();
       getUserMock.mockResolvedValueOnce({ data: { user: null } });
       authHelpers = await import("../../../supabase/authHelpers.js");
@@ -133,7 +135,7 @@ describe("account access trigger", () => {
 
   it("dispatches auth:close on sign-out", async () => {
     vi.resetModules();
-    createClientMock();
+    createClientMockUtil();
     const { getUserMock } = currentSupabaseMocks();
     getUserMock.mockResolvedValueOnce({ data: { user: null } });
     const auth = await import("../../features/auth/index.js");

--- a/storefronts/tests/sdk/login-dataset-immutable.test.js
+++ b/storefronts/tests/sdk/login-dataset-immutable.test.js
@@ -1,16 +1,18 @@
 // [Codex Fix] New test for immutable dataset
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { createClientMock, currentSupabaseMocks } from "../utils/supabase-mock";
+import {
+  createClientMock as createClientMockUtil,
+  currentSupabaseMocks,
+} from "../utils/supabase-mock";
 import { createDomStub } from "../utils/dom-stub";
 
 var signInMock;
 var getUserMock;
-var createClientMock;
 
 vi.mock("@supabase/supabase-js", () => {
   signInMock = vi.fn();
   getUserMock = vi.fn(() => Promise.resolve({ data: { user: null } }));
-  createClientMock = vi.fn(() => ({
+  const createClientMock = vi.fn(() => ({
     auth: {
       getUser: getUserMock,
       signInWithPassword: signInMock,
@@ -43,7 +45,7 @@ describe("login with immutable dataset", () => {
     let realDocument;
     beforeEach(async () => {
       vi.resetModules();
-      createClientMock();
+      createClientMockUtil();
       ({ signInMock, getUserMock } = currentSupabaseMocks());
       getUserMock.mockResolvedValue({ data: { user: null } });
       clickHandler = undefined;

--- a/storefronts/tests/sdk/login.test.js
+++ b/storefronts/tests/sdk/login.test.js
@@ -5,14 +5,13 @@ import { createDomStub } from "../utils/dom-stub";
 
 var signInMock;
 var getUserMock;
-var createClientMock;
 var getSessionMock;
 
 vi.mock("@supabase/supabase-js", () => {
   signInMock = vi.fn();
   getUserMock = vi.fn(() => Promise.resolve({ data: { user: null } }));
   getSessionMock = vi.fn(() => Promise.resolve({ data: { session: {} }, error: null }));
-  createClientMock = vi.fn(() => ({
+  const createClientMock = vi.fn(() => ({
     auth: {
       getUser: getUserMock,
       signInWithPassword: signInMock,


### PR DESCRIPTION
## Summary
- use createClientMockUtil helper in sdk test suites
- clean up redundant createClientMock variables

## Testing
- `npm test -- tests/sdk/login.test.js tests/sdk/login-dataset-immutable.test.js tests/sdk/account-access.test.js` *(fails: Config fetch failed; aborting feature initialization)*

------
https://chatgpt.com/codex/tasks/task_e_68b916d0b8748325986bffdf5be7b7d0