### PR TITLE
Auth Overhaul: Fix Popup URL Assignment in SDK

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -206,7 +206,7 @@ export async function signInWithGoogle() {
   const w = globalThis.window || globalThis;
   addPreconnect();
   const storeId = getStoreId();
-  const redirect = encodeURIComponent(`${w.location.origin}/auth/callback`);
+  const redirect = encodeURIComponent(`https://${w.location.host}/auth/callback`);
   const authorizeApi = `https://lpuqrzvokroazwlricgn.supabase.co/functions/v1/oauth-proxy/authorize?store_id=${storeId}&redirect_to=${redirect}`;
 
   if (w.top !== w.self) {
@@ -264,8 +264,9 @@ export async function signInWithGoogle() {
   try {
     const r = await fetch(authorizeApi);
     const j = await r.json().catch(() => ({}));
-    if (j?.url) popup.location = j.url;
-    else {
+    if (j?.url && popup && !popup.closed) {
+      popup.location.href = j.url;
+    } else {
       cleanup();
       w.location.replace(authorizeApi);
     }

--- a/storefronts/tests/sdk/dom-mutation.test.js
+++ b/storefronts/tests/sdk/dom-mutation.test.js
@@ -99,7 +99,7 @@ describe("dynamic DOM bindings", () => {
         return true;
       },
     };
-      const loc = { origin: "", assign: vi.fn(), replace: vi.fn() };
+      const loc = { origin: "", host: "store.example", assign: vi.fn(), replace: vi.fn() };
     Object.defineProperty(loc, "href", { get() { return ""; }, set(url) { this.replace(url); } });
     win = {
       location: loc,
@@ -236,7 +236,7 @@ describe("dynamic DOM bindings", () => {
 
     await clickHandler({ preventDefault: () => {}, target: btn });
     expect(global.window.location.replace).toHaveBeenCalledWith(
-      'https://lpuqrzvokroazwlricgn.supabase.co/functions/v1/oauth-proxy/authorize?store_id=test-store&redirect_to=%2Fauth%2Fcallback'
+      'https://lpuqrzvokroazwlricgn.supabase.co/functions/v1/oauth-proxy/authorize?store_id=test-store&redirect_to=https%3A%2F%2Fstore.example%2Fauth%2Fcallback'
     );
   });
 

--- a/storefronts/tests/sdk/oauth-google-popup.test.js
+++ b/storefronts/tests/sdk/oauth-google-popup.test.js
@@ -12,7 +12,7 @@ describe('signInWithGoogle popup', () => {
     realWindow = global.window;
     globalThis.ensureConfigLoaded = vi.fn().mockResolvedValue();
     globalThis.getCachedBrokerBase = vi.fn().mockReturnValue('https://smoothr.vercel.app');
-    const popup = { location: '', close: vi.fn(), closed: false };
+    const popup = { location: { href: '' }, close: vi.fn(), closed: false };
     const doc = {
       getElementById: vi.fn(() => ({ dataset: { storeId: 'store_test' } })),
       head: { querySelector: vi.fn(), appendChild: vi.fn() },
@@ -20,7 +20,7 @@ describe('signInWithGoogle popup', () => {
       createElement: vi.fn(() => ({ setAttribute: vi.fn(), style: {} })),
       querySelector: vi.fn(() => null),
     };
-    const location = { origin: 'https://store.example', replace: vi.fn() };
+    const location = { origin: 'https://store.example', host: 'store.example', replace: vi.fn() };
     Object.defineProperty(location, 'href', {
       set(url) { this.replace(url); },
       get() { return ''; },
@@ -63,7 +63,7 @@ describe('signInWithGoogle popup', () => {
     const specs = window.open.mock.calls[0][2];
     expect(specs).toContain('left=212');
     expect(specs).toContain('top=34');
-    expect(window.__popup.location).toBe('https://accounts.google.com/o/oauth2/auth');
+    expect(window.__popup.location.href).toBe('https://accounts.google.com/o/oauth2/auth');
     expect(window.location.replace).not.toHaveBeenCalled();
   });
 

--- a/storefronts/tests/sdk/oauth-google.test.js
+++ b/storefronts/tests/sdk/oauth-google.test.js
@@ -11,7 +11,7 @@ describe('signInWithGoogle', () => {
     globalThis.ensureConfigLoaded = vi.fn().mockResolvedValue();
     globalThis.getCachedBrokerBase = vi.fn().mockReturnValue('https://smoothr.vercel.app');
     global.fetch = vi.fn();
-    const location = { origin: 'https://store.example', replace: vi.fn() };
+    const location = { origin: 'https://store.example', host: 'store.example', replace: vi.fn() };
     Object.defineProperty(location, 'href', {
       set(url) {
         this.replace(url);


### PR DESCRIPTION
## Summary
- ensure Google OAuth redirects always use https
- set popup location to the fetched authorize URL and fall back cleanly on errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba7896e50c8325ab9704d0b223f4a2