### PR TITLE
feat(oauth): make code exchange idempotent

### DIFF
--- a/storefronts/public/oauth/callback.html
+++ b/storefronts/public/oauth/callback.html
@@ -50,6 +50,7 @@
       const otc = b64url(rand);
 
       // Notify opener once using targeted origin only
+      // Post a single, targeted message to the opener
       try {
         if (window.opener && redirect_to) {
           const msg = { type: 'SUPABASE_AUTH_COMPLETE', otc, state };


### PR DESCRIPTION
## Summary
- verify and store OAuth callback data with state hash and session cache placeholders
- make `/exchange` idempotent with race handling, caching and structured diagnostics
- ensure callback page posts a single targeted message
- cover stale state and race scenarios in Google OAuth popup tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf08fdeea4832593527cf6a2d28f37