### PR TITLE
Fix dynamic CORS for multi-tenant OAuth

### DIFF
--- a/supabase/functions/oauth-proxy/index.ts
+++ b/supabase/functions/oauth-proxy/index.ts
@@ -1,6 +1,17 @@
 import { createClient } from "npm:@supabase/supabase-js@2.39.3";
 import { applyCors, withCors } from "../_shared/cors.ts";
 
+// Match host against domain (supports leading wildcard "*.")
+function hostMatches(host: string, domain?: string | null): boolean {
+  if (!host || !domain) return false;
+  const d = String(domain);
+  if (d.startsWith("*.")) {
+    const base = d.slice(2);
+    return host === base || host.endsWith(`.${base}`);
+  }
+  return host === d;
+}
+
 const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
 const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 const HMAC_SECRET = Deno.env.get("HMAC_SECRET")!;
@@ -69,14 +80,68 @@ Deno.serve(async (req) => {
     const storeId = url.searchParams.get("store_id") || "";
     const redirect = url.searchParams.get("redirect_to") || "";
     if (!storeId || !redirect) {
-      return withCors(req, new Response(JSON.stringify({ error: "missing_params" }), {
-        status: 400,
-        headers: { "Content-Type": "application/json" },
-      }));
+      return withCors(
+        req,
+        new Response(JSON.stringify({ error: "missing_params" }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
     }
 
+    const { data: store } = await supabase
+      .from("stores")
+      .select("store_domain, live_domain, domains")
+      .eq("id", storeId)
+      .single();
+    if (!store) {
+      return withCors(
+        req,
+        new Response(JSON.stringify({ error: "invalid_store" }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }
+
+    let redirectUrl: URL;
+    try {
+      redirectUrl = new URL(redirect);
+    } catch (_) {
+      return withCors(
+        req,
+        new Response(JSON.stringify({ error: "invalid_redirect" }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }
+    const redirectHost = redirectUrl.hostname;
+    const candidates: string[] = [];
+    if (store.store_domain) candidates.push(store.store_domain);
+    if (store.live_domain) candidates.push(store.live_domain);
+    if (Array.isArray(store.domains)) candidates.push(...store.domains);
+    const validRedirect = candidates.some((d) => hostMatches(redirectHost, d));
+    if (!validRedirect) {
+      return withCors(
+        req,
+        new Response(JSON.stringify({ error: "invalid_redirect" }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }
+
+    // override allowed origin to redirect origin so CORS ACAO matches
+    const hdrs = new Headers(req.headers);
+    hdrs.set("x-cors-allowed-origin", redirectUrl.origin);
+    const corsReq = new Request(req.url, { method: req.method, headers: hdrs });
+
     const payload = { sid: storeId, rid: redirect, ts: Date.now() };
-    const s = btoa(JSON.stringify(payload)).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    const s = btoa(JSON.stringify(payload)).replace(/\+/g, "-").replace(
+      /\//g,
+      "_",
+    ).replace(/=+$/, "");
     const h = await hmac(s);
     const expires = new Date(Date.now() + 10 * 60_000).toISOString();
 
@@ -101,18 +166,24 @@ Deno.serve(async (req) => {
       },
     });
     if (error || !authData?.url) {
-      return withCors(req, new Response(
-        JSON.stringify({ error: error?.message || "oauth_error" }),
-        {
-          status: 400,
-          headers: { "Content-Type": "application/json" },
-        },
-      ));
+      return withCors(
+        corsReq,
+        new Response(
+          JSON.stringify({ error: error?.message || "oauth_error" }),
+          {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      );
     }
 
-    return withCors(req, new Response(JSON.stringify({ url: authData.url }), {
-      headers: { "Content-Type": "application/json" },
-    }));
+    return withCors(
+      corsReq,
+      new Response(JSON.stringify({ url: authData.url }), {
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
   }
 
   if (p === "/callback") {
@@ -133,9 +204,10 @@ Deno.serve(async (req) => {
       .from("auth_state_management")
       .update({ used_at: new Date().toISOString() })
       .eq("state", state);
-    const { data: sessData, error } = await supabase.auth.exchangeCodeForSession({
-      authCode: code,
-    });
+    const { data: sessData, error } = await supabase.auth
+      .exchangeCodeForSession({
+        authCode: code,
+      });
     if (error || !sessData.session) {
       return withCors(req, new Response("Exchange failed", { status: 400 }));
     }
@@ -151,26 +223,39 @@ Deno.serve(async (req) => {
     try {
       targetOrigin = new URL((row.metadata as any).rid).origin;
     } catch (_) {
-      return withCors(req, new Response("Invalid redirect URL", { status: 400 }));
+      return withCors(
+        req,
+        new Response("Invalid redirect URL", { status: 400 }),
+      );
     }
-    const body = `<!DOCTYPE html><script>(function(){const o=${JSON.stringify(targetOrigin)};const c=${JSON.stringify(otc)};try{window.opener.postMessage({ type: 'SUPABASE_AUTH_COMPLETE', otc:c }, o);}catch(e){};try{window.close();}catch(e){};setTimeout(function(){try{window.close();}catch(e){}},1000);})();</script>`;
-    return withCors(req, new Response(body, {
-      headers: {
-        "Content-Type": "text/html",
-        "Cross-Origin-Opener-Policy": "unsafe-none",
-        "Cross-Origin-Embedder-Policy": "unsafe-none",
-      },
-    }));
+    const body = `<!DOCTYPE html><script>(function(){const o=${
+      JSON.stringify(targetOrigin)
+    };const c=${
+      JSON.stringify(otc)
+    };try{window.opener.postMessage({ type: 'SUPABASE_AUTH_COMPLETE', otc:c }, o);}catch(e){};try{window.close();}catch(e){};setTimeout(function(){try{window.close();}catch(e){}},1000);})();</script>`;
+    return withCors(
+      req,
+      new Response(body, {
+        headers: {
+          "Content-Type": "text/html",
+          "Cross-Origin-Opener-Policy": "unsafe-none",
+          "Cross-Origin-Embedder-Policy": "unsafe-none",
+        },
+      }),
+    );
   }
 
   if (p === "/exchange" && req.method === "POST") {
     const body = await req.json().catch(() => ({}));
     const code = body.otc as string;
     if (!code) {
-      return withCors(req, new Response(JSON.stringify({ error: "missing_code" }), {
-        status: 400,
-        headers: { "Content-Type": "application/json" },
-      }));
+      return withCors(
+        req,
+        new Response(JSON.stringify({ error: "missing_code" }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
     }
     const { data: row } = await supabase
       .from("auth_state_management")
@@ -178,12 +263,15 @@ Deno.serve(async (req) => {
       .eq("code", code)
       .single();
     if (!row || row.used_at || new Date(row.expires_at) < new Date()) {
-      return withCors(req, new Response(JSON.stringify({ error: "invalid_code" }), {
-        status: 400,
-        headers: {
-          "Content-Type": "application/json",
-        },
-      }));
+      return withCors(
+        req,
+        new Response(JSON.stringify({ error: "invalid_code" }), {
+          status: 400,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }),
+      );
     }
     await supabase
       .from("auth_state_management")
@@ -196,11 +284,14 @@ Deno.serve(async (req) => {
       expires_at: sess.expires_at,
       provider_token: sess.provider_token,
     };
-    return withCors(req, new Response(JSON.stringify(respBody), {
-      headers: {
-        "Content-Type": "application/json",
-      },
-    }));
+    return withCors(
+      req,
+      new Response(JSON.stringify(respBody), {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }),
+    );
   }
 
   return withCors(req, new Response("Not found", { status: 404 }));


### PR DESCRIPTION
## Summary
- support store_domain and live_domain in CORS origin validation
- verify oauth-proxy /authorize redirect domain and set x-cors-allowed-origin

## Testing
- `npm run supabase:fmt`
- `npx eslint supabase/functions/_shared/cors.ts supabase/functions/oauth-proxy/index.ts` *(fails: File ignored because no matching configuration was supplied)*
- `npm run test:supabase`


------
https://chatgpt.com/codex/tasks/task_e_68bbcda3cd6c832599040bc25bc0901d