### PR TITLE
Bind Google login buttons on mutations

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -946,6 +946,10 @@ export async function init(options = {}) {
     googleClickHandler = async (e) => {
       try { e?.preventDefault?.(); } catch {}
       await signInWithGoogle();
+      const ev = typeof w.CustomEvent === 'function'
+        ? new w.CustomEvent('smoothr:login')
+        : { type: 'smoothr:login' };
+      (w.document || globalThis.document)?.dispatchEvent?.(ev);
     };
 
     appleClickHandler = async (e) => {
@@ -1157,7 +1161,25 @@ export async function init(options = {}) {
       } catch {}
     };
 
-    mutationCallback = () => { try { bindAuthElements(w.document || globalThis.document); } catch {} };
+    mutationCallback = (records = []) => {
+      const list = Array.isArray(records) ? records : [];
+      try {
+        for (const r of list) {
+          r?.addedNodes?.forEach?.(n => {
+            if (!n || n.nodeType !== 1) return;
+            if (n.matches?.('[data-smoothr="login-google"]')) {
+              if (!_bound.has(n) && typeof n.addEventListener === 'function') {
+                try { n.__smoothrAuthBound = true; } catch {}
+                n.addEventListener('click', googleClickHandler, { passive: false });
+                _bound.add(n);
+              }
+            }
+            try { bindAuthElements(n); } catch {}
+          });
+        }
+      } catch {}
+      try { bindAuthElements(w.document || globalThis.document); } catch {}
+    };
 
     api.clickHandler = clickHandler;
     api.googleClickHandler = googleClickHandler;

--- a/storefronts/tests/sdk/dom-mutation.test.js
+++ b/storefronts/tests/sdk/dom-mutation.test.js
@@ -212,7 +212,7 @@ it('routes submit on reset-only form to password-reset handler', async () => {
 
     forms.push(form);
     elements.push(btn);
-    mutationCallback();
+    mutationCallback([{ addedNodes: [btn] }]);
     expect(btn.addEventListener).toHaveBeenCalled();
 
     const user = { id: "1", email: "user@example.com" };
@@ -262,7 +262,7 @@ it('routes submit on reset-only form to password-reset handler', async () => {
     await flushPromises();
     forms.push(form);
     elements.push(btn);
-    mutationCallback();
+    mutationCallback([{ addedNodes: [btn] }]);
     expect(btn.addEventListener).toHaveBeenCalled();
 
     const user = { id: "2", email: "new@example.com" };
@@ -302,10 +302,13 @@ it('routes submit on reset-only form to password-reset handler', async () => {
       await auth.init({ supabase: createClientMock() });
     await flushPromises();
     elements.push(btn);
-    mutationCallback();
+    mutationCallback([{ addedNodes: [btn] }]);
     expect(btn.addEventListener).toHaveBeenCalled();
 
     await clickHandler({ preventDefault: () => {}, target: btn });
+    await flushPromises();
+    const types = global.document.dispatchEvent.mock.calls.map(c => c[0]?.type);
+    expect(types).toContain("smoothr:login");
     expect(global.window.location.replace).toHaveBeenCalledWith(
       'https://smoothr.vercel.app/api/auth/oauth-start?provider=google&store_id=test-store&orig='
     );


### PR DESCRIPTION
## Summary
- ensure Google login buttons bind on mutation
- emit login event after Google handler runs
- test Google login binding on dynamic elements

## Testing
- `npm test` *(fails: expected "spy" to be called at least once)*

------
https://chatgpt.com/codex/tasks/task_e_68b92f88869c83259516e148db60b2cd