### PR TITLE
Auth: Fix CORS and Supabase URL

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -189,10 +189,11 @@ function toggleSpinner(on) {
   if (el) el.style.display = on ? '' : 'none';
 }
 
+const SUPABASE_URL = 'https://lpuqrzvokroazwlricgn.supabase.co';
 function addPreconnect() {
   const head = globalThis.document?.head;
   if (!head) return;
-  ['https://accounts.google.com', 'https://lpuqrzvokroazwlricgn.supabase.co'].forEach((href) => {
+  ['https://accounts.google.com', SUPABASE_URL].forEach((href) => {
     if (head.querySelector(`link[rel="preconnect"][href="${href}"]`)) return;
     const link = document.createElement('link');
     link.rel = 'preconnect';
@@ -207,7 +208,7 @@ export async function signInWithGoogle() {
   addPreconnect();
   const storeId = getStoreId();
   const redirect = encodeURIComponent(`https://${w.location.host}/auth/callback`);
-  const authorizeApi = `https://lpuqrzvokroazwlricgn.supabase.co/functions/v1/oauth-proxy/authorize?store_id=${storeId}&redirect_to=${redirect}`;
+  const authorizeApi = `${SUPABASE_URL}/functions/v1/oauth-proxy/authorize?store_id=${storeId}&redirect_to=${redirect}`;
 
   if (w.top !== w.self) {
     w.location.replace(authorizeApi);
@@ -250,7 +251,7 @@ export async function signInWithGoogle() {
     if (data.type !== 'smoothr:auth' || !data.code) return;
     cleanup();
     try {
-      const resp = await fetch(`https://lpuqrzvokroazwlricgn.supabase.co/functions/v1/oauth-proxy/exchange?code=${data.code}`);
+      const resp = await fetch(`${SUPABASE_URL}/functions/v1/oauth-proxy/exchange?code=${data.code}`);
       const json = await resp.json();
       const { access_token, refresh_token } = json;
       const client = await resolveSupabase();

--- a/supabase/functions/oauth-proxy/index.ts
+++ b/supabase/functions/oauth-proxy/index.ts
@@ -63,7 +63,7 @@ Deno.serve(async (req) => {
     if (!storeId || !redirect) {
       return new Response(JSON.stringify({ error: "missing_params" }), {
         status: 400,
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "https://smoothr-cms.webflow.io", "Access-Control-Allow-Methods": "GET", "Access-Control-Allow-Headers": "Content-Type", "Vary": "Origin" },
       });
     }
 
@@ -102,7 +102,7 @@ Deno.serve(async (req) => {
       created_at: new Date().toISOString(),
     });
     return new Response(JSON.stringify({ url: data.url }), {
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "https://smoothr-cms.webflow.io", "Access-Control-Allow-Methods": "GET", "Access-Control-Allow-Headers": "Content-Type", "Vary": "Origin" },
     });
   }
 
@@ -152,7 +152,7 @@ Deno.serve(async (req) => {
     if (!code) {
       return new Response(JSON.stringify({ error: "missing_code" }), {
         status: 400,
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "https://smoothr-cms.webflow.io", "Access-Control-Allow-Methods": "POST", "Access-Control-Allow-Headers": "Content-Type", "Vary": "Origin" },
       });
     }
     const { data: row } = await supabase
@@ -171,7 +171,7 @@ Deno.serve(async (req) => {
       .update({ used_at: new Date().toISOString() })
       .eq("code", code);
     return new Response(JSON.stringify(row.session), {
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "https://smoothr-cms.webflow.io", "Access-Control-Allow-Methods": "POST", "Access-Control-Allow-Headers": "Content-Type", "Vary": "Origin" },
     });
   }
 


### PR DESCRIPTION
## Summary
- add CORS headers for oauth-proxy authorize and exchange endpoints
- use hosted Supabase URL constant in storefront auth init

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*
- `npm run test:supabase` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ba814857048325ac63c01b6399469c