### PR TITLE
chore: stub DOM methods in vitest setup

### DIFF
--- a/storefronts/vitest.setup.js
+++ b/storefronts/vitest.setup.js
@@ -19,9 +19,29 @@ if (typeof globalThis.document === "undefined") {
   globalThis.document = {
     addEventListener: vi.fn(),
     querySelectorAll: vi.fn(() => []),
+    getElementById: vi.fn(() => null),
+    querySelector: vi.fn(() => null),
+    createElement: vi.fn(() => ({
+      style: {},
+      setAttribute: vi.fn(),
+      appendChild: vi.fn(),
+    })),
     body: {},
     dispatchEvent: vi.fn(),
   };
+}
+if (!globalThis.document.getElementById) {
+  globalThis.document.getElementById = vi.fn(() => null);
+}
+if (!globalThis.document.querySelector) {
+  globalThis.document.querySelector = vi.fn(() => null);
+}
+if (!globalThis.document.createElement) {
+  globalThis.document.createElement = vi.fn(() => ({
+    style: {},
+    setAttribute: vi.fn(),
+    appendChild: vi.fn(),
+  }));
 }
 // Stub the <script> tag dataset so loadConfig gets a storeId in tests
 if (typeof document !== 'undefined' && !document.currentScript) {


### PR DESCRIPTION
## Summary
- stub `getElementById`, `querySelector`, and `createElement` on the test `document` object
- ensure DOM stubs exist even when a real `document` is present

## Testing
- `npm --workspace storefronts test` *(fails: 18 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b91db32c8c8325b8a44051b387dfcb