### PR TITLE
Auth Overhaul: Fix Popup Redirect and COOP

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -277,14 +277,22 @@ export async function signInWithGoogle() {
     if (j?.url && popup && !popup.closed) {
       log('Setting popup location:', j.url);
       popup.location.href = j.url;
-      const checkPopup = setInterval(() => {
-        if (popup.closed) {
-          log('Popup closed prematurely, redirecting main page');
-          clearInterval(checkPopup);
-          cleanup();
-          w.location.replace(authorizeApi);
-        }
-      }, 100);
+      // Wait for popup to load before polling
+      await new Promise(resolve => setTimeout(resolve, 500));
+      if (!popup.closed) {
+        const checkPopup = setInterval(() => {
+          if (popup.closed) {
+            log('Popup closed prematurely, redirecting main page');
+            clearInterval(checkPopup);
+            cleanup();
+            w.location.replace(authorizeApi);
+          }
+        }, 500);
+      } else {
+        log('Popup closed before polling, redirecting main page');
+        cleanup();
+        w.location.replace(authorizeApi);
+      }
     } else {
       log('No URL or popup closed, redirecting main page');
       cleanup();

--- a/supabase/functions/oauth-proxy/index.ts
+++ b/supabase/functions/oauth-proxy/index.ts
@@ -102,7 +102,14 @@ Deno.serve(async (req) => {
       created_at: new Date().toISOString(),
     });
     return new Response(JSON.stringify({ url: data.url }), {
-      headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "https://smoothr-cms.webflow.io", "Access-Control-Allow-Methods": "GET", "Access-Control-Allow-Headers": "Content-Type", "Vary": "Origin" },
+      headers: {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "https://smoothr-cms.webflow.io",
+        "Access-Control-Allow-Methods": "GET",
+        "Access-Control-Allow-Headers": "Content-Type",
+        "Vary": "Origin",
+        "Cross-Origin-Opener-Policy": "unsafe-none",
+      },
     });
   }
 
@@ -143,7 +150,12 @@ Deno.serve(async (req) => {
         try{ window.close(); }catch(e){}
       })();
     </script>`;
-    return new Response(body, { headers: { "Content-Type": "text/html" } });
+    return new Response(body, {
+      headers: {
+        "Content-Type": "text/html",
+        "Cross-Origin-Opener-Policy": "unsafe-none",
+      },
+    });
   }
 
   if (p === "/exchange" && req.method === "POST") {


### PR DESCRIPTION
## Summary
- ensure Google sign-in popup waits for authorization response before polling and redirecting main page
- disable COOP on oauth-proxy authorize and callback responses

## Testing
- `cd storefronts && npm test`
- `npm run test:supabase`


------
https://chatgpt.com/codex/tasks/task_e_68ba89ab526c832580d1dbe4baa52fe1