### PR TITLE
fix oauth popup flow

### DIFF
--- a/storefronts/tests/sdk/oauth-google-popup.test.js
+++ b/storefronts/tests/sdk/oauth-google-popup.test.js
@@ -7,7 +7,7 @@ let popup;
 let client;
 
 const AUTHORIZE =
-  'https://lpuqrzvokroazwlricgn.supabase.co/functions/v1/oauth-proxy/authorize?store_id=store_test&redirect_to=https%3A%2F%2Fstore.example';
+  'https://lpuqrzvokroazwlricgn.supabase.co/functions/v1/oauth-proxy/authorize?provider=google&store_id=store_test&redirect_to=https%3A%2F%2Fstore.example';
 const PROVIDER_URL = 'https://accounts.google.com/o/oauth2/auth';
 const EXCHANGE = 'https://lpuqrzvokroazwlricgn.supabase.co/functions/v1/oauth-proxy/exchange';
 


### PR DESCRIPTION
## Summary
- open OAuth popup immediately before async work
- build authorize URL with deterministic query params
- update tests for new authorize URL

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf3d414448325affbe2a86b8aefc0