### PR TITLE
Auth: Update reset page

### DIFF
--- a/smoothr/pages/auth/set-password.tsx
+++ b/smoothr/pages/auth/set-password.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import Head from 'next/head';
+import type { GetServerSideProps } from 'next';
 import { createClient } from '@supabase/supabase-js';
 import { loadStoreTheme } from '../../lib/branding';
 import type { Theme } from '../../lib/branding';
@@ -9,61 +10,80 @@ const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
 );
 
-export default function SetPasswordPage() {
+interface Props {
+  accessToken: string;
+  refreshToken: string;
+  storeId: string;
+  redirectTo: string | null;
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async ({ query }) => {
+  const type = typeof query.type === 'string' ? query.type : '';
+  const tokenHash = typeof query.token_hash === 'string' ? query.token_hash : '';
+  const storeId = typeof query.store_id === 'string' ? query.store_id : '';
+  let accessToken = '';
+  let refreshToken = '';
+  let redirectTo: string | null = null;
+
+  if (type === 'recovery' && tokenHash) {
+    const admin = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    );
+    try {
+      const { data } = await (admin as any).auth.admin.generateLink({
+        type: 'recovery',
+        token_hash: tokenHash,
+      });
+      const link = data?.properties?.action_link || '';
+      const url = new URL(link);
+      accessToken = url.searchParams.get('access_token') || '';
+      refreshToken = url.searchParams.get('refresh_token') || '';
+    } catch {}
+    try {
+      const { data: row } = await admin
+        .from('auth_state_management')
+        .select('metadata')
+        .eq('token_hash', tokenHash)
+        .maybeSingle();
+      redirectTo = (row?.metadata as any)?.redirect_to || null;
+    } catch {}
+  }
+
+  return {
+    props: { accessToken, refreshToken, storeId, redirectTo },
+  };
+};
+
+export default function SetPasswordPage({ accessToken, refreshToken, storeId, redirectTo }: Props) {
   const [email, setEmail] = useState<string | null>(null);
   const [pwd, setPwd] = useState('');
   const [pwd2, setPwd2] = useState('');
   const [msg, setMsg] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
-  const [ready, setReady] = useState(false);
   const [theme, setTheme] = useState<Theme | null>(null);
 
-  // NEW: hydrate session from recovery hash if present, then strip hash
   useEffect(() => {
     let mounted = true;
     (async () => {
-      try {
-        const hash = typeof window !== 'undefined' ? window.location.hash || '' : '';
-        const params = new URLSearchParams(hash.startsWith('#') ? hash.slice(1) : hash);
-        const access_token = params.get('access_token');
-        const refresh_token = params.get('refresh_token');
-
-        if (access_token && refresh_token) {
-          await supabase.auth.setSession({ access_token, refresh_token });
-          if (typeof history !== 'undefined' && history.replaceState) {
-            history.replaceState(null, '', window.location.pathname);
-          } else {
-            window.location.hash = '';
-          }
-        }
-      } catch (e) {
-        // eslint-disable-next-line no-console
-        console.warn('[set-password] setSession from hash failed', e);
-      } finally {
-        // load email for display once session (if any) is ready
-        const { data } = await supabase.auth.getUser();
-        if (mounted) {
-          setEmail(data?.user?.email ?? null);
-          const storeId =
-            (data?.user as any)?.user_metadata?.store_id ||
-            (window as any).__SMOOTHR_STORE_ID__ ||
-            '';
-          if (storeId) {
-            try {
-              const t = await loadStoreTheme(storeId);
-              setTheme(t);
-            } catch {
-              // ignore theme load errors
-            }
-          }
-          setReady(true);
+      if (accessToken && refreshToken) {
+        await supabase.auth.setSession({ access_token: accessToken, refresh_token: refreshToken });
+      }
+      const { data } = await supabase.auth.getUser();
+      if (mounted) {
+        setEmail(data?.user?.email ?? null);
+        if (storeId) {
+          try {
+            const t = await loadStoreTheme(storeId);
+            setTheme(t);
+          } catch {}
         }
       }
     })();
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [accessToken, refreshToken, storeId]);
 
   const onSubmit = useCallback(
     async (e: React.FormEvent) => {
@@ -72,96 +92,38 @@ export default function SetPasswordPage() {
       if (pwd !== pwd2) return setMsg('Passwords do not match.');
       setBusy(true);
       setMsg(null);
-
       try {
-        // Require an active session (either from hash we just set, or pre-existing)
-        const { data: sess0 } = await supabase.auth.getSession();
-        if (!sess0?.session) {
-          setMsg('Recovery link is missing or expired. Please request a new link.');
-          setBusy(false);
-          return;
-        }
-
         const { error } = await supabase.auth.updateUser({ password: pwd });
         if (error) throw error;
-
-        // Pull store_id from session metadata (bridge removed it from URL by design)
-        const { data: sess } = await supabase.auth.getSession();
-        const token = sess?.session?.access_token || '';
-        const storeId =
-          (sess?.session?.user as any)?.user_metadata?.store_id ||
-          (window as any).__SMOOTHR_STORE_ID__ || '';
-
-        if (!token) {
-          setMsg('Something went wrong (no session). Please request a new link.');
-          setBusy(false);
-          return;
+        const dest = redirectTo || '/';
+        if (typeof window !== 'undefined') {
+          window.location.replace(dest);
         }
-        if (!storeId) {
-          setMsg('Something went wrong (no store). Please contact support.');
-          setBusy(false);
-          return;
-        }
-
-        // Session handoff: POST to /api/auth/session-sync (303 to store)
-        const form = document.createElement('form');
-        form.method = 'POST';
-        form.action = '/api/auth/session-sync';
-        form.enctype = 'application/x-www-form-urlencoded';
-        form.target = '_self';
-
-        const mk = (name: string, value: string) => {
-          const input = document.createElement('input');
-          input.type = 'hidden';
-          input.name = name;
-          input.value = value;
-          form.appendChild(input);
-        };
-
-        mk('store_id', storeId);
-        mk('access_token', token);
-        document.body.appendChild(form);
-        form.submit();
-        return;
       } catch (err: any) {
-        // eslint-disable-next-line no-console
-        console.error('[set-password] error', err);
         setMsg(err?.message || 'Something went wrong');
         setBusy(false);
       }
     },
-    [pwd, pwd2],
+    [pwd, pwd2, redirectTo],
   );
 
   return (
     <>
       <Head>
         <title>Set your password</title>
-        {theme?.customCssUrl ? <link rel="stylesheet" href={theme.customCssUrl} /> : null}
-        {theme ? (
+        {theme && (
           <style>{`
-            :root {
-              --brand-bg: ${theme.bg};
-              --brand-text: ${theme.text};
-              --brand-muted: ${theme.muted};
-              --brand-primary: ${theme.primary};
-              --brand-btn-radius: ${theme.btnRadius}px;
-              --brand-font: ${theme.fontFamily};
-            }
-            body { background: var(--brand-bg); font-family: var(--brand-font); color: var(--brand-text); }
-            .card { max-width: 440px; margin: 64px auto; padding: 24px; border: 1px solid #e5e5e5; border-radius: 16px; background: #fff; }
-            .btn { padding: 12px 16px; border-radius: var(--brand-btn-radius); border: 1px solid #d0d0d0; background: var(--brand-primary); color: #fff; text-align: center; cursor: pointer; }
-            .btn[aria-disabled="true"] { opacity: .6; cursor: not-allowed; }
-            .logo { max-width: 180px; display:block; margin: 0 auto 16px; }
-            .hint { color: var(--brand-muted); }
-            input { padding: 10px 12px; border: 1px solid #ddd; border-radius: 10px; }
+            body{background:${theme.bg};color:${theme.text};font-family:${theme.fontFamily}}
+            .card{max-width:440px;margin:64px auto;padding:24px;background:#fff;border:1px solid #e5e5e5;border-radius:16px}
+            .btn{padding:12px 16px;border-radius:${theme.btnRadius}px;border:1px solid #d0d0d0;background:${theme.primary};color:#fff;text-align:center;cursor:pointer}
+            .logo{max-width:180px;display:block;margin:0 auto 16px}
+            .hint{color:${theme.muted}}
+            input{padding:10px 12px;border:1px solid #ddd;border-radius:10px}
           `}</style>
-        ) : null}
+        )}
       </Head>
       <main className="card">
-        {theme?.logoUrl
-          ? <img className="logo" src={theme.logoUrl} alt={email || 'Store logo'} />
-          : <div style={{fontWeight:700, fontSize:18, textAlign:'center', marginBottom:16}}>{email ? '' : 'Reset your password'}</div>}
+        {theme?.logoUrl && <img className="logo" src={theme.logoUrl} alt={email || 'Store logo'} />}
         <h1 style={{ fontSize: 22, fontWeight: 700, marginBottom: 8 }}>Set your password</h1>
         <p className="hint" style={{ marginBottom: 16 }}>
           {email ? <>For <strong>{email}</strong></> : 'Complete your password reset.'}
@@ -182,26 +144,16 @@ export default function SetPasswordPage() {
               onChange={(e) => setPwd2(e.target.value)}
               required
             />
-            <div
-              role="button"
-              tabIndex={0}
-              onClick={onSubmit as any}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') onSubmit(e as any);
-              }}
-              className="btn"
-              aria-disabled={!ready}
-            >
-              {busy ? 'Saving…' : ready ? 'Save password' : 'Loading…'}
-            </div>
+            {busy ? (
+              <div className="spinner" style={{ textAlign: 'center' }}>Saving...</div>
+            ) : (
+              <button type="submit" className="btn">Save password</button>
+            )}
           </div>
         </form>
-        {msg && (
-          <p style={{ color: 'crimson', marginTop: 12 }}>
-            {msg}
-          </p>
-        )}
+        {msg && <p style={{ color: 'crimson', marginTop: 12 }}>{msg}</p>}
       </main>
     </>
   );
 }
+


### PR DESCRIPTION
## Summary
- handle recovery tokens server-side and hydrate session before render
- brand password reset form with store theme and spinner
- update password then redirect to stored destination

## Testing
- `npm test` *(fails: 14 failed / 191 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5deec23483258fbb0086c576d23e