### PR TITLE
test: reset SUPABASE_URL before auth init

### DIFF
--- a/storefronts/tests/sdk/oauth-google-popup.test.js
+++ b/storefronts/tests/sdk/oauth-google-popup.test.js
@@ -13,6 +13,7 @@ const EXCHANGE = 'https://lpuqrzvokroazwlricgn.supabase.co/functions/v1/oauth-pr
 
 describe('signInWithGoogle popup', () => {
   beforeEach(async () => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
     vi.resetModules();
     realWindow = global.window;
     messageListener = undefined;

--- a/storefronts/tests/sdk/oauth-google.test.js
+++ b/storefronts/tests/sdk/oauth-google.test.js
@@ -6,6 +6,7 @@ const PROVIDER_URL = 'https://accounts.google.com/o/oauth2/auth';
 
 describe('signInWithGoogle', () => {
   beforeEach(async () => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
     vi.resetModules();
     globalThis.ensureConfigLoaded = vi.fn().mockResolvedValue();
     globalThis.getCachedBrokerBase = vi.fn().mockReturnValue('https://auth.smoothr.io');


### PR DESCRIPTION
## Summary
- reset NEXT_PUBLIC_SUPABASE_URL in oauth-google tests to ensure consistent auth init

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf8c95b308325a23ab91f0a550c77