### PR TITLE
Use WeakSet to track bound auth controls

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -469,7 +469,6 @@ export function bindAuthElements(root = globalThis.document) {
   if (!root?.querySelectorAll) return;
   const attach = (el, handler) => {
     if (!_bound.has(el) && typeof el.addEventListener === 'function') {
-      try { el.__smoothrAuthBound = true; } catch {}
       el.addEventListener('click', handler, { passive: false });
       _bound.add(el);
     }
@@ -1209,7 +1208,7 @@ export async function init(options = {}) {
         const el = e?.target?.closest?.(ACTION_SELECTORS);
         if (!el) return;
         // 1) If element already has a direct listener, skip (avoid double handling).
-        if (el.__smoothrAuthBound === true) return;
+        if (_bound.has(el)) return;
         // 2) If this event already triggered our fallback higher up, skip.
         if (e.__smoothrActionHandled === true) return;
         e.__smoothrActionHandled = true;
@@ -1232,7 +1231,6 @@ export async function init(options = {}) {
             if (!n || n.nodeType !== 1) return;
             if (n.matches?.('[data-smoothr="login-google"]')) {
               if (!_bound.has(n) && typeof n.addEventListener === 'function') {
-                try { n.__smoothrAuthBound = true; } catch {}
                 n.addEventListener('click', googleClickHandler, { passive: false });
                 _bound.add(n);
               }
@@ -1270,7 +1268,7 @@ export async function init(options = {}) {
         }
         doc.addEventListener('submit', docSubmitHandler, true);
         doc.addEventListener('keydown', docKeydownHandler, { capture: true, passive: false });
-        try { doc.__smoothrAuthBound = true; } catch {}
+        _bound.add(doc);
       }
     } catch {}
     log('auth init complete');

--- a/storefronts/tests/sdk/login-dataset-immutable.test.js
+++ b/storefronts/tests/sdk/login-dataset-immutable.test.js
@@ -115,6 +115,8 @@ describe("login with immutable dataset", () => {
       addEventListener: vi.fn(),
       querySelectorAll: vi.fn((sel) => {
         if (sel.includes('[data-smoothr="login"]')) return [loginTrigger];
+        if (sel.includes('[data-smoothr="login-google"]') && sel.includes('[data-smoothr="password-reset"]'))
+          return [resetTrigger, googleTrigger];
         if (sel.includes('[data-smoothr="password-reset"]')) return [resetTrigger];
         if (sel.includes('[data-smoothr="login-google"]')) return [googleTrigger];
         if (sel.includes('[data-smoothr="auth-form"]')) return [form];
@@ -143,9 +145,10 @@ describe("login with immutable dataset", () => {
     expect(signInMock).toHaveBeenCalled();
   });
 
-  it("binds reset and oauth triggers when dataset is immutable", async () => {
+  it("binds login, reset and oauth triggers when dataset is immutable", async () => {
     await auth.init();
     await flushPromises();
+    expect(loginTrigger.addEventListener).toHaveBeenCalled();
     expect(resetTrigger.addEventListener).toHaveBeenCalled();
     expect(googleTrigger.addEventListener).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- avoid mutating element datasets when binding auth handlers by tracking bound nodes in a `WeakSet`
- test that login, reset and OAuth controls still bind when their `dataset` objects are frozen

## Testing
- `npm --workspace storefronts test tests/sdk/login-dataset-immutable.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b95002840c832591a78f0cb4493426