### PR TITLE
feat: add platform-aware reset route and session sync fallback

### DIFF
--- a/storefronts/README.md
+++ b/storefronts/README.md
@@ -92,7 +92,7 @@ window.SMOOTHR_CONFIG.apiBase; // => 'https://example.com'
 
 - After login: set **Sign-in Success Redirect URL** to redirect via CORS-less form POST; leave blank to stay on page.
 - Recovery redirect origin resolution (allowlist): `live_domain` → `store_domain` → origin of `sign_in_redirect_url`. In development only, `orig=localhost` / `127.0.0.1` is accepted if no domains are configured.
-- The final `/auth/reset` URL **does not include** `store_id` (the SDK/loader provides store context).
+- The reset route is auto-detected: Webflow uses `/reset-password`, others default to `/auth/reset`. The final URL **does not include** `store_id` (the SDK/loader provides store context).
 - Optional: set `SMOOTHR_CONFIG.auth.silentPost = true` to use a hidden-iframe form POST for the “stay on page” path (silences dev CORS noise).
 
 ### Reset UX polish

--- a/storefronts/core/hash.js
+++ b/storefronts/core/hash.js
@@ -1,3 +1,5 @@
+import { getResetRoute } from './platformRoutes.js';
+
 export function hasRecoveryHash() {
   const h = (location.hash || '').slice(1);
   return /(^|&)(access_token|refresh_token)=/.test(h);
@@ -12,7 +14,7 @@ export function resetPath() {
     (window.SMOOTHR_CONFIG &&
       window.SMOOTHR_CONFIG.routes &&
       window.SMOOTHR_CONFIG.routes.resetPassword) ||
-    '/auth/reset'
+    getResetRoute()
   );
 }
 

--- a/storefronts/core/http/form.js
+++ b/storefronts/core/http/form.js
@@ -1,0 +1,11 @@
+export async function postForm(url, data) {
+  const body = new URLSearchParams();
+  for (const [k, v] of Object.entries(data || {})) {
+    if (v !== undefined && v !== null) body.append(k, String(v));
+  }
+  return fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString()
+  });
+}

