### PR TITLE
feat(auth): allow test supabase override

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -769,8 +769,15 @@ export async function init(options = {}) {
         return;
       }
       const action = el?.getAttribute?.('data-smoothr');
-      const testClient = (typeof window !== 'undefined' && window.__SMOOTHR_TEST_SUPABASE__) || null;
+      const testClient =
+        (globalThis.__smoothrTest?.supabase) ||
+        ((typeof window !== 'undefined' && window.__SMOOTHR_TEST_SUPABASE__) || null);
       const c = testClient || await resolveSupabase();
+      if (testClient) {
+        const s = w.Smoothr || globalThis.Smoothr || {};
+        w.Smoothr = globalThis.Smoothr = s;
+        s.__supabase = testClient;
+      }
       if (!action || !c?.auth) return;
       if (action === 'login') {
         const email = container?.querySelector('[data-smoothr="email"]')?.value ?? '';

--- a/storefronts/tests/features/auth-supabase-override.test.js
+++ b/storefronts/tests/features/auth-supabase-override.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest';
+import { __setSupabaseReadyForTests } from '../../smoothr-sdk.mjs';
+
+describe('auth.init uses injected supabase client', () => {
+  it('invokes signInWithPassword from injected client', async () => {
+    const { supabase, mocks } = globalThis.__smoothrTest || {};
+    __setSupabaseReadyForTests(supabase);
+    globalThis.fetch = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }));
+
+    const auth = await import('../../features/auth/index.js');
+    await auth.init({ storeId: '1' });
+
+    document.body.innerHTML = `
+      <div data-smoothr="auth-form">
+        <input data-smoothr="email" value="user@example.com" />
+        <input data-smoothr="password" value="Passw0rd!" />
+        <div data-smoothr="login"></div>
+      </div>
+    `;
+    const loginEl = document.querySelector('[data-smoothr="login"]');
+    await auth.clickHandler({ preventDefault: () => {}, target: loginEl });
+
+    expect(mocks.signInMock).toHaveBeenCalledTimes(1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- allow auth click handler to use global test Supabase client
- add test verifying test client injection with __setSupabaseReadyForTests

## Testing
- `npm test` *(fails: Config fetch failed; aborting feature initialization)*
- `npx vitest run --config storefronts/vitest.config.ts storefronts/tests/features/auth-supabase-override.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b94658722c8325b44d89a58e14276c