### PR TITLE
fix: preserve reset path and auto forward

### DIFF
--- a/smoothr/tests/pages/recovery-bridge.test.tsx
+++ b/smoothr/tests/pages/recovery-bridge.test.tsx
@@ -5,8 +5,11 @@ import { act } from 'react';
 
 vi.mock('../../lib/supabaseAdmin', () => ({ getSupabaseAdmin: vi.fn() }));
 vi.mock('../../../shared/auth/resolveRecoveryDestination', () => ({ resolveRecoveryDestination: vi.fn() }));
+vi.mock('../../lib/email/send', () => ({ sendEmail: vi.fn().mockResolvedValue({ ok: true }) }));
+vi.mock('../../lib/email/templates/reset', () => ({ renderResetEmail: () => ({ subject: '', html: '', text: '' }) }));
 
 import RecoveryBridgePage, { getServerSideProps } from '../../pages/auth/recovery-bridge';
+import sendResetHandler from '../../pages/api/auth/send-reset';
 import { getSupabaseAdmin } from '../../lib/supabaseAdmin';
 import { resolveRecoveryDestination } from '../../../shared/auth/resolveRecoveryDestination';
 
@@ -149,5 +152,97 @@ describe('recovery bridge', () => {
     const { container, root } = await render(<RecoveryBridgePage {...props} />);
     expect(container.textContent).toMatch(/Recovery paused/);
     root.unmount();
+  });
+
+  it('uses full path from auth_reset_url for auto-forward', async () => {
+    getSupabaseAdmin.mockReturnValue({
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            single: () => Promise.resolve({
+              data: {
+                store_domain: 'client.com',
+                live_domain: 'client.com',
+                store_name: 'Client',
+                auth_reset_url: 'https://client.com/fr/reset-password',
+              },
+            }),
+          }),
+        }),
+      }),
+    });
+    resolveRecoveryDestination.mockReturnValue({ type: 'ok', origin: 'https://client.com' });
+    const { props } = (await getServerSideProps({
+      query: { store_id: 's1', auto: '1' },
+      req: { headers: { host: 'auth.smoothr.io' } },
+    } as any)) as any;
+
+    const replace = vi.fn();
+    const originalLocation = window.location;
+    delete (window as any).location;
+    (window as any).location = {
+      hash: '#access_token=tok&type=recovery',
+      host: 'auth.smoothr.io',
+      replace,
+    } as any;
+
+    const { root } = await render(<RecoveryBridgePage {...props} />);
+    await act(async () => { await Promise.resolve(); });
+    expect(replace).toHaveBeenCalledWith(
+      'https://client.com/fr/reset-password#access_token=tok&type=recovery&store_id=s1'
+    );
+    root.unmount();
+    window.location = originalLocation;
+  });
+});
+
+describe('send-reset', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('includes auto=1 in redirectTo', async () => {
+    const generateLink = vi
+      .fn()
+      .mockResolvedValue({ data: { properties: { action_link: 'lnk' } }, error: null });
+    getSupabaseAdmin.mockReturnValue({
+      auth: { admin: { generateLink } },
+      from: (table: string) => ({
+        select: () => ({
+          eq: () => {
+            if (table === 'stores') {
+              return {
+                maybeSingle: () =>
+                  Promise.resolve({ data: { store_name: 'Demo', live_domain: null, store_domain: null } }),
+              };
+            }
+            if (table === 'store_branding') {
+              return {
+                is: () => ({
+                  limit: () => ({
+                    single: () =>
+                      Promise.resolve({ data: { logo_url: null, auto_forward_recovery: false } }),
+                  }),
+                }),
+              };
+            }
+            return {};
+          },
+        }),
+      }),
+    });
+
+    const req: any = {
+      method: 'POST',
+      headers: { host: 'auth.smoothr.io' },
+      body: { email: 'a@b.com', store_id: 's1' },
+    };
+    const json = vi.fn();
+    const res: any = { setHeader: vi.fn(), status: vi.fn(() => ({ json })) };
+
+    await sendResetHandler(req, res);
+    expect(generateLink).toHaveBeenCalled();
+    const redirectTo = generateLink.mock.calls[0][0].options.redirectTo;
+    expect(redirectTo).toMatch(/auto=1/);
   });
 });

--- a/storefronts/tests/sdk/password-reset.test.js
+++ b/storefronts/tests/sdk/password-reset.test.js
@@ -341,7 +341,7 @@ it('reset confirm syncs session via fetch when no redirect set', async () => {
   });
 
 describe('send-reset auto-forward flag', () => {
-  async function run(auto) {
+  async function run() {
     vi.resetModules();
     const generateLink = vi.fn().mockResolvedValue({
       data: { properties: { action_link: 'https://action.link' } },
@@ -360,7 +360,7 @@ describe('send-reset auto-forward flag', () => {
                         limit() {
                           return {
                             single: async () => ({
-                              data: { logo_url: null, auto_forward_recovery: auto },
+                              data: { logo_url: null },
                               error: null,
                             }),
                           };
@@ -425,13 +425,9 @@ describe('send-reset auto-forward flag', () => {
     const redirect = generateLink.mock.calls[0][0].options.redirectTo;
     return redirect;
   }
-  it('includes auto=1 when enabled', async () => {
-    const redirect = await run(true);
+  it('always includes auto=1', async () => {
+    const redirect = await run();
     expect(redirect).toMatch(/auto=1/);
-  });
-  it('omits auto when disabled', async () => {
-    const redirect = await run(false);
-    expect(redirect).not.toMatch(/auto=1/);
   });
 });
 


### PR DESCRIPTION
## Summary
- forward recovery tokens to full `auth_reset_url` href instead of origin
- always append `auto=1` when generating recovery-bridge redirect
- add tests for auto-forwarding and redirect URL

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c52095e1e48325b9ce6478a2f68489