### PR TITLE
feat: add oauth-proxy settings to supabase config.toml

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -20,3 +20,13 @@ enabled = true
 verify_jwt = true
 import_map = "./functions/get_public_store_settings/deno.json"
 entrypoint = "./functions/get_public_store_settings/index.ts"
+
+# oauth-proxy: Public endpoint for OAuth authorize, JWT disabled. Env vars set in Supabase dashboard.
+[functions.oauth-proxy]
+verify_jwt = false
+
+[functions.oauth-proxy.environment]
+HMAC_SECRET = "${HMAC_SECRET}"
+SUPABASE_URL = "${SUPABASE_URL}"
+SUPABASE_ANON_KEY = "${SUPABASE_ANON_KEY}"
+SUPABASE_SERVICE_ROLE_KEY = "${SUPABASE_SERVICE_ROLE_KEY}"


### PR DESCRIPTION
## Summary
- add oauth-proxy Supabase function config

## Testing
- `npm test` *(fails: preflight is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8d38ce388325bb259ddad17e6696