--- a/storefronts/core/http/sessionSync.js
+++ b/storefronts/core/http/sessionSync.js
@@ -1,15 +1,30 @@
+import { postForm } from './form.js';
+
+// primary: JSON + Authorization header
+// fallback: form POST when Authorization flow is unavailable (older embeds, CSP, or strict CORS)
 export async function sessionSync({ brokerBase, store_id, access_token }) {
-  const res = await fetch(`${brokerBase}/api/auth/session-sync`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${access_token}`,
-    },
-    body: JSON.stringify({ store_id }),
-  });
+  const url = `${brokerBase}/api/auth/session-sync`;
   try {
-    return await res.json();
-  } catch {
-    return {};
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(access_token ? { Authorization: `Bearer ${access_token}` } : {})
+      },
+      body: JSON.stringify({ store_id })
+    });
+    if (res.ok) return res.json();
+    // If unauthorized or blocked, try form-encoded path (back-compat)
+    if (res.status === 401 || res.status === 403) {
+      const res2 = await postForm(url, { store_id, access_token });
+      if (res2.ok) return res2.json();
+      return Promise.reject(new Error(`session-sync failed: ${res.status}/${res2.status}`));
+    }
+    return Promise.reject(new Error(`session-sync failed: ${res.status}`));
+  } catch (e) {
+    // Network failure → best-effort form fallback
+    const res2 = await postForm(url, { store_id, access_token });
+    if (res2.ok) return res2.json();
+    throw e;
   }
 }

--- a/storefronts/core/platformRoutes.js
+++ b/storefronts/core/platformRoutes.js
@@ -1,0 +1,11 @@
+export function getResetRoute() {
+  // Detect platform from loader or adapter
+  const platform =
+    (window.Smoothr && window.Smoothr.platform && window.Smoothr.platform.id) ||
+    document.querySelector('#smoothr-sdk')?.getAttribute('platform') ||
+    '';
+  // Webflow has top-level pages (no nested /auth/*)
+  if (String(platform).toLowerCase() === 'webflow') return '/reset-password';
+  // default for others
+  return '/auth/reset';
+}

--- a/storefronts/features/auth/constants.js
+++ b/storefronts/features/auth/constants.js
@@ -7,4 +7,4 @@ export const ATTR_RESET_PANEL = '[data-smoothr="reset-password"]';
 export const ATTR_SUBMIT_RESET = '[data-smoothr="submit-reset-password"]';
 export const ATTR_CONFIRM_PASSWORD = '[data-smoothr="confirm-password"]';
 export const ATTR_SIGNUP = '[data-smoothr="sign-up"]';
-export const RESET_ROUTE = '/auth/reset';
+export { getResetRoute } from '../../core/platformRoutes';

--- a/storefronts/features/auth/init.js
+++ b/storefronts/features/auth/init.js
@@ -13,8 +13,8 @@ import {
   ATTR_CONFIRM_PASSWORD,
   ATTR_SIGNUP,
   ATTR_RESET_PANEL,
-  RESET_ROUTE,
 } from './constants.js';
+import { getResetRoute } from '../../core/platformRoutes.js';
 import {
   ensureStrongPassword,
   comparePasswords,
@@ -247,10 +247,11 @@ function tryAutoOpenReset(modeHint) {
     return true;
   }
 
-  if (!location.pathname.endsWith(RESET_ROUTE)) {
+  const route = getResetRoute();
+  if (!location.pathname.endsWith(route)) {
     window.Smoothr?.events?.emit?.('smoothr:reset:auto-open', { mode: 'route-fallback' });
     __smoothrResetShown = true;
-    window.location.replace(RESET_ROUTE + location.hash);
+    window.location.replace(route + location.hash);
     return true;
   }
 
@@ -734,9 +735,10 @@ export async function requestPasswordReset(email) {
   await ensureConfigLoaded();
   const w = globalThis.window || globalThis;
   const storeId = getStoreId();
+  const base = `${w.location.origin}${getResetRoute()}`;
   const redirectTo =
     `https://lpuqrzvokroazwlricgn.supabase.co/reset?store_id=${storeId}&redirect_to=${encodeURIComponent(
-      `${w.location.origin}/auth/reset`
+      base
     )}`;
   const supabase = await resolveSupabase();
   const { error } = await supabase?.auth.resetPasswordForEmail(email, { redirectTo }) || {};
@@ -812,7 +814,7 @@ export async function init(options = {}) {
         !!panel &&
         (panel.getAttribute('data-smoothr-active') === 'true' || panel.style.display === 'flex');
       if (!(isOpen && isActive)) {
-        window.location.replace(RESET_ROUTE + window.location.hash);
+        window.location.replace(getResetRoute() + window.location.hash);
       }
     }, 800);
   }

--- a/storefronts/tests/core/form-post.test.js
+++ b/storefronts/tests/core/form-post.test.js
@@ -1,0 +1,16 @@
+import { it, expect, vi } from 'vitest';
+import { postForm } from '../../core/http/form.js';
+
+it('postForm encodes payload and sets header', async () => {
+  const fetchMock = vi.fn().mockResolvedValue({});
+  const realFetch = global.fetch;
+  // @ts-ignore
+  global.fetch = fetchMock;
+  await postForm('https://example.com', { a: 1, b: 'two', c: null, d: undefined });
+  expect(fetchMock).toHaveBeenCalledWith('https://example.com', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: 'a=1&b=two'
+  });
+  global.fetch = realFetch;
+});


### PR DESCRIPTION
## Summary
- add platform-aware helper to select correct reset password route
- ensure auth flow and hash helpers use dynamic reset route
- add form-post utility and fallback session sync to it on auth failures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4f50680d08325b5df63b4efc15228