### PR TITLE
fix: preserve opener for OAuth callback

### DIFF
--- a/storefronts/public/_headers
+++ b/storefronts/public/_headers
@@ -12,7 +12,19 @@
   Cache-Control: no-store
   Content-Security-Policy: default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'unsafe-inline'; connect-src https://lpuqrzvokroazwlricgn.supabase.co; img-src 'self' data:; base-uri 'none'; frame-ancestors 'none'
   X-Frame-Options: DENY
-  Cross-Origin-Opener-Policy: same-origin-allow-popups
+  # IMPORTANT: keep opener linkage so postMessage works across origins
+  Cross-Origin-Opener-Policy: unsafe-none
   Cross-Origin-Embedder-Policy: unsafe-none
+  Referrer-Policy: strict-origin-when-cross-origin
+
+/oauth/callback.html
+  Content-Type: text/html; charset=utf-8
+  Cache-Control: no-store
+  Content-Security-Policy: default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'unsafe-inline'; connect-src https://lpuqrzvokroazwlricgn.supabase.co; img-src 'self' data:; base-uri 'none'; frame-ancestors 'none'
+  X-Frame-Options: DENY
+  # IMPORTANT: keep opener linkage so postMessage works across origins
+  Cross-Origin-Opener-Policy: unsafe-none
+  Cross-Origin-Embedder-Policy: unsafe-none
+  Referrer-Policy: strict-origin-when-cross-origin
 
 # (Optional hardening: if you move inline JS to an external file, you can drop 'unsafe-inline' from script-src.)


### PR DESCRIPTION
## Summary
- keep oauth callback linked to opener for cross-origin messaging
- document headers for /oauth/callback.html and add strict referrer policy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bee15d6b488325b788e632f0cc3b62