### PR TITLE
Auth: Update callback page

### DIFF
--- a/smoothr/next.config.mjs
+++ b/smoothr/next.config.mjs
@@ -5,6 +5,17 @@ const nextConfig = {
   experimental: {
     externalDir: true,
   },
+  async headers() {
+    return [
+      {
+        source: '/auth/callback',
+        headers: [
+          { key: 'Cross-Origin-Opener-Policy', value: 'unsafe-none' },
+          { key: 'Cross-Origin-Embedder-Policy', value: 'unsafe-none' },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/smoothr/pages/auth/callback.tsx
+++ b/smoothr/pages/auth/callback.tsx
@@ -1,70 +1,75 @@
-// Minimal OAuth callback handler with zero UI.
+import type { GetServerSideProps } from 'next';
+import { createHmac, randomUUID } from 'crypto';
+import { getSupabaseAdmin } from '../../lib/supabaseAdmin';
 
-export function handleAuthCallback(w = window) {
-  const hash = w.location?.hash || '';
-  const params = new URLSearchParams(hash.startsWith('#') ? hash.slice(1) : hash);
-  const access_token = params.get('access_token') || '';
-  try { w.history?.replaceState?.(null, '', w.location?.pathname + w.location?.search); } catch {}
-
-  let store_id: string | null = null;
-  let orig: string | null = null;
-  try {
-    const cookie = w.document?.cookie || '';
-    const match = cookie.split('; ').find(c => c.startsWith('smoothr_oauth_ctx='));
-    if (match) {
-      const value = decodeURIComponent(match.split('=')[1] || '');
-      const parsed = JSON.parse(value);
-      store_id = parsed.store_id || null;
-      orig = parsed.orig || null;
-    }
-  } catch {}
-
-  if (w.opener) {
-    if (access_token && store_id && orig) {
-      try {
-        w.opener.postMessage(
-          { type: 'smoothr:oauth', ok: true, access_token, store_id },
-          orig,
-        );
-      } catch {}
-    }
-    try { w.close(); } catch {}
-    return { ok: !!(access_token && store_id && orig) };
-  }
-
-  if (access_token && store_id) {
-    try { w.document?.documentElement && (w.document.documentElement.style.visibility = 'hidden'); } catch {}
-    const form = w.document.createElement('form');
-    form.method = 'POST';
-    form.action = '/api/auth/session-sync';
-    form.style.display = 'none';
-    const f1 = w.document.createElement('input');
-    f1.type = 'hidden';
-    f1.name = 'store_id';
-    f1.value = store_id;
-    form.appendChild(f1);
-    const f2 = w.document.createElement('input');
-    f2.type = 'hidden';
-    f2.name = 'access_token';
-    f2.value = access_token;
-    form.appendChild(f2);
-    w.document.body.appendChild(form);
-    try { form.submit(); } catch {}
-    return { ok: true };
-  }
-
-  try { w.location?.replace?.('/'); } catch {}
-  return { ok: false };
+interface Row {
+  metadata: { redirect_to: string };
+  hmac: string;
+  code_verifier: string;
 }
 
-export default function OAuthCallbackPage() {
+const HMAC_SECRET = process.env.HMAC_SECRET || '';
+
+function sign(data: string) {
+  return createHmac('sha256', HMAC_SECRET).update(data).digest('base64');
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ query, res }) => {
+  const code = typeof query.code === 'string' ? query.code : '';
+  const state = typeof query.state === 'string' ? query.state : '';
+  if (!code || !state) {
+    res.statusCode = 400;
+    res.end('Missing code or state');
+    return { props: {} };
+  }
+
+  const supabase = getSupabaseAdmin();
+  const { data: row } = await supabase
+    .from('auth_state_management')
+    .select('metadata,hmac,code_verifier')
+    .eq('state', state)
+    .maybeSingle<Row>();
+  if (!row || sign(JSON.stringify(row.metadata)) !== row.hmac) {
+    res.statusCode = 400;
+    res.end('Invalid state');
+    return { props: {} };
+  }
+
+  const { data: sessData, error } = await supabase.auth.exchangeCodeForSession({
+    authCode: code,
+    codeVerifier: row.code_verifier,
+  });
+  if (error || !sessData.session) {
+    res.statusCode = 400;
+    res.end('Exchange failed');
+    return { props: {} };
+  }
+
+  const exchangeCode = randomUUID();
+  await supabase.from('auth_state_management').insert({
+    code: exchangeCode,
+    session: sessData.session,
+    type: 'exchange',
+    expires_at: new Date(Date.now() + 60_000).toISOString(),
+    exchange_used: false,
+  });
+  await supabase
+    .from('auth_state_management')
+    .update({ used: true })
+    .eq('state', state);
+
+  const redirect = row.metadata.redirect_to;
+  const origin = new URL(redirect).origin;
+  const oj = JSON.stringify(origin);
+  const rj = JSON.stringify(redirect);
+  const cj = JSON.stringify(exchangeCode);
+
+  res.setHeader('Content-Type', 'text/html; charset=utf-8');
+  const body = `<!DOCTYPE html><html><body><div class="spinner">Logging in...</div><script>(function(){try{history.replaceState(null,'','/auth/callback');var t=${oj};var r=${rj};var c=${cj};if(window.opener){window.opener.postMessage({type:'smoothr:auth',code:c},t);window.close();}else{location.replace(r);}}catch(e){}})();</script></body></html>`;
+  res.end(body);
+  return { props: {} };
+};
+
+export default function Callback() {
   return null;
 }
-
-if (typeof document !== 'undefined') {
-  try { document.documentElement.style.visibility = 'hidden'; } catch {}
-}
-if (typeof window !== 'undefined') {
-  try { handleAuthCallback(window); } catch {}
-}
-


### PR DESCRIPTION
## Summary
- overhaul OAuth callback handler to verify state, exchange auth code for session, and post one-time code to opener
- disable COOP/COEP headers on `/auth/callback`

## Testing
- `npm test` *(fails: w.open is not a function, signInWithGooglePopup missing)*
- `npm run lint` *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68ba5a3ff2708325b02c813bf3884a91