### PR TITLE
test(auth): broker-origin filter + opener close

### DIFF
--- a/storefronts/tests/sdk/oauth-google-popup.test.js
+++ b/storefronts/tests/sdk/oauth-google-popup.test.js
@@ -2,6 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 let signInWithGoogle;
 let realWindow;
+let messageListener;
+let popup;
+let client;
 
 const authorizeUrl =
   'https://lpuqrzvokroazwlricgn.supabase.co/functions/v1/oauth-proxy/authorize?store_id=store_test&redirect_to=https%3A%2F%2Fstore.example%2Fauth%2Fcallback';
@@ -10,9 +13,10 @@ describe('signInWithGoogle popup', () => {
   beforeEach(async () => {
     vi.resetModules();
     realWindow = global.window;
+    messageListener = undefined;
     globalThis.ensureConfigLoaded = vi.fn().mockResolvedValue();
     globalThis.getCachedBrokerBase = vi.fn().mockReturnValue('https://smoothr.vercel.app');
-    const popup = { location: { href: '' }, close: vi.fn(), closed: false };
+    popup = { location: { href: '' }, closed: false, close: vi.fn(() => { popup.closed = true; }) };
     const doc = {
       getElementById: vi.fn(() => ({ dataset: { storeId: 'store_test' } })),
       head: { querySelector: vi.fn(), appendChild: vi.fn() },
@@ -30,7 +34,7 @@ describe('signInWithGoogle popup', () => {
       document: doc,
       SMOOTHR_CONFIG: { store_id: 'store_test' },
       open: vi.fn(() => popup),
-      addEventListener: vi.fn(),
+      addEventListener: vi.fn((type, fn) => { if (type === 'message') messageListener = fn; }),
       removeEventListener: vi.fn(),
       screenLeft: 0,
       screenTop: 0,
@@ -40,13 +44,25 @@ describe('signInWithGoogle popup', () => {
     win.top = win;
     win.self = win;
     global.window = win;
+    const usedCodes = new Set();
     global.fetch = vi.fn(async (url) => {
       if (url === authorizeUrl) {
         return { ok: true, json: async () => ({ url: 'https://accounts.google.com/o/oauth2/auth' }) };
       }
+      const m = url.match(/oauth-proxy\/exchange\?code=(.*)$/);
+      if (m) {
+        const code = m[1];
+        if (usedCodes.has(code)) {
+          return { ok: false, json: async () => ({}) };
+        }
+        usedCodes.add(code);
+        return { ok: true, json: async () => ({ access_token: 'a', refresh_token: 'r' }) };
+      }
       return { ok: true, json: async () => ({}) };
     });
     const mod = await import('../../features/auth/init.js');
+    client = { auth: { setSession: vi.fn() } };
+    mod.setSupabaseClient(client);
     signInWithGoogle = mod.signInWithGoogle;
     window.__popup = popup;
   });
@@ -95,6 +111,42 @@ describe('signInWithGoogle popup', () => {
     expect(window.__popup.close).toHaveBeenCalled();
     vi.useRealTimers();
     await promise;
+  });
+
+  it('ignores messages from non-broker origins', async () => {
+    vi.useFakeTimers();
+    const promise = signInWithGoogle();
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+    fetch.mockClear();
+    await messageListener?.({ origin: 'https://evil.example', data: { type: 'smoothr:auth', code: 'abc' } });
+    expect(fetch).not.toHaveBeenCalled();
+    expect(client.auth.setSession).not.toHaveBeenCalled();
+    expect(popup.close).not.toHaveBeenCalled();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('accepts messages from supabase and closes popup after setSession', async () => {
+    vi.useFakeTimers();
+    const promise = signInWithGoogle();
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+    fetch.mockClear();
+    await messageListener?.({
+      origin: 'https://lpuqrzvokroazwlricgn.supabase.co',
+      data: { type: 'smoothr:auth', code: 'one' }
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      'https://lpuqrzvokroazwlricgn.supabase.co/functions/v1/oauth-proxy/exchange?code=one'
+    );
+    expect(client.auth.setSession).toHaveBeenCalledWith({ access_token: 'a', refresh_token: 'r' });
+    expect(popup.close).toHaveBeenCalled();
+    expect(popup.close.mock.invocationCallOrder[0]).toBeGreaterThan(
+      client.auth.setSession.mock.invocationCallOrder[0]
+    );
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   it('redirects when framed', async () => {


### PR DESCRIPTION
## Summary
- test popup flow respects broker origin filtering and closes the popup after auth
- mock /authorize and /exchange endpoints with one-time code support

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68baaf19e0e88325b93e9176aa1d14db