### PR TITLE
Handle auth container fallback for submit/keydown

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -1066,7 +1066,10 @@ export async function init(options = {}) {
 
     // document submit (capture) — NOW: supports FORM or DIV containers
     docSubmitHandler = async (e) => {
-      const container = resolveAuthContainer(e?.target);
+      let container = resolveAuthContainer(e?.target);
+      if (!container) {
+        container = resolveAuthContainer(e?.currentTarget);
+      }
       if (!container) {
         emitAuthError('NO_CONTAINER');
         return;
@@ -1107,7 +1110,8 @@ export async function init(options = {}) {
       try {
         if (e?.key !== 'Enter' && e?.key !== ' ') return;
         const el = (globalThis.document || {}).activeElement;
-        const container = resolveAuthContainer(el);
+        let container = resolveAuthContainer(el);
+        if (!container) container = resolveAuthContainer(el?.form);
         if (!container) return;
         const tag = (el?.tagName || '').toUpperCase();
         if (tag === 'TEXTAREA') return;

--- a/storefronts/tests/features/auth-handlers.test.js
+++ b/storefronts/tests/features/auth-handlers.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Verify document-level auth handlers handle nested controls
+
+describe('auth document handlers', () => {
+  it('submits login from nested control', async () => {
+    const mod = await import('../../features/auth/init.js');
+    const { init } = mod;
+    const supabase = (globalThis.__smoothrTest || {}).supabase;
+
+    document.body.innerHTML = `
+      <form data-smoothr="auth-form">
+        <div>
+          <input data-smoothr="email" value="user@example.com" />
+          <input data-smoothr="password" value="strongpass1" />
+          <button type="button" data-smoothr="login">Login</button>
+        </div>
+      </form>
+    `;
+
+    await init({ storeId: '1', supabase });
+
+    const pwd = document.querySelector('[data-smoothr="password"]');
+    pwd.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    await new Promise(r => setTimeout(r, 0));
+
+    const mocks = (globalThis.__smoothrTest || {}).mocks;
+    expect(mocks.signInMock).toHaveBeenCalled();
+  });
+
+});
+


### PR DESCRIPTION
## Summary
- fallback to currentTarget and activeElement.form when resolving auth container
- cover login via nested control submission

## Testing
- `npm --workspace storefronts test tests/features/auth-handlers.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b939fdee188325a09f41556921e31d