### PR TITLE
Prevent login attempt with invalid email

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -775,7 +775,10 @@ export async function init(options = {}) {
       if (action === 'login') {
         const email = container?.querySelector('[data-smoothr="email"]')?.value ?? '';
         const pwd = container?.querySelector('[data-smoothr="password"]')?.value ?? '';
-        if (!emailRE.test(email)) return;
+        if (!emailRE.test(email)) {
+          emitAuthError('INVALID_EMAIL');
+          return;
+        }
         let userId = null;
         try {
           const { data, error } = await c.auth.signInWithPassword({ email, password: pwd });


### PR DESCRIPTION
## Summary
- Guard login against invalid email addresses and emit an auth error before attempting sign-in
- Test that login handler skips sign-in when email fails validation

## Testing
- `npm test` *(fails: expected spy to be called at least once)*

------
https://chatgpt.com/codex/tasks/task_e_68b932e0dda08325b5c0169e3b8457f2