### PR TITLE
Auth: Fix OAuth URL to use Supabase project URL

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -192,7 +192,7 @@ function toggleSpinner(on) {
 function addPreconnect() {
   const head = globalThis.document?.head;
   if (!head) return;
-  ['https://accounts.google.com', 'https://auth.smoothr.io'].forEach((href) => {
+  ['https://accounts.google.com', 'https://lpuqrzvokroazwlricgn.supabase.co'].forEach((href) => {
     if (head.querySelector(`link[rel="preconnect"][href="${href}"]`)) return;
     const link = document.createElement('link');
     link.rel = 'preconnect';
@@ -207,7 +207,7 @@ export async function signInWithGoogle() {
   addPreconnect();
   const storeId = getStoreId();
   const redirect = encodeURIComponent(`${w.location.origin}/auth/callback`);
-  const authorizeApi = `https://auth.smoothr.io/authorize?store_id=${storeId}&redirect_to=${redirect}`;
+  const authorizeApi = `https://lpuqrzvokroazwlricgn.supabase.co/authorize?store_id=${storeId}&redirect_to=${redirect}`;
 
   if (w.top !== w.self) {
     w.location.replace(authorizeApi);
@@ -250,7 +250,7 @@ export async function signInWithGoogle() {
     if (data.type !== 'smoothr:auth' || !data.code) return;
     cleanup();
     try {
-      const resp = await fetch(`https://auth.smoothr.io/exchange?code=${data.code}`);
+      const resp = await fetch(`https://lpuqrzvokroazwlricgn.supabase.co/exchange?code=${data.code}`);
       const json = await resp.json();
       const { access_token, refresh_token } = json;
       const client = await resolveSupabase();

--- a/storefronts/tests/sdk/dom-mutation.test.js
+++ b/storefronts/tests/sdk/dom-mutation.test.js
@@ -236,7 +236,7 @@ describe("dynamic DOM bindings", () => {
 
     await clickHandler({ preventDefault: () => {}, target: btn });
     expect(global.window.location.replace).toHaveBeenCalledWith(
-      'https://auth.smoothr.io/authorize?store_id=test-store&redirect_to=%2Fauth%2Fcallback'
+      'https://lpuqrzvokroazwlricgn.supabase.co/authorize?store_id=test-store&redirect_to=%2Fauth%2Fcallback'
     );
   });
 

--- a/storefronts/tests/sdk/oauth-google-popup.test.js
+++ b/storefronts/tests/sdk/oauth-google-popup.test.js
@@ -4,7 +4,7 @@ let signInWithGoogle;
 let realWindow;
 
 const authorizeUrl =
-  'https://auth.smoothr.io/authorize?store_id=store_test&redirect_to=https%3A%2F%2Fstore.example%2Fauth%2Fcallback';
+  'https://lpuqrzvokroazwlricgn.supabase.co/authorize?store_id=store_test&redirect_to=https%3A%2F%2Fstore.example%2Fauth%2Fcallback';
 
 describe('signInWithGoogle popup', () => {
   beforeEach(async () => {

--- a/storefronts/tests/sdk/oauth-google.test.js
+++ b/storefronts/tests/sdk/oauth-google.test.js
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 let signInWithGoogle;
 
 const authorizeUrl =
-  'https://auth.smoothr.io/authorize?store_id=store_test&redirect_to=https%3A%2F%2Fstore.example%2Fauth%2Fcallback';
+  'https://lpuqrzvokroazwlricgn.supabase.co/authorize?store_id=store_test&redirect_to=https%3A%2F%2Fstore.example%2Fauth%2Fcallback';
 
 describe('signInWithGoogle', () => {
   beforeEach(async () => {


### PR DESCRIPTION
## Summary
- point SDK auth preconnect, authorize, and exchange calls at the Supabase project URL
- align OAuth test expectations with the new authorize endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba71400144832597ca358d45094d62