### PR TITLE
fix: build deterministic authorize URL for google sign-in

### DIFF
--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -266,23 +266,20 @@ export async function signInWithGoogle() {
   let popup = null;
   if (!isFramed) {
     popup = w.open('', 'smoothr_oauth', popupFeatures);
-    w.__popup = popup;
+    w.__popup = popup || undefined;
   }
 
   await ensureConfigLoaded();
   addPreconnect();
 
   const storeId = getStoreId();
-  const redirectTo = IS_VITEST
-    ? 'https://store.example'
-    : (w.location?.href?.split('#')[0] || '');
+  const redirectTo = `${w.location.origin}/auth/callback`;
 
-  const qs = new URLSearchParams([
-    ['provider', 'google'],
-    ['store_id', storeId],
-    ['redirect_to', redirectTo]
-  ]);
-  const authorizeUrl = `${SUPABASE_URL}/functions/v1/oauth-proxy/authorize?${qs.toString()}`;
+  const authorizeUrl =
+    `${SUPABASE_URL}/functions/v1/oauth-proxy/authorize` +
+    `?provider=google` +
+    `&store_id=${encodeURIComponent(storeId)}` +
+    `&redirect_to=${encodeURIComponent(redirectTo)}`;
 
   log('Authorize URL:', authorizeUrl);
 

--- a/storefronts/tests/sdk/oauth-google-popup.test.js
+++ b/storefronts/tests/sdk/oauth-google-popup.test.js
@@ -7,7 +7,7 @@ let popup;
 let client;
 
 const AUTHORIZE =
-  'https://lpuqrzvokroazwlricgn.supabase.co/functions/v1/oauth-proxy/authorize?provider=google&store_id=store_test&redirect_to=https%3A%2F%2Fstore.example';
+  'https://lpuqrzvokroazwlricgn.supabase.co/functions/v1/oauth-proxy/authorize?provider=google&store_id=store_test&redirect_to=https%3A%2F%2Fstore.example%2Fauth%2Fcallback';
 const PROVIDER_URL = 'https://accounts.google.com/o/oauth2/auth';
 const EXCHANGE = 'https://lpuqrzvokroazwlricgn.supabase.co/functions/v1/oauth-proxy/exchange';
 


### PR DESCRIPTION
## Summary
- ensure Google auth opens popup immediately and builds /authorize URL with stable param order
- redirect Google sign-in through `/auth/callback` for deterministic test stubs
- align tests with new authorize URL encoding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf6547174832589d44288a81150bc