### PR TITLE
test: harden session sync and load-config tests

### DIFF
--- a/storefronts/tests/sdk/dom-mutation.test.js
+++ b/storefronts/tests/sdk/dom-mutation.test.js
@@ -15,6 +15,20 @@ const OTHER_SELECTOR =
   '[data-smoothr="sign-up"], [data-smoothr="login-google"], [data-smoothr="login-apple"], [data-smoothr="password-reset"]';
 const ACCOUNT_ACCESS_SELECTOR = '[data-smoothr="account-access"]';
 
+function stubSuccessfulSessionSync() {
+  global.window.SMOOTHR_CONFIG = {
+    ...(global.window.SMOOTHR_CONFIG || {}),
+    __brokerBase: 'https://sdk.smoothr.io'
+  };
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({ ok: true, redirect: null })
+  });
+  global.fetch = fetchMock;
+  global.window.fetch = fetchMock;
+}
+
 it('routes submit on reset-only form to password-reset handler', async () => {
   vi.resetModules();
   createClientMock();
@@ -154,8 +168,10 @@ describe("dynamic DOM bindings", () => {
     expect(btn.addEventListener).toHaveBeenCalled();
 
     const user = { id: "1", email: "user@example.com" };
-    const { signInMock } = currentSupabaseMocks();
+    const { signInMock, getSessionMock } = currentSupabaseMocks();
     signInMock.mockResolvedValue({ data: { user }, error: null });
+    getSessionMock.mockResolvedValue({ data: { session: { access_token: 'tok' } }, error: null });
+    stubSuccessfulSessionSync();
     await clickHandler({ preventDefault: () => {}, target: btn });
     await flushPromises();
 
@@ -204,8 +220,10 @@ describe("dynamic DOM bindings", () => {
     expect(btn.addEventListener).toHaveBeenCalled();
 
     const user = { id: "2", email: "new@example.com" };
-    const { signUpMock } = currentSupabaseMocks();
+    const { signUpMock, getSessionMock } = currentSupabaseMocks();
     signUpMock.mockResolvedValue({ data: { user }, error: null });
+    getSessionMock.mockResolvedValue({ data: { session: { access_token: 'tok' } }, error: null });
+    stubSuccessfulSessionSync();
     await clickHandler({ preventDefault: () => {}, target: btn });
     await flushPromises();
 

--- a/storefronts/tests/sdk/load-config-api-base.test.js
+++ b/storefronts/tests/sdk/load-config-api-base.test.js
@@ -21,13 +21,22 @@ let supabase;
 beforeEach(() => {
   vi.resetModules();
 
-  const maybeSingle = vi.fn(async () => ({
-    data: { api_base: 'https://example.com' },
-    error: null,
-  }));
-  const eq = vi.fn(() => ({ maybeSingle }));
-  const select = vi.fn(() => ({ eq }));
-  from = vi.fn(() => ({ select }));
+  from = vi.fn((table) => {
+    const maybeSingle = vi.fn(async () => ({
+      data:
+        table === 'v_public_store'
+          ? {
+              api_base: 'https://example.com',
+              sign_in_redirect_url: 'https://example.com/after',
+              sign_out_redirect_url: 'https://example.com/out',
+            }
+          : null,
+      error: null,
+    }));
+    const eq = vi.fn(() => ({ maybeSingle }));
+    const select = vi.fn(() => ({ eq }));
+    return { select };
+  });
   supabase = { from };
 
   global.window = {

--- a/storefronts/tests/sdk/load-config-merge.test.js
+++ b/storefronts/tests/sdk/load-config-merge.test.js
@@ -20,13 +20,23 @@ beforeEach(() => {
   vi.resetModules();
   vi.stubEnv('NODE_ENV', 'production');
 
-  const maybeSingle = vi.fn(async () => ({
-    data: { api_base: 'https://example.com', foo: 'bar' },
-    error: null,
-  }));
-  const eq = vi.fn(() => ({ maybeSingle }));
-  const select = vi.fn(() => ({ eq }));
-  from = vi.fn(() => ({ select }));
+  from = vi.fn((table) => {
+    const maybeSingle = vi.fn(async () => ({
+      data:
+        table === 'v_public_store'
+          ? {
+              api_base: 'https://example.com',
+              foo: 'bar',
+              sign_in_redirect_url: 'https://example.com/after',
+              sign_out_redirect_url: 'https://example.com/out',
+            }
+          : null,
+      error: null,
+    }));
+    const eq = vi.fn(() => ({ maybeSingle }));
+    const select = vi.fn(() => ({ eq }));
+    return { select };
+  });
   supabase = { from };
 
   global.window = {


### PR DESCRIPTION
## Summary
- simulate successful brokered session sync in DOM mutation auth tests
- mock Supabase redirect settings to avoid fallback queries

## Testing
- `npm test --workspace storefronts`


------
https://chatgpt.com/codex/tasks/task_e_68c03fd543f483258bf26b4c50647c60