### PR TITLE
Auth Overhaul: Fix Popup Handling and Secure Redirect

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -263,9 +263,18 @@ export async function signInWithGoogle() {
 
   try {
     const r = await fetch(authorizeApi);
-    const j = await r.json().catch(() => ({}));
+    if (!r.ok) throw new Error('Authorize failed');
+    const j = await r.json();
     if (j?.url && popup && !popup.closed) {
       popup.location.href = j.url;
+      // Poll briefly to ensure popup loads
+      const checkPopup = setInterval(() => {
+        if (popup.closed) {
+          clearInterval(checkPopup);
+          cleanup();
+          w.location.replace(authorizeApi);
+        }
+      }, 100);
     } else {
       cleanup();
       w.location.replace(authorizeApi);

--- a/storefronts/tests/sdk/oauth-google-popup.test.js
+++ b/storefronts/tests/sdk/oauth-google-popup.test.js
@@ -42,9 +42,9 @@ describe('signInWithGoogle popup', () => {
     global.window = win;
     global.fetch = vi.fn(async (url) => {
       if (url === authorizeUrl) {
-        return { json: async () => ({ url: 'https://accounts.google.com/o/oauth2/auth' }) };
+        return { ok: true, json: async () => ({ url: 'https://accounts.google.com/o/oauth2/auth' }) };
       }
-      return { json: async () => ({}) };
+      return { ok: true, json: async () => ({}) };
     });
     const mod = await import('../../features/auth/init.js');
     signInWithGoogle = mod.signInWithGoogle;

--- a/supabase/functions/oauth-proxy/index.ts
+++ b/supabase/functions/oauth-proxy/index.ts
@@ -79,7 +79,7 @@ Deno.serve(async (req) => {
       provider,
       options: {
         skipBrowserRedirect: true,
-        redirectTo: `${url.origin}/oauth-proxy/callback`,
+        redirectTo: `https://${url.host}/functions/v1/oauth-proxy/callback`,
         queryParams: { state },
       },
     });


### PR DESCRIPTION
## Summary
- make OAuth popup navigation resilient by validating authorize fetch responses and monitoring popup state
- enforce HTTPS redirect URL in Supabase OAuth proxy to prevent insecure callbacks
- adjust OAuth popup test to include fetch response ok status

## Testing
- `npm test` (in storefronts)
- `npm run test:supabase`


------
https://chatgpt.com/codex/tasks/task_e_68ba7af83c648325af35244b7b208e79