### PR TITLE
chore: ensure document stubs expose getElementById in SDK tests

### DIFF
--- a/storefronts/tests/sdk/auth-trigger.test.js
+++ b/storefronts/tests/sdk/auth-trigger.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createDomStub } from '../utils/dom-stub';
 
 describe('auth triggers', () => {
   let win, doc, mod;
@@ -9,13 +10,12 @@ describe('auth triggers', () => {
       location: { origin: 'https://example.com' },
       dispatchEvent: vi.fn(),
     };
-    doc = {
+    doc = createDomStub({
       readyState: 'complete',
-      addEventListener: vi.fn(),
       dispatchEvent: vi.fn(),
       querySelector: vi.fn(() => null),
       querySelectorAll: vi.fn(() => []),
-    };
+    });
     global.window = win;
     global.document = doc;
     mod = await import('../../features/auth/init.js');

--- a/storefronts/tests/sdk/dom-mutation.test.js
+++ b/storefronts/tests/sdk/dom-mutation.test.js
@@ -96,6 +96,16 @@ it('routes submit on reset-only form to password-reset handler', async () => {
           if (sel === '[data-smoothr="auth-pop-up"]') return {};
           return null;
         }),
+        getElementById: vi.fn((id) =>
+          id === "smoothr-sdk"
+            ? {
+                dataset: { storeId: STORE_ID },
+                getAttribute: vi.fn((name) =>
+                  name === "data-store-id" ? STORE_ID : null
+                ),
+              }
+            : null
+        ),
         dispatchEvent() {
           return true;
         },

--- a/storefronts/tests/sdk/global-auth.test.js
+++ b/storefronts/tests/sdk/global-auth.test.js
@@ -47,6 +47,11 @@ describe("global auth", () => {
       }
       return [];
     });
+    doc.querySelector = vi.fn(() => null);
+    doc.getElementById = vi.fn(() => ({
+      dataset: { storeId: 'store_test' },
+      getAttribute: vi.fn(() => 'store_test')
+    }));
     global.document = doc;
   });
 


### PR DESCRIPTION
## Summary
- use `createDomStub` in `auth-trigger` tests
- extend document stub in `dom-mutation` tests with `getElementById`
- add `getElementById` and `querySelector` to global auth test

## Testing
- `npm test` *(fails: 10 failed, 203 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b91f40e75883259a0aa6b4dd8f1813